### PR TITLE
Add very basic agentic search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ temp/
 data/
 models/
 documents/
+__marimo__/
 .DS_Store
 .devcontainer
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,36 +1,32 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
-    hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
-    -   id: debug-statements
-    # -   id: name-tests-test
-    #     args: [--pytest-test-first]
-    -   id: requirements-txt-fixer
--   repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.2.0
-    hooks:
-    -   id: setup-cfg-fmt
--   repo: https://github.com/timothycrosley/isort
-    rev: 5.12.0
-    hooks:
-    -   id: isort
-        args: ["--profile", "black", "--filter-files"]
--   repo: https://github.com/asottile/add-trailing-comma
-    rev: v3.1.0
-    hooks:
-    -   id: add-trailing-comma
-        args: [--py36-plus]
--   repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-    -   id: flake8
-        entry: bash -c 'flake8 "$@" || true' --
-        verbose: true
--   repo: https://github.com/psf/black
-    rev: 22.12.0
-    hooks:
-    - id: black
-      language_version: python3
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.4.0
+  hooks:
+   - id: trailing-whitespace
+   - id: end-of-file-fixer
+   - id: check-yaml
+   - id: debug-statements
+     language_version: python3.12
+   - id: requirements-txt-fixer
+- repo: https://github.com/asottile/setup-cfg-fmt
+  rev: v2.2.0
+  hooks:
+   - id: setup-cfg-fmt
+- repo: https://github.com/timothycrosley/isort
+  rev: 5.12.0
+  hooks:
+   - id: isort
+     args: ["--profile", "black", "--filter-files"]
+     language_version: python3.12
+- repo: https://github.com/asottile/add-trailing-comma
+  rev: v3.1.0
+  hooks:
+   - id: add-trailing-comma
+     args: [--py36-plus]
+     language_version: python3.12
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.11.13
+  hooks:
+   - id: ruff-check
+     args: ["--fix"]
+   - id: ruff-format

--- a/akd/agents/query.py
+++ b/akd/agents/query.py
@@ -36,7 +36,7 @@ class QueryAgentOutputSchema(BaseIOSchema):
     )
 
 
-class QueryAgent(BaseAgent):
+class QueryAgent(BaseAgent[QueryAgentInputSchema, QueryAgentOutputSchema]):
     """
     Agent that generates search engine queries based on a given query.
     """
@@ -86,11 +86,11 @@ class FollowUpQueryAgentOutputSchema(BaseIOSchema):
         description="List of follow-up search queries based on the original content.",
     )
 
-    category: Optional[
-        Literal["general", "science", "research", "clarification"]
-    ] = Field(
-        default="general",
-        description="Category of the follow-up search queries.",
+    category: Optional[Literal["general", "science", "research", "clarification"]] = (
+        Field(
+            default="general",
+            description="Category of the follow-up search queries.",
+        )
     )
 
     reasoning: Optional[str] = Field(
@@ -106,7 +106,9 @@ class FollowUpQueryAgentOutputSchema(BaseIOSchema):
     )
 
 
-class FollowUpQueryAgent(BaseAgent):
+class FollowUpQueryAgent(
+    BaseAgent[FollowUpQueryAgentInputSchema, FollowUpQueryAgentOutputSchema],
+):
     """
     Agent that generates follow-up search engine queries based on original queries and content.
     """

--- a/akd/agents/query.py
+++ b/akd/agents/query.py
@@ -43,3 +43,73 @@ class QueryAgent(BaseAgent):
 
     input_schema = QueryAgentInputSchema
     output_schema = QueryAgentOutputSchema
+
+
+# --- follow up agent
+
+
+class FollowUpQueryAgentInputSchema(BaseIOSchema):
+    """This is the input schema for the FollowUpQueryAgent."""
+
+    original_queries: List[str] = Field(
+        ...,
+        description="The original search queries that were used to retrieve content.",
+    )
+
+    content: str = Field(
+        ...,
+        description="The text content obtained from the original queries "
+        "that will be used to generate follow-up queries.",
+    )
+
+    num_queries: int = Field(
+        default=3,
+        description="The number of follow-up search queries to generate.",
+    )
+
+    focus_areas: Optional[List[str]] = Field(
+        default=None,
+        description="Specific areas or aspects to focus on for follow-up queries. "
+        "If not provided, the agent will identify gaps and interesting areas automatically.",
+    )
+
+
+class FollowUpQueryAgentOutputSchema(BaseIOSchema):
+    """
+    Schema for output follow-up queries based on original queries and content.
+    Returns a list of refined search queries that dig deeper into the topic
+    or explore related areas not covered in the original content.
+    """
+
+    followup_queries: List[str] = Field(
+        ...,
+        description="List of follow-up search queries based on the original content.",
+    )
+
+    category: Optional[
+        Literal["general", "science", "research", "clarification"]
+    ] = Field(
+        default="general",
+        description="Category of the follow-up search queries.",
+    )
+
+    reasoning: Optional[str] = Field(
+        default=None,
+        description="Brief explanation of why these follow-up queries were generated "
+        "and what gaps or areas they aim to address.",
+    )
+
+    original_query_gaps: Optional[List[str]] = Field(
+        default=None,
+        description="Identified gaps or areas that weren't fully covered "
+        "in the original content.",
+    )
+
+
+class FollowUpQueryAgent(BaseAgent):
+    """
+    Agent that generates follow-up search engine queries based on original queries and content.
+    """
+
+    input_schema = FollowUpQueryAgentInputSchema
+    output_schema = FollowUpQueryAgentOutputSchema

--- a/akd/tools/_base.py
+++ b/akd/tools/_base.py
@@ -11,7 +11,11 @@ from atomic_agents.lib.base.base_tool import BaseToolConfig
 from akd.utils import AsyncRunMixin, LangchainToolMixin, get_event_loop
 
 
-class BaseTool(AtomicBaseTool, AsyncRunMixin, LangchainToolMixin):
+class BaseTool[InputSchema: BaseIOSchema, OutputSchema: BaseIOSchema](
+    AtomicBaseTool,
+    AsyncRunMixin,
+    LangchainToolMixin,
+):
     def __init__(
         self,
         config: Optional[BaseToolConfig] = None,
@@ -42,37 +46,37 @@ class BaseTool(AtomicBaseTool, AsyncRunMixin, LangchainToolMixin):
         raise NotImplementedError()
 
     @abstractmethod
-    async def arun(self, params: BaseIOSchema, **kwargs) -> BaseIOSchema:
+    async def arun(self, params: InputSchema, **kwargs) -> OutputSchema:
         """
         Executes the tool with the provided parameters in async.
 
         Args:
-            params (BaseIOSchema): Input parameters adhering to the input schema.
+            params (InputSchema): Input parameters adhering to the input schema.
 
         Returns:
-            BaseIOSchema: Output resulting from executing the tool, adhering to the output schema.
+            OutputSchema: Output resulting from executing the tool, adhering to the output schema.
 
         Raises:
             NotImplementedError: If the method is not implemented by a subclass.
         """
         raise NotImplementedError("Subclasses should implement this method")
 
-    async def run_async(self, params: BaseIOSchema, **kwargs) -> BaseIOSchema:
+    async def run_async(self, params: InputSchema, **kwargs) -> OutputSchema:
         """
         Executes the tool with the provided parameters in async.
 
         Args:
-            params (BaseIOSchema): Input parameters adhering to the input schema.
+            params (InputSchema): Input parameters adhering to the input schema.
 
         Returns:
-            BaseIOSchema: Output resulting from executing the tool, adhering to the output schema.
+            OutputSchema: Output resulting from executing the tool, adhering to the output schema.
 
         Raises:
             NotImplementedError: If the method is not implemented by a subclass.
         """
         return await self.arun(params, **kwargs)
 
-    def run(self, params: BaseIOSchema, **kwargs) -> BaseIOSchema:
+    def run(self, params: InputSchema, **kwargs) -> OutputSchema:
         """
         Executes the tool with the provided parameters by running the async implementation.
 
@@ -80,10 +84,10 @@ class BaseTool(AtomicBaseTool, AsyncRunMixin, LangchainToolMixin):
         or uses the current event loop if it's already running.
 
         Args:
-            params (BaseIOSchema): Input parameters adhering to the input schema.
+            params (InputSchema): Input parameters adhering to the input schema.
 
         Returns:
-            BaseIOSchema: Output resulting from executing the tool, adhering to the output schema.
+            OutputSchema: Output resulting from executing the tool, adhering to the output schema.
         """
         try:
             # Check if there's a running event loop


### PR DESCRIPTION
### Summary :memo:
This PR adds a new search tool component `akd.tools.search.SimpleAgenticLitSearchTool` that uses a naive approach at iteratively finding relevant literature through intelligent query generation and relevancy-based stopping criteria.

### Details
- Add `akd.agents.query.FollowUpQueryAgent` and related schemas for generating follow-up search queries based on existing content
- Implement `akd.tools.search.SimpleAgenticLitSearchTool` that performs iterative literature search with:
  - Initial query generation using existing `QueryAgent`
  - Follow-up query generation after specified iterations to explore gaps and related areas
  - Relevancy-based stopping criteria using configurable threshold (default 0.75)
  - Content deduplication to avoid retrieving the same results
  - Configurable maximum iterations (default 5) and result limits
- Enhanced type safety by adding generic type parameters to base classes (`BaseAgent`, `BaseTool`)
- Updated pre-commit configuration to use Ruff instead of flake8 for better performance
- Added `.devcontainer` and additional paths to `.gitignore`


### Usage

The new `SimpleAgenticLitSearchTool` can be used for iterative literature search with intelligent query refinement:

```python
from akd.tools.search import SimpleAgenticLitSearchTool, SearchToolInputSchema
from akd.agents.query import QueryAgent, FollowUpQueryAgent
from akd.tools.relevancy import RelevancyChecker

# Initialize component tools
search_tool = SearxNGSearchTool(config=...)  # Base search functionality
relevancy_checker = RelevancyChecker(config=...)  # Content relevancy scoring
query_agent = QueryAgent(config=...)  # Initial query generation
followup_query_agent = FollowUpQueryAgent(config=...)  # Follow-up query generation

# Create the agentic search tool
agentic_search = SimpleAgenticLitSearchTool(
    search_tool=search_tool,
    relevancy_checker=relevancy_checker,
    query_agent=query_agent,
    followup_query_agent=followup_query_agent,
    cutoff_threshold=0.95,  # Stop when relevancy score reaches 95%
    max_iteration=5,  # Maximum search iterations
    use_followup_after_iteration=1,  # Switch to follow-up queries after iteration 1
    debug=True
)

# Execute search
result = await agentic_search.arun(
    SearchToolInputSchema(
        queries=["debris flow modeling Himalayas"],
        max_results=25,
    )
)

# Access deduplicated, relevant results
for item in result.results:
    print(f"Title: {item.title}")
    print(f"Content: {item.content}")
```

The tool automatically:

- Starts with initial queries using QueryAgent
- Switches to `akd.agents.query.FollowUpQueryAgent` after specified iterations to explore content gaps
- Uses `akd.tools.relevancy.RelevancyChecker` to determine when sufficient relevant content is found
- Deduplicates results across iterations
- Stops when relevancy threshold is met or max iterations reached

### Bugfixes :bug:
- Fixed inconsistent indentation in `.pre-commit-config.yaml`
- Improved error handling in query generation methods with proper fallbacks

### Checks
- [x] Closed #40 
- [ ] Need to improve the relevancy checks