### PR TITLE
Refactor atomic-agents to use LangGraph

### DIFF
--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -5,7 +5,9 @@ from langchain.memory import ChatMessageHistory
 from langchain_openai import ChatOpenAI
 
 from pydantic import BaseModel, ConfigDict
+
 from akd.configs.project import CONFIG
+from akd.configs.prompts import DEFAULT_SYSTEM_PROMPT
 
 from ..utils import AsyncRunMixin, LangchainToolMixin
 
@@ -40,23 +42,17 @@ class BaseAgent[
         self.config = config or ConfigDict(
             client=client,
             extra="allow",
+            system_prompt=ChatPromptTemplate.from_messages(
+                    [
+                        {"role": "system", "content": DEFAULT_SYSTEM_PROMPT},
+                        MessagesPlaceholder(variable_name="memory"),
+                    ]
+                )
         )
         self.debug = debug
         self.client = client
         self.memory = ChatMessageHistory()
-        self.system_prompt = ChatPromptTemplate.from_messages(
-                    [
-                        {"role": "system", "content": """\
-        IDENTITY and PURPOSE
-        This is a conversation with a helpful and friendly AI assistant.
-
-        OUTPUT INSTRUCTIONS
-        - Always respond using the proper JSON schema.
-        - Always use the available additional information and context to enhance the response.
-        """},
-                        MessagesPlaceholder(variable_name="memory"),
-                    ]
-                )
+        self.system_prompt = self.config['system_prompt'] 
 
 
     async def get_response_async(

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -1,6 +1,5 @@
 from typing import Optional
 
-import instructor
 import openai
 from langchain_openai import ChatOpenAI
 from loguru import logger
@@ -48,12 +47,12 @@ class BaseAgent[
         self.client = config['client']
         # super().__init__(config)
 
-    @property
-    def _is_async_client(self) -> bool:
-        return isinstance(
-            self.client,
-            instructor.client.AsyncInstructor,
-        )
+    # @property
+    # def _is_async_client(self) -> bool:
+    #     return isinstance(
+    #         self.client,
+    #         instructor.client.AsyncInstructor,
+    #     )
 
     async def get_response_async(
         self,

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -3,7 +3,7 @@ from typing import Optional
 import instructor
 import openai
 from atomic_agents.agents.base_agent import BaseAgent as AtomicBaseAgent
-from atomic_agents.agents.base_agent import BaseAgentConfig, BaseIOSchema
+from atomic_agents.agents.base_agent import BaseAgentConfig
 from loguru import logger
 from pydantic import BaseModel
 
@@ -13,8 +13,8 @@ from ..utils import AsyncRunMixin, LangchainToolMixin
 
 
 class BaseAgent[
-    InputSchema: BaseIOSchema,
-    OutputSchema: BaseIOSchema,
+    InputSchema: BaseModel,
+    OutputSchema: BaseModel,
 ](
     AsyncRunMixin,
     LangchainToolMixin,

--- a/akd/agents/extraction.py
+++ b/akd/agents/extraction.py
@@ -1,7 +1,6 @@
 from abc import ABC
 from typing import Any, List, Union
 
-from atomic_agents.agents.base_agent import BaseAgent
 from loguru import logger
 from pydantic import Field, BaseModel
 

--- a/akd/agents/extraction.py
+++ b/akd/agents/extraction.py
@@ -1,9 +1,9 @@
 from abc import ABC
 from typing import Any, List, Union
 
-from atomic_agents.agents.base_agent import BaseAgent, BaseIOSchema
+from atomic_agents.agents.base_agent import BaseAgent
 from loguru import logger
-from pydantic import Field
+from pydantic import Field, BaseModel
 
 from akd.structures import ExtractionSchema, SingleEstimation
 from akd.utils import AsyncRunMixin
@@ -40,7 +40,7 @@ class IntentBasedExtractionSchemaMapper(ExtractionSchemaMapper):
         return res
 
 
-class ExtractionInputSchema(BaseIOSchema):
+class ExtractionInputSchema(BaseModel):
     """Information Extraction input schema"""
 
     query: str = Field(..., description="Query that is used for answering/extraction")
@@ -50,7 +50,7 @@ class ExtractionInputSchema(BaseIOSchema):
     )
 
 
-class EstimationExtractionOutputSchema(BaseIOSchema):
+class EstimationExtractionOutputSchema(BaseModel):
     """Estimation Extraction output schema"""
 
     estimations: List[SingleEstimation] = Field(

--- a/akd/agents/factory.py
+++ b/akd/agents/factory.py
@@ -1,7 +1,6 @@
 from typing import List, Optional, Union
 
-import instructor
-import openai
+from langchain_openai import ChatOpenAI
 from pydantic import create_model, BaseModel, ConfigDict
 
 from akd.configs.project import CONFIG
@@ -15,8 +14,9 @@ from .query import QueryAgent
 
 def create_intent_agent(config: Optional[ConfigDict] = None) -> IntentAgent:
     config = config or ConfigDict(
-        client=instructor.from_openai(
-            openai.AsyncOpenAI(api_key=CONFIG.model_config_settings.api_keys.openai),
+        client=ChatOpenAI(
+                    api_key=CONFIG.model_config_settings.api_keys.openai,
+
         ),
         model=CONFIG.model_config_settings.model_name,
         system_prompt_generator=SystemPromptGenerator(
@@ -50,8 +50,9 @@ def create_extraction_agent(
     )
     return BaseModel(
         ConfigDict(
-            client=instructor.from_openai(
-                openai.OpenAI(api_key=CONFIG.model_config_settings.api_keys.openai),
+            client=ChatOpenAI(
+                    api_key=CONFIG.model_config_settings.api_keys.openai,
+
             ),
             model=CONFIG.model_config_settings.model_name,
             # TODO: Replace with LangGraph equivalent
@@ -91,9 +92,10 @@ def create_extraction_agent(
 
 def create_query_agent(config: Optional[ConfigDict] = None) -> QueryAgent:
     config = config or ConfigDict(
-        client=instructor.from_openai(
-            openai.AsyncOpenAI(api_key=CONFIG.model_config_settings.api_keys.openai),
-        ),
+        client=ChatOpenAI(
+                    api_key=CONFIG.model_config_settings.api_keys.openai,
+
+            ),
         model=CONFIG.model_config_settings.model_name,
         # TODO: Replace with LangGraph equivalent
         system_prompt_generator=SystemPromptGenerator(

--- a/akd/agents/factory.py
+++ b/akd/agents/factory.py
@@ -2,9 +2,9 @@ from typing import List, Optional, Union
 
 import instructor
 import openai
-from atomic_agents.agents.base_agent import BaseAgent, BaseAgentConfig, BaseIOSchema
+from atomic_agents.agents.base_agent import BaseAgent, BaseAgentConfig
 from atomic_agents.lib.components.system_prompt_generator import SystemPromptGenerator
-from pydantic import create_model
+from pydantic import create_model, BaseModel
 
 from akd.configs.project import CONFIG
 from akd.structures import ExtractionSchema, SingleEstimation
@@ -46,7 +46,7 @@ def create_extraction_agent(
     _ExtractionOutputSchema = create_model(
         "_ExtractionOutputSchema",
         answer=(extraction_output_schema, "Answer from the extraction"),
-        __base__=BaseIOSchema,
+        __base__=BaseModel,
         __doc__="Extracted information from the research",
     )
     return BaseAgent(

--- a/akd/agents/factory.py
+++ b/akd/agents/factory.py
@@ -2,20 +2,19 @@ from typing import List, Optional, Union
 
 import instructor
 import openai
-from atomic_agents.agents.base_agent import BaseAgent, BaseAgentConfig
-from atomic_agents.lib.components.system_prompt_generator import SystemPromptGenerator
-from pydantic import create_model, BaseModel
+from pydantic import create_model, BaseModel, ConfigDict
 
 from akd.configs.project import CONFIG
 from akd.structures import ExtractionSchema, SingleEstimation
+from akd.nodes.system_prompt_generator import SystemPromptGenerator
 
 from .extraction import ExtractionInputSchema
 from .intents import IntentAgent
 from .query import QueryAgent
 
 
-def create_intent_agent(config: Optional[BaseAgentConfig] = None) -> IntentAgent:
-    config = config or BaseAgentConfig(
+def create_intent_agent(config: Optional[ConfigDict] = None) -> IntentAgent:
+    config = config or ConfigDict(
         client=instructor.from_openai(
             openai.AsyncOpenAI(api_key=CONFIG.model_config_settings.api_keys.openai),
         ),
@@ -36,8 +35,8 @@ def create_intent_agent(config: Optional[BaseAgentConfig] = None) -> IntentAgent
 
 def create_extraction_agent(
     extraction_output_schema: Union[ExtractionSchema, List[SingleEstimation]],
-    config: Optional[BaseAgentConfig] = None,
-) -> BaseAgent:
+    config: Optional[ConfigDict] = None,
+) -> BaseModel:
     """
     Dynamically build the agent based on the type
     of extraction schema provided.
@@ -49,12 +48,13 @@ def create_extraction_agent(
         __base__=BaseModel,
         __doc__="Extracted information from the research",
     )
-    return BaseAgent(
-        BaseAgentConfig(
+    return BaseModel(
+        ConfigDict(
             client=instructor.from_openai(
                 openai.OpenAI(api_key=CONFIG.model_config_settings.api_keys.openai),
             ),
             model=CONFIG.model_config_settings.model_name,
+            # TODO: Replace with LangGraph equivalent
             system_prompt_generator=SystemPromptGenerator(
                 background=[
                     (
@@ -89,12 +89,13 @@ def create_extraction_agent(
     )
 
 
-def create_query_agent(config: Optional[BaseAgentConfig] = None) -> QueryAgent:
-    config = config or BaseAgentConfig(
+def create_query_agent(config: Optional[ConfigDict] = None) -> QueryAgent:
+    config = config or ConfigDict(
         client=instructor.from_openai(
             openai.AsyncOpenAI(api_key=CONFIG.model_config_settings.api_keys.openai),
         ),
         model=CONFIG.model_config_settings.model_name,
+        # TODO: Replace with LangGraph equivalent
         system_prompt_generator=SystemPromptGenerator(
             background=[
                 (

--- a/akd/agents/factory.py
+++ b/akd/agents/factory.py
@@ -5,7 +5,7 @@ from pydantic import create_model, BaseModel, ConfigDict
 
 from akd.configs.project import CONFIG
 from akd.structures import ExtractionSchema, SingleEstimation
-from akd.nodes.system_prompt_generator import SystemPromptGenerator
+from atomic_agents.lib.components.system_prompt_generator import SystemPromptGenerator
 
 from .extraction import ExtractionInputSchema
 from .intents import IntentAgent
@@ -16,9 +16,9 @@ def create_intent_agent(config: Optional[ConfigDict] = None) -> IntentAgent:
     config = config or ConfigDict(
         client=ChatOpenAI(
                     api_key=CONFIG.model_config_settings.api_keys.openai,
-
-        ),
-        model=CONFIG.model_config_settings.model_name,
+                    model=CONFIG.model_config_settings.model_name,
+                    temperature=0.0,
+            ),
         system_prompt_generator=SystemPromptGenerator(
             background=[
                 ("You are an expert intent detector."),
@@ -52,9 +52,8 @@ def create_extraction_agent(
         ConfigDict(
             client=ChatOpenAI(
                     api_key=CONFIG.model_config_settings.api_keys.openai,
-
+                    model=CONFIG.model_config_settings.model_name,
             ),
-            model=CONFIG.model_config_settings.model_name,
             # TODO: Replace with LangGraph equivalent
             system_prompt_generator=SystemPromptGenerator(
                 background=[
@@ -94,9 +93,8 @@ def create_query_agent(config: Optional[ConfigDict] = None) -> QueryAgent:
     config = config or ConfigDict(
         client=ChatOpenAI(
                     api_key=CONFIG.model_config_settings.api_keys.openai,
-
+                    model=CONFIG.model_config_settings.model_name,
             ),
-        model=CONFIG.model_config_settings.model_name,
         # TODO: Replace with LangGraph equivalent
         system_prompt_generator=SystemPromptGenerator(
             background=[

--- a/akd/agents/intents.py
+++ b/akd/agents/intents.py
@@ -1,7 +1,6 @@
 from enum import Enum
 
-from atomic_agents.agents.base_agent import BaseIOSchema
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from ._base import BaseAgent
 
@@ -12,13 +11,13 @@ class Intent(str, Enum):
     # DATA_DISCOVERY = "Data Discovery"
 
 
-class IntentInputSchema(BaseIOSchema):
+class IntentInputSchema(BaseModel):
     """Input schema for determining intent of the query"""
 
     query: str = Field(..., description="The user's latest query/message/question")
 
 
-class IntentOutputSchema(BaseIOSchema):
+class IntentOutputSchema(BaseModel):
     """Output schema represents the intent of the query"""
 
     intent: Intent = Field(..., description="The user's intent")

--- a/akd/agents/litsearch.py
+++ b/akd/agents/litsearch.py
@@ -1,8 +1,7 @@
 from typing import List
 
-from atomic_agents.agents.base_agent import BaseIOSchema
 from loguru import logger
-from pydantic import Field
+from pydantic import Field, BaseModel
 
 from akd.structures import ExtractionDTO
 from akd.tools.scrapers.resolvers import BaseArticleResolver, ResolverInputSchema
@@ -24,7 +23,7 @@ from .intents import IntentAgent
 from .query import QueryAgent, QueryAgentInputSchema
 
 
-class LitAgentInputSchema(BaseIOSchema):
+class LitAgentInputSchema(BaseModel):
     """
     Input schema for the LitAgent
     """
@@ -36,7 +35,7 @@ class LitAgentInputSchema(BaseIOSchema):
     )
 
 
-class LitAgentOutputSchema(BaseIOSchema):
+class LitAgentOutputSchema(BaseModel):
     """
     Output schema for the LitAgent
     """

--- a/akd/agents/query.py
+++ b/akd/agents/query.py
@@ -1,12 +1,11 @@
 from typing import List, Literal, Optional
 
-from atomic_agents.agents.base_agent import BaseIOSchema
-from pydantic import Field
+from pydantic import Field, BaseModel
 
 from ._base import BaseAgent
 
 
-class QueryAgentInputSchema(BaseIOSchema):
+class QueryAgentInputSchema(BaseModel):
     """This is the input schema for the QueryAgent."""
 
     query: str = Field(
@@ -20,7 +19,7 @@ class QueryAgentInputSchema(BaseIOSchema):
     )
 
 
-class QueryAgentOutputSchema(BaseIOSchema):
+class QueryAgentOutputSchema(BaseModel):
     """
     Schema for output queries  for information, news,
     references, and other content.
@@ -48,7 +47,7 @@ class QueryAgent(BaseAgent[QueryAgentInputSchema, QueryAgentOutputSchema]):
 # --- follow up agent
 
 
-class FollowUpQueryAgentInputSchema(BaseIOSchema):
+class FollowUpQueryAgentInputSchema(BaseModel):
     """This is the input schema for the FollowUpQueryAgent."""
 
     original_queries: List[str] = Field(
@@ -74,7 +73,7 @@ class FollowUpQueryAgentInputSchema(BaseIOSchema):
     )
 
 
-class FollowUpQueryAgentOutputSchema(BaseIOSchema):
+class FollowUpQueryAgentOutputSchema(BaseModel):
     """
     Schema for output follow-up queries based on original queries and content.
     Returns a list of refined search queries that dig deeper into the topic

--- a/akd/agents/relevancy.py
+++ b/akd/agents/relevancy.py
@@ -1,8 +1,5 @@
 from typing import List, Optional
 
-import instructor
-import openai
-from atomic_agents.agents.base_agent import BaseAgentConfig
 from pydantic import Field, BaseModel
 
 from akd.configs.project import CONFIG

--- a/akd/agents/relevancy.py
+++ b/akd/agents/relevancy.py
@@ -2,8 +2,8 @@ from typing import List, Optional
 
 import instructor
 import openai
-from atomic_agents.agents.base_agent import BaseAgentConfig, BaseIOSchema
-from pydantic import Field
+from atomic_agents.agents.base_agent import BaseAgentConfig
+from pydantic import Field, BaseModel
 
 from akd.configs.project import CONFIG
 from akd.structures import RelevancyLabel
@@ -11,7 +11,7 @@ from akd.structures import RelevancyLabel
 from ._base import BaseAgent
 
 
-class RelevancyAgentInputSchema(BaseIOSchema):
+class RelevancyAgentInputSchema(BaseModel):
     """Input schema for relevancy agent"""
 
     query: str = Field(
@@ -24,7 +24,7 @@ class RelevancyAgentInputSchema(BaseIOSchema):
     )
 
 
-class RelevancyAgentOutputSchema(BaseIOSchema):
+class RelevancyAgentOutputSchema(BaseModel):
     """Output schema for relevancy agent"""
 
     label: RelevancyLabel = Field(

--- a/akd/configs/prompts.py
+++ b/akd/configs/prompts.py
@@ -1,0 +1,48 @@
+DEFAULT_SYSTEM_PROMPT = """IDENTITY and PURPOSE
+This is a conversation with a helpful and friendly AI assistant.
+
+OUTPUT INSTRUCTIONS
+- Always respond using the proper JSON schema.
+- Always use the available additional information and context to enhance the response."""
+
+
+INTENT_SYSTEM_PROMPT = """IDENTITY and PURPOSE:
+You are an expert intent detector.
+
+OUTPUT INSTRUCTIONS:
+- Estimation is when the data is used in a process to estimate numerically
+- Data discovery deals with queries asking for data explicitly
+- Example for Data Disoverery includes: Where do I find HLS data?
+- Always respond using the proper JSON schema.
+- Always use the available additional information and context to enhance the response."""
+
+
+EXTRACTION_SYSTEM_PROMPT = """IDENTITY and PURPOSE:
+You are an expert in scientific information extraction.
+Your goal is to accurately extract and summarize relevant information from academic literature while maintaining fidelity to the original sources.
+
+INTERNAL ASSISTANT STEPS:
+- Identify patterns, contradictions, and gaps in the literature across different sources.
+- Extract relevant information based on the given schema, ensuring clarity and completeness.
+- Maintain structured and systematic extraction, focusing on key arguments, methodologies, findings, and supporting data.
+
+OUTPUT INSTRUCTIONS:
+- Don't give anything that's not present in the content.
+- Ensure extracted content remains faithful to original sources, avoiding extrapolation or misinterpretation.
+- Provide structured summaries including key arguments, methodologies, findings, and limitations.
+- Use a scientific tone, ensuring clarity, coherence, and proper citation handling.
+- Avoid speculation, personal opinions, or unverifiable claims."""
+
+
+QUERY_SYSTEM_PROMPT = """IDENTITY and PURPOSE:
+You are an expert scientific search engine query generator with a deep understanding of which queries will maximize the number of relevant results for science.
+
+INTERNAL ASSISTANT STEPS:
+- Analyze the given instruction to identify key concepts and aspects that need to be researched.
+- For each aspect, craft a search query using appropriate search operators and syntax.
+- Ensure queries cover different angles of the topic (technical, practical, comparative, etc.).
+
+OUTPUT INSTRUCTIONS:
+- Return exactly the requested number of queries.
+- Format each query like a search engine query, not a natural language question.
+- Each query should be a concise string of keywords and operators."""

--- a/akd/tools/_base.py
+++ b/akd/tools/_base.py
@@ -4,34 +4,31 @@ import asyncio
 from abc import abstractmethod
 from typing import Optional
 
-from pydantic import BaseModel
-from atomic_agents.lib.base.base_tool import BaseTool as AtomicBaseTool
-from atomic_agents.lib.base.base_tool import BaseToolConfig
+from pydantic import BaseModel, ConfigDict
 
 from akd.utils import AsyncRunMixin, LangchainToolMixin, get_event_loop
 
 
 class BaseTool[InputSchema: BaseModel, OutputSchema: BaseModel](
-    AtomicBaseTool,
     AsyncRunMixin,
     LangchainToolMixin,
 ):
     def __init__(
         self,
-        config: Optional[BaseToolConfig] = None,
+        config: Optional[ConfigDict] = None,
         debug: bool = False,
     ) -> None:
         """
         Initializes the BaseTool with an optional configuration override.
 
         Args:
-            config (BaseToolConfig, optional):
+            config (ConfigDict, optional):
                 Configuration for the tool, including optional title
                 and description overrides.
             debug (bool, optional):
                 Boolean flag for debug mode.
         """
-        config = config or BaseToolConfig()
+        config = config or ConfigDict()
         self.config = config
         self.debug = bool(debug) or getattr(config, "debug", False)
         super().__init__(config)

--- a/akd/tools/_base.py
+++ b/akd/tools/_base.py
@@ -4,14 +4,14 @@ import asyncio
 from abc import abstractmethod
 from typing import Optional
 
-from atomic_agents.agents.base_agent import BaseIOSchema
+from pydantic import BaseModel
 from atomic_agents.lib.base.base_tool import BaseTool as AtomicBaseTool
 from atomic_agents.lib.base.base_tool import BaseToolConfig
 
 from akd.utils import AsyncRunMixin, LangchainToolMixin, get_event_loop
 
 
-class BaseTool[InputSchema: BaseIOSchema, OutputSchema: BaseIOSchema](
+class BaseTool[InputSchema: BaseModel, OutputSchema: BaseModel](
     AtomicBaseTool,
     AsyncRunMixin,
     LangchainToolMixin,

--- a/akd/tools/fact_reasoner_tool.py
+++ b/akd/tools/fact_reasoner_tool.py
@@ -5,7 +5,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 from loguru import logger
-from pydantic import Field, BaseModel
+from pydantic import Field, BaseModel, ConfigDict
 
 # Local fm_factual modules (subtree path)
 from akd.tools.fact_reasoner.fm_factual.atom_extractor import AtomExtractor
@@ -15,10 +15,10 @@ from akd.tools.fact_reasoner.fm_factual.fact_reasoner import FactReasoner
 from akd.tools.fact_reasoner.fm_factual.nli_extractor import NLIExtractorOld
 from akd.tools.fact_reasoner.fm_factual.query_builder import QueryBuilder
 
-from ._base import BaseTool, BaseToolConfig
+from ._base import BaseTool
 
 
-class FactReasonerToolConfig(BaseToolConfig):
+class FactReasonerToolConfig(ConfigDict):
     gen_model: str
     context_retriever_service_type: str
     cache_dir: str

--- a/akd/tools/fact_reasoner_tool.py
+++ b/akd/tools/fact_reasoner_tool.py
@@ -5,7 +5,7 @@ import os
 from typing import Any, Dict, List, Optional
 
 from loguru import logger
-from pydantic import Field
+from pydantic import Field, BaseModel
 
 # Local fm_factual modules (subtree path)
 from akd.tools.fact_reasoner.fm_factual.atom_extractor import AtomExtractor
@@ -15,7 +15,7 @@ from akd.tools.fact_reasoner.fm_factual.fact_reasoner import FactReasoner
 from akd.tools.fact_reasoner.fm_factual.nli_extractor import NLIExtractorOld
 from akd.tools.fact_reasoner.fm_factual.query_builder import QueryBuilder
 
-from ._base import BaseIOSchema, BaseTool, BaseToolConfig
+from ._base import BaseTool, BaseToolConfig
 
 
 class FactReasonerToolConfig(BaseToolConfig):
@@ -27,7 +27,7 @@ class FactReasonerToolConfig(BaseToolConfig):
     merlin_path: str
 
 
-class FactReasonerInputSchema(BaseIOSchema):
+class FactReasonerInputSchema(BaseModel):
     """Schema for input of a tool for generating factuality scores."""
 
     response: str = Field(
@@ -35,7 +35,7 @@ class FactReasonerInputSchema(BaseIOSchema):
     )
 
 
-class FactReasonerOutputSchema(BaseIOSchema):
+class FactReasonerOutputSchema(BaseModel):
     """Schema for output of a tool for generating factuality scores."""
 
     results: Dict[str, Any] = Field(..., description="FactReasoner result dictionary.")

--- a/akd/tools/relevancy.py
+++ b/akd/tools/relevancy.py
@@ -1,9 +1,8 @@
 import itertools
 from typing import List, Optional
 
-from atomic_agents.lib.base.base_tool import BaseToolConfig
 from loguru import logger
-from pydantic import Field, BaseModel
+from pydantic import Field, BaseModel, ConfigDict
 
 from akd.agents.relevancy import (
     RelevancyAgent,
@@ -49,10 +48,10 @@ class RelevancyCheckerOutputSchema(BaseModel):
     )
 
 
-class RelevancyCheckerConfig(BaseToolConfig):
+class RelevancyCheckerConfig(ConfigDict):
     """Configuration for the RelevancyChecker."""
 
-    model_config = {"arbitrary_types_allowed": True}
+    model_config = {"extra": "allow"}
 
     debug: bool = Field(
         default=True,

--- a/akd/tools/relevancy.py
+++ b/akd/tools/relevancy.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from atomic_agents.lib.base.base_tool import BaseToolConfig
 from loguru import logger
-from pydantic import Field
+from pydantic import Field, BaseModel
 
 from akd.agents.relevancy import (
     RelevancyAgent,
@@ -12,7 +12,7 @@ from akd.agents.relevancy import (
 )
 from akd.structures import RelevancyLabel
 
-from ._base import BaseIOSchema, BaseTool
+from ._base import BaseTool
 
 
 class RelevancyCheckerInputSchema(RelevancyAgentInputSchema):
@@ -21,7 +21,7 @@ class RelevancyCheckerInputSchema(RelevancyAgentInputSchema):
     pass
 
 
-class _RelevancyCheckerSwappedInputSchema(BaseIOSchema):
+class _RelevancyCheckerSwappedInputSchema(BaseModel):
     """Schema with swapped field order"""
 
     content: str = Field(
@@ -34,7 +34,7 @@ class _RelevancyCheckerSwappedInputSchema(BaseIOSchema):
     )
 
 
-class RelevancyCheckerOutputSchema(BaseIOSchema):
+class RelevancyCheckerOutputSchema(BaseModel):
     """Output schema for the RelevancyChecker."""
 
     score: float = Field(

--- a/akd/tools/scrapers/resolvers.py
+++ b/akd/tools/scrapers/resolvers.py
@@ -5,18 +5,18 @@ from urllib.parse import urljoin
 import requests
 from bs4 import BeautifulSoup
 from loguru import logger
-from pydantic import Field, HttpUrl
+from pydantic import Field, HttpUrl, BaseModel
 
-from akd.tools._base import BaseIOSchema, BaseTool, BaseToolConfig
+from akd.tools._base import BaseTool, BaseToolConfig
 
 
-class ResolverInputSchema(BaseIOSchema):
+class ResolverInputSchema(BaseModel):
     """Input schema for resolver"""
 
     url: HttpUrl = Field(..., description="Input url to resolve the article from")
 
 
-class ResolverOutputSchema(BaseIOSchema):
+class ResolverOutputSchema(BaseModel):
     """Output schema for resolver"""
 
     url: HttpUrl = Field(..., description="Resolved output url")

--- a/akd/tools/scrapers/resolvers.py
+++ b/akd/tools/scrapers/resolvers.py
@@ -5,9 +5,9 @@ from urllib.parse import urljoin
 import requests
 from bs4 import BeautifulSoup
 from loguru import logger
-from pydantic import Field, HttpUrl, BaseModel
+from pydantic import Field, HttpUrl, BaseModel, ConfigDict
 
-from akd.tools._base import BaseTool, BaseToolConfig
+from akd.tools._base import BaseTool
 
 
 class ResolverInputSchema(BaseModel):
@@ -26,7 +26,7 @@ class ResolverOutputSchema(BaseModel):
     )
 
 
-class ArticleResolverConfig(BaseToolConfig):
+class ArticleResolverConfig(ConfigDict):
     """Configuration for the resolver"""
 
     model_config = {"arbitrary_types_allowed": True}

--- a/akd/tools/scrapers/web_scrapers.py
+++ b/akd/tools/scrapers/web_scrapers.py
@@ -9,15 +9,15 @@ import requests
 from bs4 import BeautifulSoup
 from crawl4ai import AsyncWebCrawler
 from markdownify import markdownify
-from pydantic import Field, HttpUrl
+from pydantic import Field, HttpUrl, BaseModel
 from readability import Document
 from requests import HTTPError, RequestException
 
 from akd.structures import SearchResultItem
-from akd.tools._base import BaseIOSchema, BaseTool, BaseToolConfig
+from akd.tools._base import BaseTool, BaseToolConfig
 
 
-class WebpageScraperToolInputSchema(BaseIOSchema):
+class WebpageScraperToolInputSchema(BaseModel):
     """
     Input schema for the WebpageScraperTool.
     """
@@ -39,7 +39,7 @@ class WebpageMetadata(SearchResultItem):
     )
 
 
-class WebpageScraperToolOutputSchema(BaseIOSchema):
+class WebpageScraperToolOutputSchema(BaseModel):
     """Schema for the output of the WebpageScraperTool."""
 
     content: str = Field(

--- a/akd/tools/scrapers/web_scrapers.py
+++ b/akd/tools/scrapers/web_scrapers.py
@@ -9,12 +9,12 @@ import requests
 from bs4 import BeautifulSoup
 from crawl4ai import AsyncWebCrawler
 from markdownify import markdownify
-from pydantic import Field, HttpUrl, BaseModel
+from pydantic import Field, HttpUrl, BaseModel, ConfigDict
 from readability import Document
 from requests import HTTPError, RequestException
 
 from akd.structures import SearchResultItem
-from akd.tools._base import BaseTool, BaseToolConfig
+from akd.tools._base import BaseTool
 
 
 class WebpageScraperToolInputSchema(BaseModel):
@@ -52,7 +52,7 @@ class WebpageScraperToolOutputSchema(BaseModel):
     )
 
 
-class WebpageScraperToolConfig(BaseToolConfig):
+class WebpageScraperToolConfig(ConfigDict):
     """Configuration for the WebpageScraperTool."""
 
     user_agent: str = Field(

--- a/akd/tools/search.py
+++ b/akd/tools/search.py
@@ -21,10 +21,10 @@ from akd.agents.query import (
 from akd.structures import SearchResultItem
 from akd.tools.relevancy import RelevancyChecker, RelevancyCheckerInputSchema
 
-from ._base import BaseIOSchema, BaseTool, BaseToolConfig
+from ._base import BaseTool, BaseToolConfig
 
 
-class SearchToolInputSchema(BaseIOSchema):
+class SearchToolInputSchema(BaseModel):
     """
     Schema for input to a tool for searching for information,
     news, references, and other content.
@@ -41,7 +41,7 @@ class SearchToolInputSchema(BaseIOSchema):
     )
 
 
-class SearchToolOutputSchema(BaseIOSchema):
+class SearchToolOutputSchema(BaseModel):
     """Schema for output of a tool for searching for information,
     news, references, and other content."""
 

--- a/akd/tools/search.py
+++ b/akd/tools/search.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Literal, Optional
 
 import aiohttp
 from loguru import logger
-from pydantic import BaseModel, SecretStr, field_validator
+from pydantic import BaseModel, SecretStr, field_validator, ConfigDict
 from pydantic.fields import Field
 from pydantic.networks import HttpUrl
 
@@ -21,7 +21,7 @@ from akd.agents.query import (
 from akd.structures import SearchResultItem
 from akd.tools.relevancy import RelevancyChecker, RelevancyCheckerInputSchema
 
-from ._base import BaseTool, BaseToolConfig
+from ._base import BaseTool
 
 
 class SearchToolInputSchema(BaseModel):
@@ -86,7 +86,7 @@ class SearxNGSearchToolOutputSchema(SearchToolOutputSchema):
     pass
 
 
-class SearxNGSearchToolConfig(BaseToolConfig):
+class SearxNGSearchToolConfig(ConfigDict):
     base_url: HttpUrl = os.getenv("SEARXNG_BASE_URL", "http://localhost:8080")
     max_results: int = os.getenv("SEARXNG_MAX_RESULTS", 10)
     engines: List[str] = os.getenv(
@@ -391,7 +391,7 @@ class SemanticScholarSearchToolOutputSchema(SearchToolOutputSchema):
     pass
 
 
-class SemanticScholarSearchToolConfig(BaseToolConfig):
+class SemanticScholarSearchToolConfig(ConfigDict):
     """Configuration for the Semantic Scholar Search Tool."""
 
     api_key: Optional[str] = Field(

--- a/akd/tools/utils.py
+++ b/akd/tools/utils.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, create_model
 from akd.structures import CallableSpec
 from akd.utils import AsyncRunMixin
 
-from ._base import BaseIOSchema, BaseTool
+from ._base import BaseTool
 
 
 def tool_wrapper(func: Union[Callable[..., Any], Coroutine]) -> Any:
@@ -58,13 +58,13 @@ def tool_wrapper(func: Union[Callable[..., Any], Coroutine]) -> Any:
     input_schema = create_model(
         f"{func_name}InputSchema",
         **fields,
-        __base__=BaseIOSchema,
+        __base__=BaseModel,
         __doc__=f"Input Schema for {func_name}",
     )
     output_schema = create_model(
         f"{func_name}OutputSchema",
         result=(return_type, ...),
-        __base__=BaseIOSchema,
+        __base__=BaseModel,
         __doc__=f"Output Schema for {func_name}",
     )
 

--- a/scripts/run_lit_agent.py
+++ b/scripts/run_lit_agent.py
@@ -2,7 +2,6 @@ import argparse
 import asyncio
 import json
 
-import instructor
 import openai
 from loguru import logger
 from pydantic import ConfigDict

--- a/scripts/run_lit_agent.py
+++ b/scripts/run_lit_agent.py
@@ -5,8 +5,9 @@ import json
 import instructor
 import openai
 from loguru import logger
+from pydantic import ConfigDict
+from langchain_openai import ChatOpenAI
 
-from akd.agents._base import BaseAgentConfig
 from akd.agents.extraction import (
     EstimationExtractionAgent,
     IntentBasedExtractionSchemaMapper,
@@ -43,7 +44,7 @@ async def main(args):
     )
 
     intent_agent = IntentAgent(
-        config=BaseAgentConfig(client=instructor.from_openai(openai.AsyncOpenAI())),
+        config=ConfigDict(client=ChatOpenAI()),
     )
 
     query_agent = create_query_agent()


### PR DESCRIPTION
### Summary
This PR works on replacing atomic agents with its Pydantic and Langchain equivalent. This is because most of the atomic agents code is just a wrapper around Pydantic, which we can directly implement instead of using it through atomic agents remove our dependency on the package

### Details
1. The PR replaces BaseIOSchema with BaseModel since BaseIOSchema implement BaseModel. This way, we can implement our own Schema's without going through the checks imposed by BaseIOSchema.
2. It also replaces AtomicBaseAgent with BaseModel. This is to remove the need certain functionalities such as SystemPromptGenerator and AgentMemory, which can be implemented from node to node without wrapping the code around it.
3. BaseAgentConfig is replaced by ConfigDict. This allows client to implemented without using the instructor library.

### TODO
1. The SystemPromptGenerator still has to be replaced with ChatPromptTemplate or its equivalent.
2. Since LangGraph implements tooling and asynchronous calling, we have to address the need for AsyncRunMixin and LangchainToolMixin.
3. Run tests over the existing tools and nodes to check if they work as expected:
