### PR TITLE
Remove api key error

### DIFF
--- a/akd/tools/search.py
+++ b/akd/tools/search.py
@@ -435,12 +435,12 @@ class SemanticScholarSearchToolConfig(BaseToolConfig):
     @field_validator("api_key", mode="before")
     @classmethod
     def validate_api_key(cls, v):
-        if v is None:
-            logger.warning(
-                "Semantic Scholar API key not provided. Rate limits may apply.",
-            )
-        return SecretStr(v) if v else None
-
+        if not v:
+            logger.warning("Semantic Scholar API key not provided. Rate limits may apply.")
+            return None
+        if isinstance(v, SecretStr):
+            return v.get_secret_value()
+        return v  
 
 class SemanticScholarSearchTool(
     BaseTool[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     "readability-lxml>=0.8.1",
     "requests>=2.32.3",
     "wikipedia>=1.4.0",
+    "langchain-openai==0.3.27", 
+    
 ]
 
 [tool.poetry]


### PR DESCRIPTION
In SemanticScholarSearchToolConfig, there was mismatch in the type of api_key returned by validator, it now returns the api key as a plain string 
