### PR TITLE
Bugfix and refactor storm agent with new abstraction structure

### DIFF
--- a/akd/agents/storm/__init__.py
+++ b/akd/agents/storm/__init__.py
@@ -1,1 +1,8 @@
-from .storm import StormAgent, StormInputSchema, StormOutputSchema
+from .storm import StormAgent, StormAgentConfig, StormInputSchema, StormOutputSchema
+
+__all__ = [
+    "StormAgent",
+    "StormInputSchema",
+    "StormOutputSchema",
+    "StormAgentConfig",
+]


### PR DESCRIPTION
### Summary :memo:
This pull request refactors the `StormAgent` to align with the new base agent abstraction structure. The primary goal is to decouple the agent's configuration from its core logic, improving modularity and maintainability. A new `StormAgentConfig` class has been introduced to manage settings like HITL mode and other STORM-specific configurations.

### Details
_Describe more what you did on changes._
1.  **Introduced `StormAgentConfig`**: Created a new `BaseAgentConfig` subclass to hold all configuration for the `StormAgent`, including the `hitl` flag and `storm_settings`.
2.  **Refactored `StormAgent`**:
    * Updated the agent to use the new `config_schema`.
    * Replaced the `__init__` method with the `_post_init` hook for initialization logic.
    * Modified the agent to access its configuration through `self.config` (e.g., `self.config.hitl`).
3.  **Standardized Schemas**: Updated `StormInputSchema` and `StormOutputSchema` to inherit from the base `InputSchema` and `OutputSchema` for consistency.
4.  **Aligned Execution Method**: Renamed the core execution method to `_arun` to match the `BaseAgent` interface, which wraps it with input/output validation.

### Bugfixes :bug:
-   **Configuration Handling**: Corrected the agent's configuration management. Settings are now properly passed and managed through a dedicated `StormAgentConfig` Pydantic model, preventing tight coupling within the agent's initialization logic.

### Checks
- [x] Tested Changes
- [ ] Stakeholder Approval