### PR TITLE
Bugfix local repository search and sort the results by score

### DIFF
--- a/akd/serializers.py
+++ b/akd/serializers.py
@@ -6,6 +6,7 @@ to handle Pydantic models and other complex objects properly.
 
 from typing import Any
 
+import numpy as np
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from pydantic import BaseModel
 from pydantic.networks import HttpUrl
@@ -25,6 +26,9 @@ class AKDSerializer(JsonPlusSerializer):
             return obj.model_dump(mode="json")
         elif isinstance(obj, HttpUrl):
             return str(obj)
+        elif isinstance(obj, np.ndarray):
+            # Convert NumPy arrays to lists for JSON serialization
+            return obj.tolist()
         elif isinstance(obj, dict):
             return {k: self._convert_pydantic_to_dict(v) for k, v in obj.items()}
         elif isinstance(obj, (list, tuple)):

--- a/akd/tools/code_search.py
+++ b/akd/tools/code_search.py
@@ -243,6 +243,41 @@ class LocalRepoCodeSearchTool(CodeSearchTool):
 
         return results.reset_index(drop=True).to_dict("records")
 
+    def _sort_results(
+        self,
+        results: list[SearchResultItem],
+        sort_by: str = "score",
+    ) -> list[SearchResultItem]:
+        """
+        Sort results by the specified key. First checks for the key directly in the dict,
+        then checks in the 'extra' field if it exists. Returns unsorted if key not found.
+        """
+
+        def __get_sort_key(result):
+            # First check if sort_by key exists directly in the dict
+            if sort_by in result:
+                return result[sort_by]
+
+            # Then check if 'extra' field exists and contains the sort_by key
+            if (
+                "extra" in result
+                and isinstance(result["extra"], dict)
+                and sort_by in result["extra"]
+            ):
+                return result["extra"][sort_by]
+
+            # If key not found anywhere, return a default value that will sort last
+            # Using float('inf') for numerical sorting or empty string for string sorting
+            return float("inf")
+
+        try:
+            # Sort in descending order (highest score first)
+            # Change reverse=False if you want ascending order
+            return sorted(results, key=__get_sort_key, reverse=True)
+        except TypeError:
+            # If sorting fails (mixed types), return as is
+            return results
+
     async def _arun(
         self,
         params: CodeSearchToolInputSchema,
@@ -280,8 +315,15 @@ class LocalRepoCodeSearchTool(CodeSearchTool):
             )
             for result in all_results_data
         ]
+        try:
+            formatted_results = self._sort_results(
+                formatted_results,
+                sort_by="score",
+            )
+        except Exception as e:
+            logger.error(f"Error sorting repo list by score: {e}")
 
-        return self.output_schema(results=formatted_results)
+        return self.output_schema(results=formatted_results, category="technology")
 
 
 """

--- a/akd/tools/code_search.py
+++ b/akd/tools/code_search.py
@@ -124,7 +124,7 @@ class CodeSearchTool(BaseTool[CodeSearchToolInputSchema, CodeSearchToolOutputSch
 
             # If key not found anywhere, return a default value that will sort last
             # Using float('inf') for numerical sorting or empty string for string sorting
-            return float("inf")
+            return float("-inf")
 
         try:
             # Sort in descending order (highest score first)

--- a/akd/tools/code_search.py
+++ b/akd/tools/code_search.py
@@ -157,6 +157,7 @@ class LocalRepoCodeSearchToolConfig(CodeSearchToolConfig):
         "1nPaEWD9Wuf115aEmqJQusCvJlPc7AP7O",
     )
     embedding_model_name: str = os.getenv("CODE_SEARCH_MODEL", "all-MiniLM-L6-v2")
+    remove_embedding_column: bool = True
     debug: bool = False
 
 
@@ -219,6 +220,7 @@ class LocalRepoCodeSearchTool(CodeSearchTool):
         query: str,
         top_k: int = 25,
         embeddings_column: str = "embeddings",
+        remove_embedding_column: bool = True,
         debug: bool = False,
     ) -> list[dict]:
         """
@@ -275,6 +277,10 @@ class LocalRepoCodeSearchTool(CodeSearchTool):
 
         results = self.repo_data.iloc[top_indices].copy()
         results["score"] = similarities[top_indices]
+        results["score"] = results["score"].astype(float)
+
+        if remove_embedding_column:
+            results = results.drop(columns=[embeddings_column])
 
         return results.reset_index(drop=True).to_dict("records")
 
@@ -298,6 +304,7 @@ class LocalRepoCodeSearchTool(CodeSearchTool):
                     query=query,
                     top_k=params.top_k,
                     embeddings_column="embeddings",
+                    remove_embedding_column=self.remove_embedding_column,
                     debug=self.debug,
                 )
                 if results:

--- a/akd/tools/code_search.py
+++ b/akd/tools/code_search.py
@@ -272,10 +272,11 @@ class LocalRepoCodeSearchTool(CodeSearchTool):
 
         formatted_results = [
             SearchResultItem(
-                title="GitHub Repository",
-                url=HttpUrlAdapter.validate_python(result.get("URL")),
-                content=result.get("text"),
+                title=f"GitHub Repository for {query}",
+                url=HttpUrlAdapter.validate_python(result.pop("URL", "")),
+                content=result.pop("text", ""),
                 query=query,
+                extra=result,
             )
             for result in all_results_data
         ]

--- a/akd/tools/misc.py
+++ b/akd/tools/misc.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
+
 import numpy as np
-import pandas as pd
-from scipy.spatial.distance import cdist
-from tqdm import tqdm
 from loguru import logger
-from sentence_transformers import SentenceTransformer
-from pathlib import Path
 from pydantic import HttpUrl, TypeAdapter
+from sentence_transformers import SentenceTransformer
 
 HttpUrlAdapter = TypeAdapter(HttpUrl)
+
 
 class Embedder:
     """Base class for embedding models."""
@@ -75,14 +73,20 @@ class Embedder:
     def compute_similarity(self, query: str, text: str) -> float:
         """Compute similarity between query and text."""
         raise NotImplementedError("Subclasses must implement this method.")
-    
+
     def _parse_embedding(self, emb_str) -> np.ndarray:
         """Parse embedding from string format to numpy array."""
-        if pd.isna(emb_str):
+
+        # If it's already a numpy array, return it
+        if isinstance(emb_str, np.ndarray):
+            return emb_str
+
+        # Handle None, NaN, or empty values
+        if emb_str is None or emb_str == "" or str(emb_str).lower() in ["nan", "none"]:
             return np.zeros(self.embedding_dimensions)
+
         try:
             return np.array([float(x) for x in str(emb_str).split(",")])
-        except (ValueError, AttributeError):
+        except (ValueError, AttributeError, TypeError):
             logger.warning(f"Failed to parse embedding: {emb_str}")
-            return np.zeros(self.embedding_dim)
-    
+            return np.zeros(self.embedding_dimensions)


### PR DESCRIPTION
### Summary :memo:
_Write an overview about it._

This pull request introduces two main improvements to the local repository code search functionality. First, it resolves a bug in the embedding parsing logic that occurred when handling non-string or NaN-like values. Second, it adds a feature to sort the search results by their relevance score, ensuring the most relevant code snippets appear first.

### Details
_Describe more what you did on changes._
1.  **`akd/tools/misc.py`**:
    * Refactored the `_parse_embedding` method to remove the dependency on `pandas`.
    * Replaced the `pd.isna()` check with more robust handling for `None`, empty strings, and numpy arrays to prevent parsing errors.
2.  **`akd/tools/code_search.py`**:
    * Added a new `_sort_results` method to sort search results by score in descending order.
    * Applied this sorting to the `LocalRepoCodeSearchTool` results.
    * Improved result formatting with a more descriptive title (`f"GitHub Repository for {query}"`) and safer dictionary key access using `.pop()`.
    * Added `category="technology"` to the output schema.

### Bugfixes :bug:
- Fixed an issue in `_parse_embedding` where a `TypeError` could occur when checking for NaN values on non-DataFrame inputs. The logic now correctly handles various empty or invalid inputs without relying on pandas.

### Checks
- [x] Tested Changes