### PR TITLE
Bugfix pdf check logic in pdf scraper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "pytest-asyncio>=1.0.0",
     "langchain-openai>=0.3.27",
     "tenacity>=9.1.2",
+    "httpx>=0.28.1",
 ]
 
 [tool.poetry]


### PR DESCRIPTION
### Summary :memo:
This pull request introduces a more robust method for detecting whether a given URL points to a PDF file. The previous implementation only checked if the URL string ended with `.pdf`, which could fail for many valid PDF links (e.g., those generated dynamically). This change enhances the `_is_pdf` check to inspect the `Content-Type` header of the URL, ensuring more reliable PDF identification.

### Details
_Describe more what you did on changes._
1.  Modified the `_is_pdf` method in `SimplePDFScraper` to be an `async` static method.
2.  For URLs, the method now performs an asynchronous `HEAD` request using `httpx` to check the `Content-Type` header. It returns `True` if the content type is `application/pdf`.
3.  Implemented a fallback mechanism: if the `HEAD` request fails, it reverts to checking if the URL path ends with `.pdf` or contains `/pdf`.
4.  Local file path validation (checking for a `.pdf` extension) remains unchanged.
5.  Updated the `_arun` method to properly `await` the new asynchronous `_is_pdf` method.
6.  Added `httpx` as a project dependency in `pyproject.toml` to support the new network request functionality.

### Bugfixes :bug:
- Fixes an issue where the `SimplePDFScraper` would incorrectly reject valid PDF URLs that do not explicitly end with the `.pdf` file extension.

### Checks
- [X] Tested Changes
- [ ] Stakeholder Approval