### PR TITLE
Bugfix/semantic tool

### DIFF
--- a/akd/tools/search.py
+++ b/akd/tools/search.py
@@ -629,7 +629,7 @@ class SemanticScholarSearchTool(
         Returns:
             The JSON response dictionary from the API or None if an error occurs.
         """
-        search_url = urljoin(str(self.config.base_url), "graph/v1/paper/search")
+        search_url = urljoin(str(self.config.base_url), f"graph/v1/paper/DOI:{query}")
         params = {
             "fields": ",".join(self.config.fields)
         }

--- a/akd/tools/search.py
+++ b/akd/tools/search.py
@@ -503,7 +503,7 @@ class SemanticScholarSearchTool(
         Returns:
             The JSON response dictionary from the API or None if an error occurs.
         """
-        search_url = urljoin(self.config.base_url, "graph/v1/paper/search")
+        search_url = urljoin(str(self.config.base_url), "graph/v1/paper/search")
         params = {
             "query": query,
             "offset": offset,
@@ -629,7 +629,7 @@ class SemanticScholarSearchTool(
         Returns:
             The JSON response dictionary from the API or None if an error occurs.
         """
-        search_url = urljoin(self.config.base_url, "graph/v1/paper/search")
+        search_url = urljoin(str(self.config.base_url), "graph/v1/paper/search")
         params = {
             "fields": ",".join(self.config.fields)
         }


### PR DESCRIPTION
### Summary:
Fixed bugs introduced by previous commit.


### Bugfixes :bug: (delete if dind't have any)
- self.config.base_url is of type HttpURL which results in TypeError: Cannot mix str and non-str arguments. It has to be converted to string.
- The correct URL had been replaced with search. It has been replaced

### Checks
- [x] Tested Changes
- [ ] Stakeholder Approval
