### PR TITLE
Modify doi_to_paper to use external ID instead

### DIFF
--- a/akd/tools/search.py
+++ b/akd/tools/search.py
@@ -431,6 +431,8 @@ class SemanticScholarSearchToolConfig(BaseToolConfig):
             ),
         ),
     )
+    # External ID to fetch paper details with
+    external_id: Optional[Literal["DOI", "ARXIV", "PMID", "ACL", "MAG", "CorpusId", "PMCID", "URL"]] = Field(default="DOI")
     debug: bool = False
 
     @field_validator("api_key", mode="before")
@@ -467,6 +469,7 @@ class SemanticScholarSearchTool(
         fields: Optional[List[str]] = None,
         results_per_page: int = 100,
         max_pages_per_query: int = 5,
+        external_id: str = "DOI",
         debug: bool = False,
     ) -> SemanticScholarSearchTool:
         """Creates an instance from specific parameters."""
@@ -476,6 +479,7 @@ class SemanticScholarSearchTool(
             "max_results": max_results,
             "results_per_page": results_per_page,
             "max_pages_per_query": max_pages_per_query,
+            "external_id": external_id,
             "debug": debug,
         }
         if fields:
@@ -895,19 +899,12 @@ class SemanticScholarSearchTool(
         Returns:
             List of PaperDataItem objects.
         """
-        external_id = kwargs.get("external_id", "DOI")
-        if external_id not in ["DOI", "ARXIV", "PMID", "ACL", "MAG", "CorpusId", "PMCID", "URL"]:
-            raise ValueError(
-                f"Unsupported external_id '{external_id}'. "
-                f"Must be one of: {', '.join(["DOI", "ARXIV", "PMID", "ACL", "MAG", "CorpusId", "PMCID", "URL"])}"
-            )
-
         async with aiohttp.ClientSession() as session:
             tasks = [
                 self._fetch_paper_by_external_id(
                     session,
                     query,
-                    external_id
+                    kwargs.get("external_id", self.config.external_id)
                 )
                 for query in params.queries
             ]

--- a/akd/tools/search.py
+++ b/akd/tools/search.py
@@ -890,16 +890,16 @@ class SemanticScholarSearchTool(
         Args:
             params: Input parameters including queries and category.
             **kwargs:
-            - external_id (str, optional): The type of external identifier ("DOI", "ARXIV", "PMID", "ACL", "MAG", "CorpusId").
+            - external_id (str, optional): The type of external identifier ("DOI", "ARXIV", "PMID", "ACL", "MAG", "CorpusId", "PMCID", "URL").
               Defaults to "DOI" if not provided.
         Returns:
             List of PaperDataItem objects.
         """
-        external_id = kwargs.get("external_id", "DOI").upper()
-        if external_id not in ["DOI", "ARXIV", "PMID", "ACL", "MAG", "CorpusId"]:
+        external_id = kwargs.get("external_id", "DOI")
+        if external_id not in ["DOI", "ARXIV", "PMID", "ACL", "MAG", "CorpusId", "PMCID", "URL"]:
             raise ValueError(
                 f"Unsupported external_id '{external_id}'. "
-                f"Must be one of: {', '.join(["DOI", "ARXIV", "PMID", "ACL", "MAG", "CorpusId"])}"
+                f"Must be one of: {', '.join(["DOI", "ARXIV", "PMID", "ACL", "MAG", "CorpusId", "PMCID", "URL"])}"
             )
 
         async with aiohttp.ClientSession() as session:

--- a/akd/tools/search.py
+++ b/akd/tools/search.py
@@ -689,7 +689,7 @@ class SemanticScholarSearchTool(
                 f"Failed to fetch Semantic Scholar results for query '{query}': {e}",
             )
 
-        return []
+        return [None]
 
     def _parse_result(
         self,

--- a/akd/tools/search.py
+++ b/akd/tools/search.py
@@ -612,10 +612,11 @@ class SemanticScholarSearchTool(
                 f"Could not parse response to paper object for doi {doi}: {str(e)}",
             )
     
-    async def _fetch_paper_by_doi(
+    async def _fetch_paper_by_external_id(
         self,
         session: aiohttp.ClientSession,
         query: str,
+        external_id: str = 'DOI',
     ) -> Optional[Dict[str, Any]]:
         """
         Fetches a single page of search results from Semantic Scholar.
@@ -629,7 +630,7 @@ class SemanticScholarSearchTool(
         Returns:
             The JSON response dictionary from the API or None if an error occurs.
         """
-        search_url = urljoin(str(self.config.base_url), f"graph/v1/paper/DOI:{query}")
+        search_url = urljoin(str(self.config.base_url), f"graph/v1/paper/{external_id}:{query}")
         params = {
             "fields": ",".join(self.config.fields)
         }
@@ -879,24 +880,34 @@ class SemanticScholarSearchTool(
 
         return final_results
     
-    async def doi_to_paper(self,
+    async def fetch_paper_by_external_id(self,
                            params: SemanticScholarSearchToolInputSchema,
                            **kwargs,
     )-> list[PaperDataItem]:
         """
-        Fetches a paper based on it's DOI.
+        Fetches a paper from Semantic Scholar using an external ID.
 
         Args:
             params: Input parameters including queries and category.
-
+            **kwargs:
+            - external_id (str, optional): The type of external identifier ("DOI", "ARXIV", "PMID", "ACL", "MAG", "CorpusId").
+              Defaults to "DOI" if not provided.
         Returns:
             List of PaperDataItem objects.
         """
+        external_id = kwargs.get("external_id", "DOI").upper()
+        if external_id not in ["DOI", "ARXIV", "PMID", "ACL", "MAG", "CorpusId"]:
+            raise ValueError(
+                f"Unsupported external_id '{external_id}'. "
+                f"Must be one of: {', '.join(["DOI", "ARXIV", "PMID", "ACL", "MAG", "CorpusId"])}"
+            )
+
         async with aiohttp.ClientSession() as session:
             tasks = [
-                self._fetch_paper_by_doi(
+                self._fetch_paper_by_external_id(
                     session,
                     query,
+                    external_id
                 )
                 for query in params.queries
             ]


### PR DESCRIPTION
### Summary:
This paper modifies the doi_to_paper function to fetch papers using any external ID.
By default, the code will use DOI, otherwise, it can fetch papers using these IDs - ["DOI", "ARXIV", "PMID", "ACL", "MAG", "CorpusId"]


### Usage:
```python
from akd.tools.search import SemanticScholarSearchTool, SemanticScholarSearchToolInputSchema

semantic_search_tool = SemanticScholarSearchTool()
output_with_ext_id = await semantic_search_tool.fetch_paper_by_external_id(SemanticScholarSearchToolInputSchema(queries=["2502.10522"]), external_id='arxiv')
output_with_defaults = await semantic_search_tool.fetch_paper_by_external_id(SemanticScholarSearchToolInputSchema(queries=["10.1145/3701716.3717805"]))
```

### Checks
- [ ] Tested Changes
- [ ] Stakeholder Approval
