### PR TITLE
Bugfix [Code Search]: Add deduplication method to remove duplicate results

### DIFF
--- a/akd/tools/code_search.py
+++ b/akd/tools/code_search.py
@@ -618,7 +618,19 @@ class GitHubCodeSearchTool(CodeSearchTool, SearxNGSearchTool):
             )
 
         # Call the parent's _arun method with the modified parameters
-        return await super()._arun(params=params, max_results=max_results, **kwargs)
+        output = await super()._arun(params=params, max_results=max_results, **kwargs)
+
+        try:
+            deduped = self._deduplicate_results(output.results, key="url")
+        except Exception as e:
+            logger.error(f"Error deduplicating results: {e}")
+
+        try:
+            sorted_results = self._sort_results(deduped, sort_by="score")
+        except Exception as e:
+            logger.error(f"Error sorting repo list by score: {e}")
+
+        return self.output_schema(results=sorted_results, category="technology")
 
 
 class SDECodeSearchToolConfig(CodeSearchToolConfig):


### PR DESCRIPTION
### Summary :memo:
This PR introduces a centralized deduplication method to the `CodeSearchTool` base class to eliminate redundant search results across tools. It adds a reusable `_deduplicate_results` method that filters results based on their `url` field.  
The logic is now applied consistently across `CombinedCodeSearchTool`, `LocalRepoCodeSearchTool`, and `SDECodeSearchTool`.

### Details
1. Added `_deduplicate_results()` method to `CodeSearchTool`, which removes duplicates based on the `url` field.  
2. Applied deduplication in `CombinedCodeSearchTool._rerank_results()` before sorting and truncating top-k results.  
3. Applied deduplication in `LocalRepoCodeSearchTool._arun()` after formatting results.  
4. Applied deduplication in `SDECodeSearchTool._arun()` after formatting results.  
5. Applied deduplication and sorting in `GitHubCodeSearchTool._arun()` after retrieving results from SearxNG.
6. Preserved existing sorting logic (`_sort_results`) across all tools.

### Bugfixes :bug: 
- Fixed an issue where duplicate entries appeared in the final output when tools were run with multiple queries.

### Checks
- [x] Deduplication applied to all tool outputs
- [x] Tested Changes
