### PR TITLE
Bugfix instructorbase agent

### DIFF
--- a/akd/configs/project.py
+++ b/akd/configs/project.py
@@ -3,7 +3,7 @@ from enum import Enum, auto
 from functools import lru_cache
 from typing import Optional
 
-from pydantic import BaseModel, field_validator
+from pydantic import AnyUrl, BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -38,6 +38,10 @@ class ModelConfigSettings(BaseSettings):
     temperature: float = 0.0
     max_tokens: int = 120_000_000
     api_keys: ApiKeys = ApiKeys()
+    base_url: AnyUrl | None = Field(
+        default=AnyUrl(os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")),
+        description="Base URL for the model provider API",
+    )
     default_no_answer: str = "Answer not found"
 
 


### PR DESCRIPTION
- Apprently, the provided api key was not being used. Rather it was used from global config.
- Defaulted to global if None

### Summary :memo:
This pull request addresses a bug in the `BaseAgent` where an API key provided during instantiation was being ignored. The agent was incorrectly hardcoded to always use the global API key from `CONFIG`. This change ensures that the agent prioritizes the provided `api_key`, falling back to the global configuration only when a specific key is not supplied. Additionally, the `BaseAgentConfig` has been updated to use default values from the global configuration for `api_key`, `model_name`, and `system_prompt`.

### Details
_Describe more what you did on changes._
1.  In the `BaseAgent`'s `__init__` method, the `openai.AsyncOpenAI` client initialization was updated. It now uses the logic `self.api_key` or `CONFIG.model_config_settings.api_keys.openai`, which prioritizes the instance-specific API key over the global one.
2.  In the `BaseAgentConfig` class, the fields for `api_key`, `model_name`, and `system_prompt` were modified to use `pydantic.Field` to set their default values directly from the global `CONFIG` file.
3. Add `base_url` to `BaseAgentConfig`

### Bugfixes :bug:
- Fixed an issue where `BaseAgent` would always use the global OpenAI API key, even when a different key was passed to its configuration during initialization.

### Checks
- [x] Tested Changes
- [ ] Stakeholder Approval