### PR TITLE
Add OpenAIEmbedder for Local Code Search Tool

### DIFF
--- a/akd/tools/code_search.py
+++ b/akd/tools/code_search.py
@@ -254,6 +254,7 @@ class LocalRepoCodeSearchToolConfig(CodeSearchToolConfig):
         "1nPaEWD9Wuf115aEmqJQusCvJlPc7AP7O",
     )
     embedder_type: Literal["sentence-transformers", "openai"] = "sentence-transformers"
+    wait_time: int = 1
     embedding_model_name: str = os.getenv("CODE_SEARCH_MODEL", "all-MiniLM-L6-v2")
     remove_embedding_column: bool = True
     text_column: str = "text"
@@ -402,7 +403,7 @@ class LocalRepoCodeSearchTool(CodeSearchTool):
 
             if self.config.embedder_type == "openai":
                 # Wait for 1 second between batches to avoid rate limit
-                time.sleep(1)
+                time.sleep(self.config.wait_time)
 
         # Store embeddings in memory
         self.repo_data[self.config.embeddings_column] = embeddings

--- a/akd/tools/code_search.py
+++ b/akd/tools/code_search.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import os
-from typing import Optional
+from typing import Literal, Optional
 import requests
 import json
+import time
 
 import numpy as np
 import pandas as pd
@@ -17,7 +18,7 @@ from sentence_transformers import CrossEncoder
 from akd.errors import SchemaValidationError
 from akd.structures import SearchResultItem
 from akd.tools._base import BaseTool, BaseToolConfig
-from akd.tools.misc import Embedder, HttpUrlAdapter
+from akd.tools.misc import Embedder, HttpUrlAdapter, OpenAIEmbedder
 from akd.tools.search import (
     SearchToolInputSchema,
     SearchToolOutputSchema,
@@ -252,6 +253,7 @@ class LocalRepoCodeSearchToolConfig(CodeSearchToolConfig):
         "CODE_SEARCH_FILE_ID",
         "1nPaEWD9Wuf115aEmqJQusCvJlPc7AP7O",
     )
+    embedder_type: Literal["sentence-transformers", "openai"] = "sentence-transformers"
     embedding_model_name: str = os.getenv("CODE_SEARCH_MODEL", "all-MiniLM-L6-v2")
     remove_embedding_column: bool = True
     text_column: str = "text"
@@ -288,7 +290,12 @@ class LocalRepoCodeSearchTool(CodeSearchTool):
 
             logger.info("Loading data and embedding model...")
             self.repo_data = pd.read_csv(self.config.data_file)
-            self.embedder = Embedder(self.config.embedding_model_name)
+            if self.config.embedder_type == "sentence-transformers":
+                self.embedder = Embedder(self.config.embedding_model_name)
+            elif self.config.embedder_type == "openai":
+                self.embedder = OpenAIEmbedder(
+                    model_name=self.config.embedding_model_name
+                )
 
             if self.config.embeddings_column not in self.repo_data.columns:
                 logger.warning(
@@ -373,7 +380,7 @@ class LocalRepoCodeSearchTool(CodeSearchTool):
             return
 
         logger.info(
-            f"Generating embeddings for {len(self.repo_data)} texts in batches of {batch_size}..."
+            f"Generating embeddings for {len(self.repo_data)} texts in batches of {batch_size} using {self.config.embedder_type}..."
         )
 
         # Get texts to embed
@@ -392,6 +399,10 @@ class LocalRepoCodeSearchTool(CodeSearchTool):
                 batch_size=batch_size,
             )
             embeddings.extend(batch_embeddings)
+
+            if self.config.embedder_type == "openai":
+                # Wait for 1 second between batches to avoid rate limit
+                time.sleep(1)
 
         # Store embeddings in memory
         self.repo_data[self.config.embeddings_column] = embeddings

--- a/akd/tools/search/__init__.py
+++ b/akd/tools/search/__init__.py
@@ -14,6 +14,7 @@ from .searxng_search import (
     SearxNGSearchTool,
     SearxNGSearchToolInputSchema,
     SearxNGSearchToolOutputSchema,
+    SearxNGSearchToolConfig,
 )
 from .semantic_scholar_search import (
     SemanticScholarSearchTool,

--- a/akd/tools/search/__init__.py
+++ b/akd/tools/search/__init__.py
@@ -34,6 +34,7 @@ __all__ = [
     "SearxNGSearchTool",
     "SearxNGSearchToolInputSchema",
     "SearxNGSearchToolOutputSchema",
+    "SearxNGSearchToolConfig",
     # Semantic Scholar
     "SemanticScholarSearchTool",
     "SemanticScholarSearchToolOutputSchema",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "httpx>=0.28.1",
     "sentence-transformers>=5.0.0",
     "ollama>=0.5.1",
+    "tiktoken>=0.9.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
### Summary :memo:
This PR introduces a new `OpenAIEmbedder` class that enables text embedding using OpenAI’s hosted models (e.g., `text-embedding-3-small`). This provides an alternative to local sentence-transformer models for embedding README content, improving the flexibility and quality of the embedding pipeline.

### Details
- **`OpenAIEmbedder` class**:
  - Implements the `Embedder` interface using the OpenAI API (`openai.OpenAI().embeddings.create(...)`).
  - Accepts `model_name` (default: `text-embedding-3-small`) and an optional `api_key`.
  - Automatically truncates input texts to stay within OpenAI token limits (8192 tokens).
  - Ensures `None` or empty entries are replaced with dummy strings to preserve input alignment.

- **Safe input handling**:
  - Introduced `truncate_text()` helper to guard against exceeding model context limits.
  - Ensures all inputs to OpenAI are valid strings to avoid 400 errors from the API.

- **Drop-in replacement**:
  - Designed to be a drop-in replacement in places where the standard `Embedder` is used.
  - Returns NumPy arrays consistent with `SentenceTransformer`-based embeddings.
  
### Usage

```python
from akd.tools.misc import OpenAIEmbedder

embedder = OpenAIEmbedder(model_name="text-embedding-3-small")
embeddings = embedder.embed_texts(["Some README text"])
```

### Bugfixes :bug: 
- [Minor] Added `SearxNGSearchToolConfig` in `akd/tools/search/__init__.py` to fix import issues for `CodeSearchTool`.

### Checks
- [X] Tested Changes
- [ ] Stakeholder Approval
