### PR TITLE
Add PyPaperBot-based scraper for full text parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,41 @@ This framework is built on the principle that **human researchers should direct 
 
 ## Architecture
 
-The system uses a **Planner-Orchestrator** pattern with standardized `NodeTemplate` components:
+The system implements a **Planner-Orchestrator** pattern with standardized `NodeTemplate` components for maximum flexibility and scientific rigor:
 
-- **Global Context**: Maintains overall research project state
-- **Local Context**: Need-to-know subsets for individual agents
-- **Specialized Agents**: Literature search, data extraction, relevancy checking, etc.
-- **Multi-Agent RAG**: Literature, Data, Code search agents, Gap agents, conflict agents, and quality validators, Science guardrails, etc.
-- **Framework Agnostic**: Core logic decoupled from orchestration and execution of individual agents and tools.
+### Core Design Patterns
+
+- **NodeTemplate Architecture**: All functional components implement the standardized `AbstractNodeTemplate` (`akd.nodes.templates`) with:
+  - Well-defined state management
+  - Input/output guardrails for validation
+  - Tool subset isolation (principle of least privilege)
+  - Framework-agnostic design that can wrap into any orchestration engine
+
+- **Context Management**:
+  - **Global Context**: Maintains overall research project state
+  - **Local Context**: Sandboxed, need-to-know subsets for individual agents
+  - Prevents context bleeding between agents
+
+- **Human-in-the-Loop Control**: Researchers maintain control over:
+  - Workflow approval and modifications
+  - Parameter tuning for any component
+  - Branching and merging decisions
+
+- **Multi-Agent Coordination**: Specialized agents work together with conflict detection and gap identification
+
+### Human-in-the-Loop Control Points
+
+The framework ensures researchers maintain control throughout the discovery process:
+
+- **Plan Approval**: Initial research plans and any significant modifications require explicit human approval
+- **Parameter Control**: Researchers can inspect and adjust parameters for any NodeTemplate component
+- **Workflow Direction**: AI proposes next steps but humans direct the overall research strategy
+- **Quality Gates**: Human validation required before accepting AI-generated analyses or conclusions
+- **Branching Decisions**: Research workflow branching and merging decisions are human-directed
+
+**Golden Rule**: When in doubt about research direction, data validity, or result interpretation, the system defers to human researcher guidance.
+
+For comprehensive design principles, see [Design Philosophy](docs/design_philosophy.md).
 
 ## Quick Start
 
@@ -38,6 +66,12 @@ source .venv/bin/activate
 # Install dependencies
 uv sync
 
+# For development (includes testing tools)
+uv sync --extra dev
+
+# For local development (includes marimo and other local tools)
+uv sync --extra dev --extra local
+
 # Setup environment variables
 cp .env.example .env
 # Edit .env with your API keys and configurations
@@ -48,21 +82,67 @@ cp .env.example .env
 
 Refer to the [notebooks](notebooks) for examples.
 
+## Core Tools & Agents
+
+The framework provides a comprehensive suite of specialized tools and agents for scientific research:
+
+### Search Tools
+- **SearxNGSearchTool** (`akd.tools.search.searxng_search`) - General web search with privacy focus
+- **SemanticScholarSearchTool** (`akd.tools.search.semantic_scholar_search`) - Academic paper search and discovery
+- **Code Search Tool** (`akd.tools.code_search`) - Code repository search and analysis
+
+### Search Agents
+- **Deep Search Agent** (`akd.agents.search.deep_search`) - Advanced multi-step literature search with iterative refinement
+- **Controlled Search Agent** (`akd.agents.search.controlled`) - Structured search workflow with quality controls
+- **Query Agent & FollowUp Query Agent** (`akd.agents.query`) - Query processing, refinement, and follow-up generation
+- **Relevancy Agent** (`akd.agents.relevancy`) - Content relevance assessment and filtering
+
+### Extraction & Processing
+- **PyPaperBot Scraper** (`akd.tools.scrapers.pypaperbot`) - PDF content extraction and processing
+- **DoclingScraper** (`akd.tools.scrapers`) - Advanced document processing and text extraction
+- **Web Scrapers** (`akd.tools.scrapers.web_scrapers`) - Content extraction from web sources
+
+### Specialized Components
+- **Source Validator** (`akd.tools.source_validator`) - Source quality validation and verification
+- **Relevancy Checker** (`akd.tools.relevancy`) - Content relevance validation against research context
+- **Link Relevancy Assessor** (`akd.tools.link_relevancy_assessor`) - URL relevance assessment and filtering
+
+## Scientific Guardrails
+
+The framework implements deep guardrails specifically designed for scientific research integrity:
+
+### Deep Attribution & Validation
+- **Traceable Claims**: All claims traceable to specific source sentences and data points
+- **Source Quality**: Prioritizes refereed journals and validated data repositories
+- **Attribution Chain**: Complete attribution from final claims back to original sources
+- **Quality Validation**: Multi-level validation of source credibility and relevance
+
+### Conflict Detection & Gap Analysis
+- **Agentic RAG**: Multi-agent approach to comprehensive information retrieval
+  - **Gap Agent**: Actively identifies missing information and research gaps
+  - **Conflict Agent**: Specifically searches for contradictory evidence and conflicting findings
+- **Bias Prevention**: Deliberately surfaces contradictory evidence to prevent confirmation bias
+- **Evidence Balance**: Ensures both supporting and conflicting evidence is presented
+
+### Transparent Research Process
+- **Stateful Execution**: Complete workflow state capture for reproducibility
+- **Shareable Artifacts**: Research graphs that others can inspect, validate, and extend
+- **Human Validation**: All AI-generated content clearly labeled and requires human approval
+- **Complete Transparency**: Every step of the research process is inspectable and documented
+
 ## Key Features
 
-
-- **Deep Attribution**: claims traceable to specific source material, down to the sentences that were combined to make the claim (via factreasoner).
-- **Conflict Detection**: Actively identifies contradictory evidence
-- **Shareable Workflows**: Complete research (execution) graphs that others can inspect and extend, not just summarized end products.
-- **Scientific Guardrails**: Guardrails that go beyond the generic LLM literature, that explicity designed to support scientific research.
-- **Stateful Execution**: The workflow maintains a persistent, stateful context of the research journey, enabling a branching, reversible and iterative process that supports a researcher's natural methodology rather than imposing a rigid, automated sequence that current agentic systems embrace.
+- **Human-in-the-Loop Control**: Researchers direct the discovery process with AI augmentation
+- **Framework Agnostic**: Core logic decoupled from orchestration engines for maximum flexibility
+- **Reproducible Research**: Complete workflow capture enables true reproducibility and sharing
+- **Community-Driven**: Open framework designed for collaborative scientific advancement
 
 ## Project Structure
 
 ```
 akd/                    # Core framework
 ├── agents/            # Specialized research agents
-├── nodes/             # NodeTemplate implementations  
+├── nodes/             # NodeTemplate implementations
 ├── tools/             # Research tools and scrapers
 └── configs/           # Configuration management
 

--- a/akd/tools/scrapers/__init__.py
+++ b/akd/tools/scrapers/__init__.py
@@ -7,12 +7,15 @@ from ._base import (
 )
 from .omni import DoclingScraper, DoclingScraperConfig, OmniScraperInputSchema
 from .pdf_scrapers import PDFScraperInputSchema, SimplePDFScraper
+from .pypaperbot_scraper import PyPaperBotScraper, PyPaperBotScraperConfig
 from .web_scrapers import Crawl4AIWebScraper, SimpleWebScraper
 
 __all__ = [
     "SimplePDFScraper",
     "SimpleWebScraper",
     "Crawl4AIWebScraper",
+    "PyPaperBotScraper",
+    "PyPaperBotScraperConfig",
     "PDFScraperInputSchema",
     "ScraperToolInputSchema",
     "ScraperToolOutputSchema",

--- a/akd/tools/scrapers/__init__.py
+++ b/akd/tools/scrapers/__init__.py
@@ -7,7 +7,7 @@ from ._base import (
 )
 from .omni import DoclingScraper, DoclingScraperConfig, OmniScraperInputSchema
 from .pdf_scrapers import PDFScraperInputSchema, SimplePDFScraper
-from .pypaperbot_scraper import PyPaperBotScraper, PyPaperBotScraperConfig
+from .pypaperbot import PyPaperBotScraper, PyPaperBotScraperConfig
 from .web_scrapers import Crawl4AIWebScraper, SimpleWebScraper
 
 __all__ = [

--- a/akd/tools/scrapers/pypaperbot.py
+++ b/akd/tools/scrapers/pypaperbot.py
@@ -23,7 +23,7 @@ from .omni import DoclingScraper
 _PYPAPERBOT_AVAILABLE: bool = importlib.util.find_spec("PyPaperBot") is not None
 if not _PYPAPERBOT_AVAILABLE:
     logger.warning(
-        "PyPaperBot not available. Please install using `pip install PyPaperBot`",
+        "PyPaperBot not available. Please install using `uv pip install PyPaperBot`. Alternatively, install with `uv sync --extra dev --extra local`.",
     )
 
 

--- a/akd/tools/scrapers/pypaperbot.py
+++ b/akd/tools/scrapers/pypaperbot.py
@@ -49,11 +49,7 @@ class PyPaperBotScraperConfig(ScraperToolConfig):
         description="Use title-based query fallback if DOI cannot be extracted",
     )
 
-    # Anna's Archive configuration (SciDB only)
-    annas_archive_mirror: str = Field(
-        default="https://annas-archive.se/",
-        description="Anna's Archive (SciDB) mirror URL for PyPaperBot",
-    )
+    # Network configuration for PyPaperBot
     proxy: Optional[str] = Field(
         default=None,
         description="Comma-separated proxies string understood by PyPaperBot --proxy",
@@ -71,9 +67,10 @@ class PyPaperBotScraperConfig(ScraperToolConfig):
 class PyPaperBotScraper(ScraperToolBase):
     """
     Scraper that uses PyPaperBot package to fetch full-text PDFs via DOI or query
-    from Anna's Archive (SciDB), then converts the file to Markdown using Docling.
+    using pypaperbot, then converts the file to Markdown using Docling.
 
     Reference: ferru97/PyPaperBot on GitHub.
+    Currently, using https://github.com/NISH1001/PyPaperBot/tree/develop fork that fixes google scholar
     """
 
     input_schema = ScraperToolInputSchema
@@ -121,8 +118,7 @@ class PyPaperBotScraper(ScraperToolBase):
                 str(out_dir),
             ]
 
-            # Add Anna's Archive mirror (required)
-            cmd.extend(["--annas-archive-mirror", self.config.annas_archive_mirror])
+            # PyPaperBot will use default mirrors automatically
 
             # Add optional parameters from config
             if self.config.proxy:
@@ -197,8 +193,7 @@ class PyPaperBotScraper(ScraperToolBase):
                 str(out_dir),
             ]
 
-            # Add Anna's Archive mirror (required)
-            cmd.extend(["--annas-archive-mirror", self.config.annas_archive_mirror])
+            # PyPaperBot will use default mirrors automatically
 
             # Add optional parameters from config
             if self.config.proxy:

--- a/akd/tools/scrapers/pypaperbot.py
+++ b/akd/tools/scrapers/pypaperbot.py
@@ -245,8 +245,6 @@ class PyPaperBotScraper(ScraperToolBase):
 
     def _extract_doi_from_url(self, url: str) -> Optional[str]:
         """Extract DOI from URL using simple pattern matching."""
-        import re
-
         # Common DOI patterns
         doi_patterns = [
             r"10\.\d{4,}/[^\s\"<>#]+",  # Standard DOI format

--- a/akd/tools/scrapers/pypaperbot_scraper.py
+++ b/akd/tools/scrapers/pypaperbot_scraper.py
@@ -1,0 +1,305 @@
+import asyncio
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+from loguru import logger
+from pydantic import Field
+
+from ._base import (
+    ScraperToolBase,
+    ScraperToolConfig,
+    ScraperToolInputSchema,
+    ScraperToolOutputSchema,
+)
+from .omni import DoclingScraper, OmniScraperInputSchema
+
+# Detect if PyPaperBot module is available in the current environment
+_PYPAPERBOT_AVAILABLE: bool = importlib.util.find_spec("PyPaperBot") is not None
+
+
+class PyPaperBotScraperConfig(ScraperToolConfig):
+    """Configuration options for PyPaperBotScraper."""
+
+    max_runtime_seconds: int = Field(
+        default=120,
+        description="Maximum time allowed for PyPaperBot to run (seconds)",
+    )
+    scholar_pages: str = Field(
+        default="1",
+        description="Number of Google Scholar pages to inspect when using query fallback",
+    )
+    scholar_results: int = Field(
+        default=7,
+        ge=1,
+        le=10,
+        description="Number of results to download when scholar-pages=1",
+    )
+    enable_query_fallback: bool = Field(
+        default=True,
+        description="Use title-based query fallback if DOI cannot be extracted",
+    )
+
+    # Anna's Archive configuration (SciDB only)
+    annas_archive_mirror: str = Field(
+        default="https://annas-archive.se/",
+        description="Anna's Archive (SciDB) mirror URL for PyPaperBot",
+    )
+    proxy: Optional[str] = Field(
+        default=None,
+        description="Comma-separated proxies string understood by PyPaperBot --proxy",
+    )
+    single_proxy: Optional[str] = Field(
+        default=None,
+        description="Single proxy URL for PyPaperBot --single-proxy",
+    )
+    selenium_chrome_version: Optional[int] = Field(
+        default=None,
+        description="First three digits of local Chrome version to enable Selenium path in PyPaperBot",
+    )
+
+
+class PyPaperBotScraper(ScraperToolBase):
+    """
+    Scraper that uses PyPaperBot package to fetch full-text PDFs via DOI or query
+    from Anna's Archive (SciDB), then converts the file to Markdown using Docling.
+
+    Reference: ferru97/PyPaperBot on GitHub.
+    """
+
+    input_schema = ScraperToolInputSchema
+    output_schema = ScraperToolOutputSchema
+    config_schema = PyPaperBotScraperConfig
+
+    def __init__(
+        self,
+        config: PyPaperBotScraperConfig | None = None,
+        debug: bool = False,
+    ) -> None:
+        super().__init__(config=config or PyPaperBotScraperConfig(), debug=debug)
+
+    def _find_downloaded_pdf(self, directory: Path) -> Optional[Path]:
+        """Find first PDF file in directory."""
+        try:
+            for pdf_file in directory.glob("*.pdf"):
+                if pdf_file.is_file() and pdf_file.stat().st_size > 0:
+                    return pdf_file
+        except Exception as e:
+            if self.debug:
+                logger.debug(f"PDF search failed in {directory}: {e}")
+        return None
+
+    async def _run_pypaperbot_with_doi(self, doi: str, out_dir: Path) -> Optional[Path]:
+        """Run PyPaperBot with DOI."""
+        if not _PYPAPERBOT_AVAILABLE:
+            if self.debug:
+                logger.debug("PyPaperBot package not available")
+            return None
+
+        try:
+            cmd = [
+                sys.executable,
+                "-m",
+                "PyPaperBot",
+                "--doi",
+                doi,
+                "--dwn-dir",
+                str(out_dir),
+            ]
+
+            # Add Anna's Archive mirror (required)
+            cmd.extend(["--annas-archive-mirror", self.config.annas_archive_mirror])
+
+            # Add optional parameters from config
+            if self.config.proxy:
+                cmd.extend(["--proxy", self.config.proxy])
+            if self.config.single_proxy:
+                cmd.extend(["--single-proxy", self.config.single_proxy])
+            if self.config.selenium_chrome_version:
+                cmd.extend(
+                    [
+                        "--selenium-chrome-version",
+                        str(self.config.selenium_chrome_version),
+                    ]
+                )
+
+            if self.debug:
+                logger.debug(f"Running PyPaperBot command: {' '.join(cmd)}")
+
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=out_dir,
+            )
+
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(), timeout=self.config.max_runtime_seconds
+                )
+
+                if self.debug:
+                    logger.debug(f"PyPaperBot stdout: {stdout.decode()}")
+                    if stderr:
+                        logger.debug(f"PyPaperBot stderr: {stderr.decode()}")
+
+                return self._find_downloaded_pdf(out_dir)
+            except asyncio.TimeoutError:
+                process.kill()
+                if self.debug:
+                    logger.debug(f"PyPaperBot timeout for DOI: {doi}")
+                return None
+        except Exception as e:
+            if self.debug:
+                logger.debug(f"PyPaperBot execution failed for DOI {doi}: {e}")
+        return None
+
+    async def _run_pypaperbot_with_query(
+        self, query: str, out_dir: Path
+    ) -> Optional[Path]:
+        """Run PyPaperBot with search query."""
+        if not _PYPAPERBOT_AVAILABLE or not self.config.enable_query_fallback:
+            return None
+
+        try:
+            cmd = [
+                sys.executable,
+                "-m",
+                "PyPaperBot",
+                "--query",
+                query,
+                "--scholar-pages",
+                self.config.scholar_pages,
+                "--scholar-results",
+                str(self.config.scholar_results),
+                "--dwn-dir",
+                str(out_dir),
+            ]
+
+            # Add Anna's Archive mirror (required)
+            cmd.extend(["--annas-archive-mirror", self.config.annas_archive_mirror])
+
+            # Add optional parameters from config
+            if self.config.proxy:
+                cmd.extend(["--proxy", self.config.proxy])
+            if self.config.selenium_chrome_version:
+                cmd.extend(
+                    [
+                        "--selenium-chrome-version",
+                        str(self.config.selenium_chrome_version),
+                    ]
+                )
+
+            if self.debug:
+                logger.debug(f"Running PyPaperBot command: {' '.join(cmd)}")
+
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=out_dir,
+            )
+
+            try:
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(), timeout=self.config.max_runtime_seconds
+                )
+
+                if self.debug:
+                    logger.debug(f"PyPaperBot stdout: {stdout.decode()}")
+                    if stderr:
+                        logger.debug(f"PyPaperBot stderr: {stderr.decode()}")
+
+                return self._find_downloaded_pdf(out_dir)
+            except asyncio.TimeoutError:
+                process.kill()
+                if self.debug:
+                    logger.debug(f"PyPaperBot timeout for query: {query}")
+                return None
+        except Exception as e:
+            if self.debug:
+                logger.debug(f"PyPaperBot execution failed for query {query}: {e}")
+        return None
+
+    def _extract_doi_from_url(self, url: str) -> Optional[str]:
+        """Extract DOI from URL using simple pattern matching."""
+        import re
+
+        # Common DOI patterns
+        doi_patterns = [
+            r"10\.\d{4,}/[^\s\"<>#]+",  # Standard DOI format
+            r"/doi/(?:full/|pdf/|pdfdirect/)?(10\.[^/?#]+)",  # Wiley DOI extraction
+        ]
+
+        for pattern in doi_patterns:
+            match = re.search(pattern, url, re.IGNORECASE)
+            if match:
+                # Return the full DOI or the captured group
+                return match.group(1) if match.groups() else match.group(0)
+
+        return None
+
+    def _extract_query_from_url(self, url: str) -> Optional[str]:
+        """Extract a reasonable search query from URL."""
+        # For now, just use the URL itself as the query
+        # PyPaperBot will try to extract meaningful information
+        return url
+
+    async def _arun(
+        self,
+        params: ScraperToolInputSchema,
+        **_kwargs,
+    ) -> ScraperToolOutputSchema:
+        """Main execution method."""
+        url_str = str(params.url)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tmp_path = Path(tmp_dir)
+
+            # First, try to extract DOI from URL
+            doi = self._extract_doi_from_url(url_str)
+            pdf_path = None
+
+            if doi:
+                if self.debug:
+                    logger.debug(f"Extracted DOI: {doi}")
+                pdf_path = await self._run_pypaperbot_with_doi(doi, tmp_path)
+
+            # Fallback to query-based search if no DOI found or DOI search failed
+            if not pdf_path and self.config.enable_query_fallback:
+                query = self._extract_query_from_url(url_str)
+                if query:
+                    if self.debug:
+                        logger.debug(f"Falling back to query search: {query}")
+                    pdf_path = await self._run_pypaperbot_with_query(query, tmp_path)
+
+            # Convert PDF to markdown using Docling if PDF found
+            if pdf_path and pdf_path.exists():
+                try:
+                    docling_scraper = DoclingScraper(debug=self.debug)
+                    result = await docling_scraper.arun(
+                        OmniScraperInputSchema(url=str(pdf_path))
+                    )
+
+                    if result.content and result.content.strip():
+                        # Update metadata with original URL
+                        result.metadata.url = params.url
+                        result.metadata.query = doi or url_str
+                        return result
+                except Exception as e:
+                    if self.debug:
+                        logger.debug(f"Docling conversion failed: {e}")
+
+            # Return empty result if all strategies failed
+            from ._base import ScrapedMetadata
+
+            return ScraperToolOutputSchema(
+                content="",
+                metadata=ScrapedMetadata(
+                    url=params.url,
+                    title="",
+                    query=doi or url_str,
+                ),
+            )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,10 +93,11 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=1.0.0",
     "pytest-cov>=6.0.0",
-    "ipykernel>=6.30.0",
-    "ipywidgets>=8.1.7",
     "pre-commit>=4.2.0",
 ]
 local = [
     "marimo==0.15.0",
+    "jupyter",
+    "ipykernel>=6.30.0",
+    "ipywidgets>=8.1.7",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,8 @@ dependencies = [
     "tiktoken>=0.9.0",
     "rapidfuzz>=3.13.0",
     "deepeval>=3.4.0",
-    "pypaperbot>=1.4.1",
     "undetected-chromedriver>=3.5.5",
+    "pypaperbot @ git+https://github.com/NISH1001/PyPaperBot.git@develop",
 ]
 
 [project.urls]
@@ -96,4 +96,7 @@ dev = [
     "ipykernel>=6.30.0",
     "ipywidgets>=8.1.7",
     "pre-commit>=4.2.0",
+]
+local = [
+    "marimo==0.15.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,9 @@ dependencies = [
     "ollama>=0.5.1",
     "tiktoken>=0.9.0",
     "rapidfuzz>=3.13.0",
-    "deepeval>=3.4.0"
+    "deepeval>=3.4.0",
+    "pypaperbot>=1.4.1",
+    "undetected-chromedriver>=3.5.5",
 ]
 
 [project.urls]

--- a/tests/tools/scrapers/test_pypaperbot_scraper.py
+++ b/tests/tools/scrapers/test_pypaperbot_scraper.py
@@ -1,0 +1,212 @@
+"""Integration tests for PyPaperBotScraper."""
+
+import importlib.util
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import AnyUrl
+
+from akd.tools.scrapers._base import ScrapedMetadata, ScraperToolInputSchema
+from akd.tools.scrapers.pypaperbot_scraper import (
+    PyPaperBotScraper,
+    PyPaperBotScraperConfig,
+)
+
+# Check if PyPaperBot is available (same check as in the scraper)
+_PYPAPERBOT_AVAILABLE: bool = importlib.util.find_spec("PyPaperBot") is not None
+
+
+class TestPyPaperBotScraper:
+    """Test suite for PyPaperBotScraper."""
+
+    def test_doi_extraction_from_arxiv_url(self):
+        """Test DOI extraction from arXiv URLs."""
+        scraper = PyPaperBotScraper()
+
+        # Test the specific arXiv URL
+        arxiv_url = "https://doi.org/10.48550/arXiv.2411.08181"
+        doi = scraper._extract_doi_from_url(arxiv_url)
+
+        assert doi == "10.48550/arXiv.2411.08181"
+
+        # Test other DOI formats
+        test_cases = [
+            ("https://dx.doi.org/10.1038/nature12373", "10.1038/nature12373"),
+            ("https://doi.org/10.1126/science.1234567", "10.1126/science.1234567"),
+            (
+                "https://www.nature.com/articles/10.1038/s41586-023-12345-6",
+                "10.1038/s41586-023-12345-6",
+            ),
+        ]
+
+        for url, expected_doi in test_cases:
+            extracted_doi = scraper._extract_doi_from_url(url)
+            assert extracted_doi == expected_doi
+
+    def test_query_extraction_from_url(self):
+        """Test query extraction from URLs."""
+        scraper = PyPaperBotScraper()
+
+        # Test the arXiv URL
+        arxiv_url = "https://doi.org/10.48550/arXiv.2411.08181"
+        query = scraper._extract_query_from_url(arxiv_url)
+
+        assert "10.48550/arXiv.2411.08181" in query
+
+    def test_scraper_config(self):
+        """Test PyPaperBotScraper configuration."""
+        config = PyPaperBotScraperConfig(
+            max_runtime_seconds=60,
+            scholar_pages="2",
+            scholar_results=5,
+            enable_query_fallback=False,
+        )
+
+        scraper = PyPaperBotScraper(config=config)
+
+        assert scraper.config.max_runtime_seconds == 60
+        assert scraper.config.scholar_pages == "2"
+        assert scraper.config.scholar_results == 5
+        assert scraper.config.enable_query_fallback is False
+
+    @pytest.mark.skipif(
+        not _PYPAPERBOT_AVAILABLE,
+        reason="PyPaperBot not available in environment",
+    )
+    @pytest.mark.asyncio
+    async def test_pypaperbot_scraper_with_arxiv_url_integration(self):
+        """Integration test with actual PyPaperBot for the specific arXiv URL.
+
+        This test requires PyPaperBot to be installed and will be skipped in CI/CD
+        environments where it's not available.
+        """
+        # Configure with shorter timeout for testing
+        config = PyPaperBotScraperConfig(
+            max_runtime_seconds=60,  # Shorter timeout for testing
+            enable_query_fallback=True,
+        )
+
+        scraper = PyPaperBotScraper(config=config, debug=True)
+
+        # Test input
+        input_data = ScraperToolInputSchema(
+            url=AnyUrl("https://doi.org/10.48550/arXiv.2411.08181"),
+        )
+
+        # Run the scraper
+        result = await scraper.arun(input_data)
+
+        # Verify result structure
+        assert result is not None
+        assert hasattr(result, "content")
+        assert hasattr(result, "metadata")
+
+        # If content was successfully scraped, verify it contains the expected title
+        if result.content and result.content.strip():
+            assert (
+                "Challenges in Guardrailing Large Language Models for Science"
+                in result.content
+            )
+            assert result.metadata.url == input_data.url
+
+        # Note: If PyPaperBot fails to download or the content is empty,
+        # the test will still pass as long as the scraper handles it gracefully
+
+    @pytest.mark.skipif(
+        not _PYPAPERBOT_AVAILABLE,
+        reason="PyPaperBot not available in environment",
+    )
+    @pytest.mark.asyncio
+    async def test_pypaperbot_scraper_fallback_behavior(self):
+        """Test fallback behavior when DOI extraction might fail."""
+        config = PyPaperBotScraperConfig(
+            max_runtime_seconds=30,
+            enable_query_fallback=True,
+        )
+
+        scraper = PyPaperBotScraper(config=config, debug=True)
+
+        # Test with a URL that might not have a clear DOI
+        input_data = ScraperToolInputSchema(
+            url=AnyUrl("https://example.com/some-paper-about-llm-guardrails"),
+        )
+
+        result = await scraper.arun(input_data)
+
+        # Should handle gracefully even if no content is found
+        assert result is not None
+        assert hasattr(result, "content")
+        assert hasattr(result, "metadata")
+        assert result.metadata.url == input_data.url
+
+    @pytest.mark.asyncio
+    async def test_pypaperbot_scraper_with_mocked_docling(self):
+        """Test PyPaperBotScraper with mocked Docling scraper to isolate PyPaperBot behavior."""
+        # Create a mock for the internal scraper (Docling)
+        mock_docling_result = type(
+            "MockResult",
+            (),
+            {
+                "content": "Challenges in Guardrailing Large Language Models for Science\n\nThis is test content from the mocked scraper.",
+                "metadata": type(
+                    "MockMetadata",
+                    (),
+                    {
+                        "title": "Challenges in Guardrailing Large Language Models for Science",
+                        "url": "test_url",
+                    },
+                )(),
+            },
+        )()
+
+        mock_scraper = AsyncMock()
+        mock_scraper.arun.return_value = mock_docling_result
+        mock_scraper.input_schema = ScraperToolInputSchema
+
+        # Test PyPaperBotScraper with mocked Docling
+        scraper = PyPaperBotScraper(scraper=mock_scraper, debug=True)
+
+        input_data = ScraperToolInputSchema(
+            url=AnyUrl("https://doi.org/10.48550/arXiv.2411.08181"),
+        )
+
+        # Mock the PDF finding and PyPaperBot execution
+        with (
+            patch.object(scraper, "_find_downloaded_pdf") as mock_find_pdf,
+            patch.object(scraper, "_run_pypaperbot_with_doi") as mock_run_pypaperbot,
+        ):
+            # Mock successful PDF download
+            from pathlib import Path
+
+            mock_pdf_path = Path("/tmp/test.pdf")
+            mock_find_pdf.return_value = mock_pdf_path
+            mock_run_pypaperbot.return_value = mock_pdf_path
+
+            result = await scraper.arun(input_data)
+
+            # Verify the result contains expected content
+            assert result.content == mock_docling_result.content
+            assert (
+                "Challenges in Guardrailing Large Language Models for Science"
+                in result.content
+            )
+            assert result.metadata.url == input_data.url
+
+    def test_empty_result_handling(self):
+        """Test that scraper handles empty results gracefully."""
+        scraper = PyPaperBotScraper(debug=True)
+
+        # This should not raise an exception
+        empty_result = scraper.output_schema(
+            content="",
+            metadata=ScrapedMetadata(
+                url=AnyUrl("https://doi.org/10.48550/arXiv.2411.08181"),
+                title="",
+                query="10.48550/arXiv.2411.08181",
+            ),
+        )
+
+        assert empty_result.content == ""
+        assert empty_result.metadata.url == AnyUrl(
+            "https://doi.org/10.48550/arXiv.2411.08181",
+        )

--- a/tests/tools/scrapers/test_pypaperbot_scraper.py
+++ b/tests/tools/scrapers/test_pypaperbot_scraper.py
@@ -7,10 +7,7 @@ import pytest
 from pydantic import AnyUrl
 
 from akd.tools.scrapers._base import ScrapedMetadata, ScraperToolInputSchema
-from akd.tools.scrapers.pypaperbot_scraper import (
-    PyPaperBotScraper,
-    PyPaperBotScraperConfig,
-)
+from akd.tools.scrapers.pypaperbot import PyPaperBotScraper, PyPaperBotScraperConfig
 
 # Check if PyPaperBot is available (same check as in the scraper)
 _PYPAPERBOT_AVAILABLE: bool = importlib.util.find_spec("PyPaperBot") is not None


### PR DESCRIPTION
### Summary :memo:
This PR introduces a new scraper, `PyPaperBotScraper`, which leverages the `PyPaperBot` library to fetch full-text PDFs of academic papers from Anna's Archive. This scraper enhances our data collection capabilities by providing a reliable way to obtain PDFs using a DOI or a search query.

### Details
1. **Added `PyPaperBotScraper`**: A new scraper that uses `PyPaperBot` to download PDFs. It can handle both DOI links and free-form search queries.
2. **Configuration and Integration**: Added `PyPaperBotScraperConfig` for configuration and integrated the new scraper into the existing framework by updating `akd/tools/scrapers/__init__.py`.
3. **Dependencies**: Added `pypaperbot` and `undetected-chromedriver` to the project's dependencies in `pyproject.toml`.

### Minor changes
- Updated `pyproject.toml` with new `local` group dependency which is used for local sync (contains marimo and jupyter related dependencies`
- Updated the `README` with newer documentation and installation setup


## Usage
The `PyPaperBotScraper` can be used to fetch papers from URLs. Here is an example of how to use it with a DOI link:

```python
from akd.tools.scrapers import PyPaperBotScraper, OmniScraperInputSchema

# Initialize the scraper
scraper = PyPaperBotScraper(debug=True)

# Run the scraper with a DOI URL
result = await scraper.arun(
    OmniScraperInputSchema(url="https://doi.org/10.48550/arXiv.2411.08181")
)

# The result will contain the scraped content and metadata
print(result.model_dump())
```


### Checks
- [x] Tested Changes
- [x] Test cases
- [ ] Stakeholder Approval

---


# Notes
- When using link like `https://arxiv.org/abs/2411.08181` (which should actually be resolved to `https://doi.org/10.48550/arXiv.2411.08181` ), without any DOI, it will give reference to wrong PDF.
- Highly recommended to run this only after proper URL/DOI has been resolved