### PR TITLE
Add `strict` filter to searxng tool + New test suites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,14 @@ SEARCH_ENGINE=duckduckgo
 GOOGLE_API_KEY="<google api key>"
 GOOGLE_CSE_ID="<google search api key>"
 
+# SearxNG
 SEARXNG_BASE_URL="<SEARXNG base url>" #"http://localhost:8080"
+SEARXNG_MAX_PAGES=25
+SEARXNG_RESULTS_PER_PAGE=10
+SEARXNG_SCORE_CUTOFF=0.25
+SEARXNG_STRICT=False
+SEARXNG_DEBUG=False
+SEARXNG_ENGINES="google,arxiv,google_scholar"
 
 # for your vector store
 EMBEDDING_MODEL_ID="nasa-impact/nasa-smd-ibm-st-v2"

--- a/tests/tools/search/conftest.py
+++ b/tests/tools/search/conftest.py
@@ -1,0 +1,218 @@
+"""
+Fixtures and test data for SearxNG search tool tests.
+"""
+
+import os
+from typing import Any, Dict
+from unittest.mock import AsyncMock
+
+import pytest
+
+from akd.structures import SearchResultItem
+from akd.tools.search.searxng_search import (
+    SearxNGSearchTool,
+    SearxNGSearchToolConfig,
+    SearxNGSearchToolInputSchema,
+)
+
+
+@pytest.fixture
+def sample_searxng_config():
+    """Sample SearxNG configuration for testing."""
+    return SearxNGSearchToolConfig(
+        base_url=os.getenv("SEARXNG_BASE_URL", "http://localhost:8080"),
+        max_results=10,
+        engines=["google", "arxiv", "google_scholar"],
+        max_pages=5,
+        results_per_page=10,
+        score_cutoff=0.25,
+        strict=True,
+        debug=False,
+    )
+
+
+@pytest.fixture
+def sample_search_input():
+    """Sample search input schema."""
+    return SearxNGSearchToolInputSchema(
+        queries=["machine learning", "deep learning"],
+        category="science",
+        max_results=5,
+    )
+
+
+@pytest.fixture
+def mock_searxng_response() -> Dict[str, Any]:
+    """Mock SearxNG API response."""
+    return {
+        "results": [
+            {
+                "title": "Introduction to Machine Learning",
+                "content": "Machine learning is a subset of artificial intelligence...",
+                "url": "https://example.com/ml-intro",
+                "engine": "google",
+                "score": 0.95,
+                "publishedDate": "2023-01-15",
+                "doi": "10.1000/test123",
+                "category": "science",
+            },
+            {
+                "title": "Deep Learning Fundamentals",
+                "content": "Deep learning is a machine learning technique...",
+                "url": "https://example.com/dl-fundamentals",
+                "engine": "arxiv",
+                "score": 0.90,
+                "publishedDate": "2023-02-10",
+                "category": "science",
+            },
+            {
+                "title": "Neural Networks Explained",
+                "content": "Neural networks are computing systems inspired by...",
+                "url": "https://example.com/neural-networks",
+                "engine": "google_scholar",
+                "score": 0.85,
+                "publishedDate": "2023-03-05",
+            },
+            {
+                "title": "Low Score Article",
+                "content": "This article has a low relevance score...",
+                "url": "https://example.com/low-score",
+                "engine": "google",
+                "score": 0.15,  # Below default cutoff
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def mock_searxng_empty_response() -> dict[str, Any]:
+    """Mock empty SearxNG API response."""
+    return {"results": []}
+
+
+@pytest.fixture
+def mock_searxng_malformed_response() -> dict[str, Any]:
+    """Mock malformed SearxNG API response for error testing."""
+    return {
+        "results": [
+            {
+                "title": "Article with Missing Fields",
+                # Missing required fields like 'url', 'content'
+                "engine": "google",
+                "score": 0.8,
+            },
+            {
+                # Missing title
+                "content": "Content without title",
+                "url": "https://example.com/no-title",
+                "engine": "arxiv",
+                "score": 0.7,
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def sample_search_result_items() -> list[SearchResultItem]:
+    """Sample SearchResultItem objects for testing."""
+    return [
+        SearchResultItem(
+            url="https://example.com/ml-intro",
+            title="Introduction to Machine Learning",
+            content="Machine learning is a subset of artificial intelligence...",
+            query="machine learning",
+            category="science",
+            doi="10.1000/test123",
+            published_date="2023-01-15",
+            engine="google",
+        ),
+        SearchResultItem(
+            url="https://example.com/dl-fundamentals",
+            title="Deep Learning Fundamentals",
+            content="Deep learning is a machine learning technique...",
+            query="deep learning",
+            category="science",
+            published_date="2023-02-10",
+            engine="arxiv",
+        ),
+    ]
+
+
+@pytest.fixture
+def mock_searxng_tool(sample_searxng_config):
+    """Mock SearxNG tool instance."""
+    tool = SearxNGSearchTool(config=sample_searxng_config)
+    return tool
+
+
+@pytest.fixture
+def mock_aiohttp_session():
+    """Mock aiohttp ClientSession for testing."""
+    session = AsyncMock()
+
+    # Mock response object
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.reason = "OK"
+    mock_response.url = "http://localhost:8080/search"
+
+    # Context manager support
+    session.get.return_value.__aenter__ = AsyncMock(return_value=mock_response)
+    session.get.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    return session
+
+
+@pytest.fixture
+def mock_failed_aiohttp_session():
+    """Mock aiohttp ClientSession that returns HTTP errors."""
+    session = AsyncMock()
+
+    # Mock failed response
+    mock_response = AsyncMock()
+    mock_response.status = 500
+    mock_response.reason = "Internal Server Error"
+    mock_response.url = "http://localhost:8080/search"
+
+    session.get.return_value.__aenter__ = AsyncMock(return_value=mock_response)
+    session.get.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    return session
+
+
+@pytest.fixture
+def mock_network_error_session():
+    """Mock aiohttp ClientSession that raises network errors."""
+    session = AsyncMock()
+    session.get.side_effect = Exception("Network error")
+    return session
+
+
+@pytest.fixture
+def duplicate_results_response() -> Dict[str, Any]:
+    """Mock response with duplicate URLs for deduplication testing."""
+    return {
+        "results": [
+            {
+                "title": "Original Article",
+                "content": "This is the original article...",
+                "url": "https://example.com/article",
+                "engine": "google",
+                "score": 0.95,
+            },
+            {
+                "title": "Duplicate Article",
+                "content": "This is a duplicate of the same article...",
+                "url": "https://example.com/article",  # Same URL
+                "engine": "arxiv",
+                "score": 0.85,
+            },
+            {
+                "title": "Another Article",
+                "content": "This is a different article...",
+                "url": "https://example.com/different",
+                "engine": "google_scholar",
+                "score": 0.80,
+            },
+        ],
+    }

--- a/tests/tools/search/test_searxng_functional.py
+++ b/tests/tools/search/test_searxng_functional.py
@@ -1,0 +1,634 @@
+"""
+Functional/integration tests for SearxNG search tool.
+
+Tests the complete workflow including HTTP requests (mocked),
+pagination, and end-to-end search functionality.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from akd.structures import SearchResultItem
+from akd.tools.search.searxng_search import (
+    SearxNGSearchTool,
+    SearxNGSearchToolInputSchema,
+)
+
+
+class TestSearxNGFunctionalAPI:
+    """Test SearxNG tool with mocked HTTP responses."""
+
+    @pytest.mark.asyncio
+    async def test_successful_search_single_query(
+        self,
+        sample_searxng_config,
+        mock_searxng_response,
+    ):
+        """Test successful search with a single query."""
+        tool = SearxNGSearchTool(config=sample_searxng_config)
+
+        # Mock the entire _arun method to avoid HTTP calls
+        async def mock_arun(params, max_results=None, **kwargs):
+            # Simulate processing the mock response
+            filtered_results = [
+                result
+                for result in mock_searxng_response["results"]
+                if result.get("score", 0) >= tool.config.score_cutoff
+                and all(field in result for field in ["title", "content", "url"])
+            ]
+
+            results = [
+                SearchResultItem(
+                    url=result["url"],
+                    title=result["title"],
+                    content=result["content"],
+                    query=params.queries[0],
+                    category=params.category,
+                    doi=result.get("doi"),
+                    published_date=result.get("publishedDate"),
+                    engine=result.get("engine"),
+                )
+                for result in filtered_results[: max_results or params.max_results]
+            ]
+
+            return tool.output_schema(
+                results=results,
+                category=params.category,
+            )
+
+        with patch.object(tool, "_arun", mock_arun):
+            input_params = SearxNGSearchToolInputSchema(
+                queries=["machine learning"],
+                category="science",
+                max_results=5,
+            )
+
+            result = await tool._arun(input_params)
+
+            assert isinstance(result.results, list)
+            assert len(result.results) > 0
+            assert result.category == "science"
+
+            # Check that results have required fields
+            for item in result.results:
+                assert isinstance(item, SearchResultItem)
+                assert item.url is not None
+                assert item.title is not None
+                assert item.query is not None
+
+    @pytest.mark.asyncio
+    async def test_successful_search_multiple_queries(
+        self,
+        sample_searxng_config,
+        mock_searxng_response,
+    ):
+        """Test successful search with multiple queries."""
+        tool = SearxNGSearchTool(config=sample_searxng_config)
+
+        async def mock_arun(params, max_results=None, **kwargs):
+            all_results = []
+            for query in params.queries:
+                filtered_results = [
+                    result
+                    for result in mock_searxng_response["results"]
+                    if result.get("score", 0) >= tool.config.score_cutoff
+                    and all(field in result for field in ["title", "content", "url"])
+                ]
+
+                for result in filtered_results:
+                    all_results.append(
+                        SearchResultItem(
+                            url=result["url"],
+                            title=result["title"],
+                            content=result["content"],
+                            query=query,
+                            category=params.category,
+                            doi=result.get("doi"),
+                            published_date=result.get("publishedDate"),
+                            engine=result.get("engine"),
+                        ),
+                    )
+
+            return tool.output_schema(
+                results=all_results[: max_results or params.max_results],
+                category=params.category,
+            )
+
+        with patch.object(tool, "_arun", mock_arun):
+            input_params = SearxNGSearchToolInputSchema(
+                queries=["machine learning", "deep learning", "neural networks"],
+                category="science",
+                max_results=10,
+            )
+
+            result = await tool._arun(input_params)
+
+            assert isinstance(result.results, list)
+            assert result.category == "science"
+
+            # Should have results from multiple queries
+            queries_found = {item.query for item in result.results}
+            assert len(queries_found) > 0
+
+    @pytest.mark.asyncio
+    async def test_empty_search_results(
+        self,
+        sample_searxng_config,
+        mock_searxng_empty_response,
+    ):
+        """Test handling of empty search results."""
+        tool = SearxNGSearchTool(config=sample_searxng_config)
+
+        async def mock_arun(params, max_results=None, **kwargs):
+            return tool.output_schema(
+                results=[],
+                category=params.category,
+            )
+
+        with patch.object(tool, "_arun", mock_arun):
+            input_params = SearxNGSearchToolInputSchema(
+                queries=["very specific nonexistent query"],
+                max_results=10,
+            )
+
+            result = await tool._arun(input_params)
+
+            assert isinstance(result.results, list)
+            assert len(result.results) == 0
+
+    @pytest.mark.asyncio
+    async def test_http_error_handling(self, sample_searxng_config):
+        """Test handling of HTTP errors."""
+        tool = SearxNGSearchTool(config=sample_searxng_config)
+
+        # Mock the _fetch_search_results_paginated method to raise an exception
+        async def mock_fetch_search_results_paginated(
+            session,
+            query,
+            category,
+            target_results,
+        ):
+            raise Exception(
+                "Failed to fetch search results for query 'test query': 500 Internal Server Error",
+            )
+
+        with patch.object(
+            tool,
+            "_fetch_search_results_paginated",
+            mock_fetch_search_results_paginated,
+        ):
+            input_params = SearxNGSearchToolInputSchema(
+                queries=["test query"],
+                max_results=5,
+            )
+
+            with pytest.raises(Exception, match="Failed to fetch search results"):
+                await tool._arun(input_params)
+
+    @pytest.mark.asyncio
+    async def test_network_timeout_handling(self, sample_searxng_config):
+        """Test handling of network timeouts."""
+        tool = SearxNGSearchTool(config=sample_searxng_config)
+
+        # Mock the _fetch_search_results_paginated method to raise a timeout
+        async def mock_fetch_search_results_paginated(
+            session,
+            query,
+            category,
+            target_results,
+        ):
+            raise asyncio.TimeoutError("Request timeout")
+
+        with patch.object(
+            tool,
+            "_fetch_search_results_paginated",
+            mock_fetch_search_results_paginated,
+        ):
+            input_params = SearxNGSearchToolInputSchema(
+                queries=["test query"],
+                max_results=5,
+            )
+
+            with pytest.raises(Exception):
+                await tool._arun(input_params)
+
+
+class TestSearxNGPagination:
+    """Test pagination functionality."""
+
+    @pytest.mark.asyncio
+    async def test_pagination_multiple_pages(self, sample_searxng_config):
+        """Test fetching results across multiple pages."""
+        config = sample_searxng_config
+        config.max_pages = 3
+        config.results_per_page = 2
+        tool = SearxNGSearchTool(config=config)
+
+        # Combined results that would come from multiple pages
+        all_results = [
+            {
+                "title": "Result 1",
+                "content": "Content 1",
+                "url": "http://test1.com",
+                "score": 0.9,
+                "engine": "google",
+            },
+            {
+                "title": "Result 2",
+                "content": "Content 2",
+                "url": "http://test2.com",
+                "score": 0.8,
+                "engine": "arxiv",
+            },
+            {
+                "title": "Result 3",
+                "content": "Content 3",
+                "url": "http://test3.com",
+                "score": 0.7,
+                "engine": "google_scholar",
+            },
+            {
+                "title": "Result 4",
+                "content": "Content 4",
+                "url": "http://test4.com",
+                "score": 0.6,
+                "engine": "google",
+            },
+        ]
+
+        # Mock the paginated fetch method
+        async def mock_fetch_search_results_paginated(
+            session,
+            query,
+            category,
+            target_results,
+        ):
+            # Add query to results and return them
+            results = []
+            for result in all_results[:target_results]:
+                result_copy = result.copy()
+                result_copy["query"] = query
+                results.append(result_copy)
+            return results
+
+        with patch.object(
+            tool,
+            "_fetch_search_results_paginated",
+            mock_fetch_search_results_paginated,
+        ):
+            input_params = SearxNGSearchToolInputSchema(
+                queries=["test query"],
+                max_results=4,  # Should trigger pagination
+            )
+
+            result = await tool._arun(input_params)
+
+            assert len(result.results) <= 4
+            assert len(result.results) > 2  # Should have results from multiple pages
+
+    @pytest.mark.asyncio
+    async def test_pagination_with_session_mock(self, sample_searxng_config):
+        """Test pagination using fetch_search_results_paginated method."""
+        tool = SearxNGSearchTool(config=sample_searxng_config)
+
+        # Mock aiohttp session
+        session = AsyncMock()
+
+        # Create mock results that would come from pagination
+        all_results = [
+            {
+                "title": "Result 1",
+                "content": "Content 1",
+                "url": "http://test1.com",
+                "score": 0.9,
+                "engine": "google",
+            },
+            {
+                "title": "Result 2",
+                "content": "Content 2",
+                "url": "http://test2.com",
+                "score": 0.8,
+                "engine": "arxiv",
+            },
+        ]
+
+        # Test the _fetch_search_results_paginated method directly
+        async def mock_fetch_search_results(session, query, category, page_num):
+            # Return results for first page only
+            if page_num == 1:
+                results = all_results.copy()
+                for result in results:
+                    result["query"] = query
+                return results
+            return []
+
+        with patch.object(tool, "_fetch_search_results", mock_fetch_search_results):
+            results = await tool._fetch_search_results_paginated(
+                session=session,
+                query="test query",
+                category="science",
+                target_results=4,
+            )
+
+            assert len(results) >= 2  # Should have gotten results from pagination
+
+
+class TestSearxNGQueryParameters:
+    """Test query parameter handling."""
+
+    @pytest.mark.asyncio
+    async def test_query_parameters_basic(self, sample_searxng_config):
+        """Test that correct query parameters are sent."""
+        tool = SearxNGSearchTool(config=sample_searxng_config)
+
+        # Mock the HTTP session to capture request parameters
+        captured_params = {}
+
+        async def mock_fetch_search_results(session, query, category=None, page_num=1):
+            # Capture the parameters that would be sent
+            captured_params.update(
+                {
+                    "query": query,
+                    "category": category,
+                    "page_num": page_num,
+                },
+            )
+            return []
+
+        with patch.object(tool, "_fetch_search_results", mock_fetch_search_results):
+            input_params = SearxNGSearchToolInputSchema(
+                queries=["test query"],
+                category="science",
+                max_results=5,
+            )
+
+            await tool._arun(input_params)
+
+            # Verify the parameters were passed correctly
+            assert captured_params["query"] == "test query"
+            assert captured_params["category"] == "science"
+
+    @pytest.mark.asyncio
+    async def test_query_parameters_with_category(self, sample_searxng_config):
+        """Test query parameters with different categories."""
+        tool = SearxNGSearchTool(config=sample_searxng_config)
+
+        captured_params = {}
+
+        async def mock_fetch_search_results(session, query, category=None, page_num=1):
+            captured_params.update(
+                {
+                    "category": category,
+                },
+            )
+            return []
+
+        with patch.object(tool, "_fetch_search_results", mock_fetch_search_results):
+            input_params = SearxNGSearchToolInputSchema(
+                queries=["technology query"],
+                category="technology",
+                max_results=5,
+            )
+
+            await tool._arun(input_params)
+
+            # Verify category parameter
+            assert captured_params["category"] == "technology"
+
+    @pytest.mark.asyncio
+    async def test_query_parameters_no_category(self, sample_searxng_config):
+        """Test query parameters without category."""
+        tool = SearxNGSearchTool(config=sample_searxng_config)
+
+        captured_params = {}
+
+        async def mock_fetch_search_results(session, query, category=None, page_num=1):
+            captured_params.update(
+                {
+                    "category": category,
+                },
+            )
+            return []
+
+        with patch.object(tool, "_fetch_search_results", mock_fetch_search_results):
+            input_params = SearxNGSearchToolInputSchema(
+                queries=["general query"],
+                category=None,  # No category
+                max_results=5,
+            )
+
+            await tool._arun(input_params)
+
+            # Verify no categories parameter when None
+            assert captured_params.get("category") is None
+
+
+class TestSearxNGResultProcessing:
+    """Test end-to-end result processing."""
+
+    @pytest.mark.asyncio
+    async def test_result_deduplication_across_queries(
+        self,
+        sample_searxng_config,
+        duplicate_results_response,
+    ):
+        """Test deduplication of results across multiple queries."""
+        tool = SearxNGSearchTool(config=sample_searxng_config)
+
+        # Mock to return duplicate results for different queries
+        async def mock_fetch_search_results(session, query, category=None, page_num=1):
+            results = duplicate_results_response["results"].copy()
+            for result in results:
+                result["query"] = query
+            return results
+
+        with patch.object(tool, "_fetch_search_results", mock_fetch_search_results):
+            input_params = SearxNGSearchToolInputSchema(
+                queries=[
+                    "query1",
+                    "query2",
+                ],  # Different queries might return same URLs
+                max_results=10,
+            )
+
+            result = await tool._arun(input_params)
+
+            # Check that URLs are unique
+            urls = [item.url for item in result.results]
+            assert len(urls) == len(set(urls)), (
+                "URLs should be unique after deduplication"
+            )
+
+    @pytest.mark.asyncio
+    async def test_score_cutoff_filtering(self, sample_searxng_config):
+        """Test that results below score cutoff are filtered out."""
+        tool = SearxNGSearchTool(config=sample_searxng_config)
+
+        # Response with mixed scores
+        mixed_score_results = [
+            {
+                "title": "High Score",
+                "content": "Content",
+                "url": "http://high.com",
+                "score": 0.9,
+                "engine": "google",
+            },
+            {
+                "title": "Above Cutoff",
+                "content": "Content",
+                "url": "http://above.com",
+                "score": 0.3,
+                "engine": "arxiv",
+            },
+            {
+                "title": "Below Cutoff",
+                "content": "Content",
+                "url": "http://below.com",
+                "score": 0.1,
+                "engine": "google_scholar",
+            },  # Below 0.25
+        ]
+
+        async def mock_fetch_search_results_paginated(
+            session,
+            query,
+            category,
+            target_results,
+        ):
+            results = mixed_score_results.copy()
+            for result in results:
+                result["query"] = query
+            return results
+
+        with patch.object(
+            tool,
+            "_fetch_search_results_paginated",
+            mock_fetch_search_results_paginated,
+        ):
+            input_params = SearxNGSearchToolInputSchema(
+                queries=["test query"],
+                max_results=10,
+            )
+
+            result = await tool._arun(input_params)
+
+            # Should only have results above score cutoff (0.25)
+            assert len(result.results) == 2
+            assert all("below" not in str(item.url).lower() for item in result.results)
+
+    @pytest.mark.asyncio
+    async def test_max_results_limiting(self, sample_searxng_config):
+        """Test that results are limited by max_results parameter."""
+        tool = SearxNGSearchTool(config=sample_searxng_config)
+
+        # Response with many results
+        many_results = [
+            {
+                "title": f"Result {i}",
+                "content": f"Content {i}",
+                "url": f"http://test{i}.com",
+                "score": 0.9 - i * 0.05,
+            }
+            for i in range(20)  # 20 results
+        ]
+
+        async def mock_fetch_search_results(session, query, category=None, page_num=1):
+            results = many_results.copy()
+            for result in results:
+                result["query"] = query
+            return results
+
+        with patch.object(tool, "_fetch_search_results", mock_fetch_search_results):
+            input_params = SearxNGSearchToolInputSchema(
+                queries=["test query"],
+                max_results=5,  # Limit to 5 results
+            )
+
+            result = await tool._arun(input_params)
+
+            # Should be limited to max_results
+            assert len(result.results) <= 5
+
+
+class TestSearxNGErrorRecovery:
+    """Test error recovery and resilience."""
+
+    @pytest.mark.asyncio
+    async def test_partial_failure_pagination(self, sample_searxng_config):
+        """Test handling of partial failures during pagination."""
+        tool = SearxNGSearchTool(config=sample_searxng_config)
+
+        # Mock session where some pages fail
+        session = AsyncMock()
+
+        # Mock successful first page
+        first_page_results = [
+            {
+                "title": "Result 1",
+                "content": "Content 1",
+                "url": "http://test1.com",
+                "score": 0.9,
+                "engine": "google",
+            },
+        ]
+
+        call_count = 0
+
+        async def mock_fetch_search_results(session, query, category, page_num):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                results = first_page_results.copy()
+                for result in results:
+                    result["query"] = query
+                return results
+            else:
+                # Simulate failure on subsequent pages
+                raise Exception("Network error on page 2")
+
+        with patch.object(tool, "_fetch_search_results", mock_fetch_search_results):
+            results = await tool._fetch_search_results_paginated(
+                session=session,
+                query="test query",
+                category="science",
+                target_results=10,  # Would require multiple pages
+            )
+
+            # Should still return results from successful page
+            assert len(results) >= 1
+            assert results[0]["title"] == "Result 1"
+
+    @pytest.mark.asyncio
+    async def test_malformed_response_handling(
+        self,
+        sample_searxng_config,
+        mock_searxng_malformed_response,
+    ):
+        """Test handling of malformed API responses."""
+        tool = SearxNGSearchTool(config=sample_searxng_config)
+
+        # Mock to return malformed results
+        async def mock_fetch_search_results(session, query, category=None, page_num=1):
+            results = mock_searxng_malformed_response["results"].copy()
+            for result in results:
+                result["query"] = query
+            return results
+
+        with patch.object(tool, "_fetch_search_results", mock_fetch_search_results):
+            input_params = SearxNGSearchToolInputSchema(
+                queries=["test query"],
+                max_results=10,
+            )
+
+            result = await tool._arun(input_params)
+
+            # Should handle malformed results gracefully
+            # (results with missing required fields should be filtered out)
+            assert isinstance(result.results, list)
+            # All returned results should have required fields
+            for item in result.results:
+                assert item.title is not None
+                assert item.url is not None
+                assert item.content is not None

--- a/tests/tools/search/test_searxng_unit.py
+++ b/tests/tools/search/test_searxng_unit.py
@@ -1,0 +1,415 @@
+"""
+Unit tests for SearxNG search tool.
+
+Tests individual components and methods of the SearxNGSearchTool
+without making actual HTTP requests.
+"""
+
+import pytest
+
+from akd.structures import SearchResultItem
+from akd.tools.search.searxng_search import (
+    SearxNGSearchTool,
+    SearxNGSearchToolConfig,
+    SearxNGSearchToolInputSchema,
+    SearxNGSearchToolOutputSchema,
+)
+
+
+class TestSearxNGSearchToolConfig:
+    """Test SearxNG tool configuration."""
+
+    def test_config_defaults(self):
+        """Test default configuration values."""
+        config = SearxNGSearchToolConfig()
+
+        assert config.max_results == 10
+        assert config.max_pages == 25
+        assert config.results_per_page == 10
+        assert config.score_cutoff == 0.25
+        assert config.strict is False
+        assert config.debug is False
+        assert config.engines == ["google", "arxiv", "google_scholar"]
+
+    def test_config_with_custom_values(self):
+        """Test configuration with custom values."""
+        config = SearxNGSearchToolConfig(
+            base_url="http://custom.searxng.com",
+            max_results=20,
+            engines=["duckduckgo", "bing"],
+            max_pages=10,
+            results_per_page=5,
+            score_cutoff=0.5,
+            strict=True,
+            debug=True,
+        )
+
+        # HttpUrl automatically adds trailing slash
+        assert str(config.base_url) == "http://custom.searxng.com/"
+        assert config.max_results == 20
+        assert config.engines == ["duckduckgo", "bing"]
+        assert config.max_pages == 10
+        assert config.results_per_page == 5
+        assert config.score_cutoff == 0.5
+        assert config.strict is True
+        assert config.debug is True
+
+    def test_config_validation(self):
+        """Test configuration validation."""
+        # Test max_pages validation
+        with pytest.raises(ValueError):
+            SearxNGSearchToolConfig(max_pages=0)
+
+        with pytest.raises(ValueError):
+            SearxNGSearchToolConfig(max_pages=101)
+
+        # Test results_per_page validation
+        with pytest.raises(ValueError):
+            SearxNGSearchToolConfig(results_per_page=0)
+
+        with pytest.raises(ValueError):
+            SearxNGSearchToolConfig(results_per_page=101)
+
+        # Test score_cutoff validation
+        with pytest.raises(ValueError):
+            SearxNGSearchToolConfig(score_cutoff=-0.1)
+
+        with pytest.raises(ValueError):
+            SearxNGSearchToolConfig(score_cutoff=1.1)
+
+    def test_config_from_environment(self):
+        """Test configuration loading from environment variables."""
+        # Test manual instantiation with values (since env vars are resolved at import)
+        config = SearxNGSearchToolConfig(
+            base_url="http://env.searxng.com",
+            max_results=15,
+            engines=["duckduckgo", "startpage"],
+            max_pages=30,
+            results_per_page=8,
+            score_cutoff=0.3,
+        )
+
+        # HttpUrl automatically adds trailing slash
+        assert str(config.base_url) == "http://env.searxng.com/"
+        assert config.max_results == 15
+        assert config.engines == ["duckduckgo", "startpage"]
+        assert config.max_pages == 30
+        assert config.results_per_page == 8
+        assert config.score_cutoff == 0.3
+
+
+class TestSearxNGSearchToolSchemas:
+    """Test SearxNG tool input/output schemas."""
+
+    def test_input_schema_validation(self):
+        """Test input schema validation."""
+        # Valid input
+        valid_input = SearxNGSearchToolInputSchema(
+            queries=["test query"],
+            category="science",
+            max_results=5,
+        )
+        assert valid_input.queries == ["test query"]
+        assert valid_input.category == "science"
+        assert valid_input.max_results == 5
+
+    def test_input_schema_defaults(self):
+        """Test input schema default values."""
+        input_schema = SearxNGSearchToolInputSchema(queries=["test"])
+
+        assert input_schema.category == "science"
+        assert input_schema.max_results == 10
+
+    def test_output_schema_validation(self, sample_search_result_items):
+        """Test output schema validation."""
+        output = SearxNGSearchToolOutputSchema(
+            results=sample_search_result_items,
+            category="science",
+        )
+
+        assert len(output.results) == 2
+        assert output.category == "science"
+        assert all(isinstance(item, SearchResultItem) for item in output.results)
+
+
+class TestSearxNGSearchTool:
+    """Test SearxNG search tool initialization and utility methods."""
+
+    def test_tool_initialization_default(self):
+        """Test tool initialization with default config."""
+        tool = SearxNGSearchTool()
+
+        assert tool.config.max_results == 10
+        assert tool.config.base_url == "http://localhost:8080"
+        assert tool.config.engines == ["google", "arxiv", "google_scholar"]
+
+    def test_tool_initialization_custom_config(self, sample_searxng_config):
+        """Test tool initialization with custom config."""
+        tool = SearxNGSearchTool(config=sample_searxng_config)
+
+        assert tool.config.max_results == 10
+        assert tool.config.strict is True
+        assert tool.config.engines == ["google", "arxiv", "google_scholar"]
+
+    def test_from_params_class_method(self):
+        """Test tool creation using from_params class method."""
+        tool = SearxNGSearchTool.from_params(
+            base_url="http://test.searxng.com",
+            max_results=20,
+            engines=["duckduckgo"],
+            strict=False,
+            debug=True,
+        )
+
+        # HttpUrl automatically adds trailing slash
+        assert str(tool.config.base_url) == "http://test.searxng.com/"
+        assert tool.config.max_results == 20
+        assert tool.config.engines == ["duckduckgo"]
+        assert tool.config.strict is False
+        assert tool.config.debug is True
+
+    def test_normalize_engine_name(self):
+        """Test engine name normalization."""
+        assert (
+            SearxNGSearchTool.normalize_engine_name("Google Scholar")
+            == "google_scholar"
+        )
+        assert SearxNGSearchTool.normalize_engine_name("DuckDuckGo") == "duckduckgo"
+        assert SearxNGSearchTool.normalize_engine_name("google") == "google"
+        assert SearxNGSearchTool.normalize_engine_name("ARXIV") == "arxiv"
+
+    def test_engine_names_match(self):
+        """Test engine name matching."""
+        assert SearxNGSearchTool.engine_names_match("google", "Google")
+        assert SearxNGSearchTool.engine_names_match("Google Scholar", "google_scholar")
+        assert SearxNGSearchTool.engine_names_match("duckduckgo", "DuckDuckGo")
+        assert not SearxNGSearchTool.engine_names_match("google", "bing")
+
+
+class TestResultProcessing:
+    """Test result processing methods."""
+
+    @pytest.mark.asyncio
+    async def test_process_results_score_filtering(self, mock_searxng_tool):
+        """Test that results are filtered by score cutoff."""
+        # Mock results with different scores and engines that match the config
+        mock_results = [
+            {
+                "title": "High Score",
+                "content": "test",
+                "url": "http://test1.com",
+                "score": 0.9,
+                "engine": "google",
+            },
+            {
+                "title": "Medium Score",
+                "content": "test",
+                "url": "http://test2.com",
+                "score": 0.3,
+                "engine": "arxiv",
+            },
+            {
+                "title": "Low Score",
+                "content": "test",
+                "url": "http://test3.com",
+                "score": 0.1,
+                "engine": "google",
+            },  # Below cutoff
+        ]
+
+        processed = await mock_searxng_tool._process_results(mock_results)
+
+        # Should filter out low score result (0.1 < 0.25 cutoff)
+        assert len(processed) == 2
+        assert all(
+            result.get("score", 0) >= mock_searxng_tool.config.score_cutoff
+            for result in processed
+        )
+
+    @pytest.mark.asyncio
+    async def test_process_results_strict_engine_filtering(self):
+        """Test strict engine filtering."""
+        config = SearxNGSearchToolConfig(
+            engines=["google", "arxiv"],
+            strict=True,
+        )
+        tool = SearxNGSearchTool(config=config)
+
+        mock_results = [
+            {
+                "title": "Google Result",
+                "content": "test",
+                "url": "http://test1.com",
+                "score": 0.9,
+                "engine": "google",
+            },
+            {
+                "title": "ArXiv Result",
+                "content": "test",
+                "url": "http://test2.com",
+                "score": 0.8,
+                "engine": "arxiv",
+            },
+            {
+                "title": "Bing Result",
+                "content": "test",
+                "url": "http://test3.com",
+                "score": 0.7,
+                "engine": "bing",
+            },  # Should be filtered
+        ]
+
+        processed = await tool._process_results(mock_results)
+
+        # Should filter out bing result
+        assert len(processed) == 2
+        assert all(result.get("engine") in ["google", "arxiv"] for result in processed)
+
+    @pytest.mark.asyncio
+    async def test_process_results_deduplication(self, mock_searxng_tool):
+        """Test URL deduplication."""
+        mock_results = [
+            {
+                "title": "First",
+                "content": "test",
+                "url": "http://duplicate.com",
+                "score": 0.9,
+                "engine": "google",
+            },
+            {
+                "title": "Second",
+                "content": "test",
+                "url": "http://unique.com",
+                "score": 0.8,
+                "engine": "arxiv",
+            },
+            {
+                "title": "Third",
+                "content": "test",
+                "url": "http://duplicate.com",
+                "score": 0.7,
+                "engine": "google_scholar",
+            },  # Duplicate URL
+        ]
+
+        processed = await mock_searxng_tool._process_results(mock_results)
+
+        # Should remove duplicate URL, keeping the higher scored one
+        assert len(processed) == 2
+        urls = [result["url"] for result in processed]
+        assert "http://duplicate.com" in urls
+        assert "http://unique.com" in urls
+        assert urls.count("http://duplicate.com") == 1
+
+    @pytest.mark.asyncio
+    async def test_process_results_sorting_by_score(self, mock_searxng_tool):
+        """Test results are sorted by score in descending order."""
+        mock_results = [
+            {
+                "title": "Medium",
+                "content": "test",
+                "url": "http://test1.com",
+                "score": 0.5,
+                "engine": "google",
+            },
+            {
+                "title": "High",
+                "content": "test",
+                "url": "http://test2.com",
+                "score": 0.9,
+                "engine": "arxiv",
+            },
+            {
+                "title": "Low",
+                "content": "test",
+                "url": "http://test3.com",
+                "score": 0.3,
+                "engine": "google_scholar",
+            },
+        ]
+
+        processed = await mock_searxng_tool._process_results(mock_results)
+
+        # Should be sorted by score descending
+        scores = [result.get("score", 0) for result in processed]
+        assert scores == sorted(scores, reverse=True)
+        assert processed[0]["title"] == "High"
+        assert processed[-1]["title"] == "Low"
+
+    @pytest.mark.asyncio
+    async def test_process_results_missing_required_fields(self, mock_searxng_tool):
+        """Test filtering of results with missing required fields."""
+        mock_results = [
+            {
+                "title": "Valid",
+                "content": "test",
+                "url": "http://test1.com",
+                "score": 0.9,
+                "engine": "google",
+            },
+            {
+                "content": "test",
+                "url": "http://test2.com",
+                "score": 0.8,
+                "engine": "arxiv",
+            },  # Missing title
+            {
+                "title": "No Content",
+                "url": "http://test3.com",
+                "score": 0.7,
+                "engine": "google",
+            },  # Missing content
+            {
+                "title": "No URL",
+                "content": "test",
+                "score": 0.6,
+                "engine": "arxiv",
+            },  # Missing URL
+        ]
+
+        processed = await mock_searxng_tool._process_results(mock_results)
+
+        # Should only include results with all required fields
+        assert len(processed) == 1
+        assert processed[0]["title"] == "Valid"
+
+    @pytest.mark.asyncio
+    async def test_process_results_doi_handling(self, mock_searxng_tool):
+        """Test DOI field processing."""
+        mock_results = [
+            {
+                "title": "Paper with DOI list",
+                "content": "test",
+                "url": "http://test1.com",
+                "score": 0.9,
+                "engine": "google",
+                "doi": ["10.1000/test123", "10.1000/alt456"],  # DOI as list
+            },
+            {
+                "title": "Paper with DOI string",
+                "content": "test",
+                "url": "http://test2.com",
+                "score": 0.8,
+                "engine": "arxiv",
+                "doi": "10.1000/single789",  # DOI as string
+            },
+            {
+                "title": "Paper with numeric DOI",
+                "content": "test",
+                "url": "http://test3.com",
+                "score": 0.7,
+                "engine": "google_scholar",
+                "doi": 123456789,  # DOI as number
+            },
+        ]
+
+        processed = await mock_searxng_tool._process_results(mock_results)
+
+        assert len(processed) == 3
+        # Results are sorted by score, so order is: 0.9, 0.8, 0.7
+        # Should take first DOI from list
+        assert processed[0]["doi"] == "10.1000/test123"
+        # Should keep string DOI as-is
+        assert processed[1]["doi"] == "10.1000/single789"
+        # Should convert numeric DOI to string
+        assert processed[2]["doi"] == "123456789"


### PR DESCRIPTION
### Summary :memo:
This pull request enhances the `SearxNGSearchTool` by introducing a "strict" search mode for engine filtering and adds a comprehensive test suite to ensure its reliability and correctness.

### Details
_Describe more what you did on changes._
1. **Strict Engine Filtering**:
    - Added a `strict` boolean flag to `SearxNGSearchToolConfig`. When `True`, search results are filtered to only include those from engines specified in the `engines` configuration.
    - Implemented helper methods (`normalize_engine_name`, `engine_names_match`) to standardize and compare engine names, accommodating variations like "Google" vs. "google".
2. **Comprehensive Test Suite**:
    - Created extensive unit tests (`test_searxng_unit.py`) for the tool's configuration, Pydantic schemas, and result processing logic.
    - Added functional tests (`test_searxng_functional.py`) to validate the tool's behavior against mock API responses.
    - Implemented a full set of `pytest` fixtures (`conftest.py`) to provide mock data, configurations, and simulated network conditions.


### Checks
- [x] Tested Changes
- [ ] Stakeholder Approval
---