### PR TITLE
Add more request header keys and values in the config

### DIFF
--- a/akd/tools/scrapers/_base.py
+++ b/akd/tools/scrapers/_base.py
@@ -104,6 +104,10 @@ class WebScraperToolConfig(ScraperToolConfig):
         default="en-US,en;q=0.5",
         description="Accept-Language header for HTTP requests.",
     )
+    follow_redirects: bool = Field(
+        default=True,
+        description="Whether to follow HTTP redirects.",
+    )
 
     @computed_field
     def headers(self) -> dict[str, str]:
@@ -115,7 +119,9 @@ class WebScraperToolConfig(ScraperToolConfig):
             "User-Agent": self.user_agent,
             "Accept": self.accept_header,
             "Accept-Language": self.accept_language,
+            "Accept-Encoding": "gzip, deflate",
             "Connection": "keep-alive",
+            "Upgrade-Insecure-Requests": "1",
         }
 
 
@@ -397,7 +403,10 @@ class PDFScraper(ScraperToolBase):
         temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".pdf")
         headers = self.headers
         try:
-            async with httpx.AsyncClient(timeout=self.timeout) as client:
+            async with httpx.AsyncClient(
+                timeout=self.timeout,
+                follow_redirects=self.follow_redirects,
+            ) as client:
                 async with client.stream("GET", url, headers=headers) as response:
                     response.raise_for_status()
 

--- a/akd/tools/scrapers/_base.py
+++ b/akd/tools/scrapers/_base.py
@@ -104,6 +104,10 @@ class WebScraperToolConfig(ScraperToolConfig):
         default="en-US,en;q=0.5",
         description="Accept-Language header for HTTP requests.",
     )
+    accept_encoding: str = Field(
+        default="gzip, deflate",
+        description="Accept-Encoding header for HTTP requests.",
+    )
     follow_redirects: bool = Field(
         default=True,
         description="Whether to follow HTTP redirects.",
@@ -119,7 +123,7 @@ class WebScraperToolConfig(ScraperToolConfig):
             "User-Agent": self.user_agent,
             "Accept": self.accept_header,
             "Accept-Language": self.accept_language,
-            "Accept-Encoding": "gzip, deflate",
+            "Accept-Encoding": self.accept_encoding,
             "Connection": "keep-alive",
             "Upgrade-Insecure-Requests": "1",
         }


### PR DESCRIPTION
### Summary 📝

This pull request enhances the scraper's configuration by adding a `follow_redirects` option and expanding the default HTTP request headers. These changes increase the scraper's flexibility and help it more closely mimic a standard web browser, improving its reliability and reducing the likelihood of being blocked.

### Details

The following changes have been implemented:

* **Added `follow_redirects` Flag:** A new boolean configuration option, `follow_redirects`, has been introduced. When enabled, the scraper will automatically handle and follow HTTP redirects (e.g., 301, 302), which is crucial for navigating modern websites.
* **Expanded Default Headers:** The set of default request headers has been updated to include:
    * `Upgrade-Insecure-Requests: '1'`: This common header signals to the server that the client prefers to be upgraded to a secure (HTTPS) connection.
    * Other standard browser headers have also been added to make the scraper's requests appear more authentic.

These additions give us more granular control over the scraper's behavior and improve its overall effectiveness.

### Checks

- [ ] Stakeholder Approval