### PR TITLE
Bugfix: Code Search Result Titles  

### DIFF
--- a/akd/tools/code_search.py
+++ b/akd/tools/code_search.py
@@ -167,7 +167,7 @@ class CombinedCodeSearchToolConfig(CodeSearchToolConfig):
     """
 
     reranker_model_name: str = Field(
-        "cross-encoder/ms-marco-MiniLM-L6-v2",
+        "cross-encoder/ms-marco-MiniLM-L12-v2",
         description="The model to use for reranking the combined results.",
     )
 
@@ -249,17 +249,18 @@ class LocalRepoCodeSearchToolConfig(CodeSearchToolConfig):
     """
 
     data_file: str = str(
-        get_akd_root() / "docs" / "repositories_with_embeddings_v3.csv"
+        get_akd_root() / "docs" / "repositories_with_embeddings_v4.csv"
     )
     google_drive_file_id: str = os.getenv(
         "CODE_SEARCH_FILE_ID",
-        "1QtTKnlQmSFshCvw3cXAHXgMQQ-DMuGq0",
+        "1-3eD0kJFKgsgKhREA4dOW_V2gYfosK9R",
     )
     embedder_type: Literal["sentence-transformers", "openai"] = "sentence-transformers"
     wait_time: int = 1
-    embedding_model_name: str = os.getenv("CODE_SEARCH_MODEL", "all-MiniLM-L6-v2")
+    embedding_model_name: str = os.getenv("CODE_SEARCH_MODEL", "thenlper/gte-large")
     remove_embedding_column: bool = True
     text_column: str = "text"
+    name_column: str = "name"
     desc_column: str = "description"
     embeddings_column: str = "embeddings"
     debug: bool = False
@@ -390,7 +391,9 @@ class LocalRepoCodeSearchTool(CodeSearchTool):
         # Get texts to embed
         texts = (
             (
-                self.repo_data[self.config.desc_column].fillna("")
+                self.repo_data[self.config.name_column].fillna("")
+                + " "
+                + self.repo_data[self.config.desc_column].fillna("")
                 + " "
                 + self.repo_data[self.config.text_column].fillna("")
             )
@@ -512,7 +515,7 @@ class LocalRepoCodeSearchTool(CodeSearchTool):
 
         formatted_results = [
             SearchResultItem(
-                title=f"GitHub Repository for {query}",
+                title=f"GitHub Repository: {result.pop('name', '')}",
                 url=HttpUrlAdapter.validate_python(result.pop("URL", "")),
                 content=result.pop("text", ""),
                 query=query,
@@ -742,7 +745,7 @@ class SDECodeSearchTool(CodeSearchTool):
 
         formatted_results = [
             SearchResultItem(
-                title=f"SDE Code Search for {query}",
+                title=f"SDE Code Search Result",
                 url=HttpUrlAdapter.validate_python(result.pop("url", "")),
                 content=result.pop("full_text", ""),
                 query=query,

--- a/akd/tools/code_search.py
+++ b/akd/tools/code_search.py
@@ -249,7 +249,9 @@ class LocalRepoCodeSearchToolConfig(CodeSearchToolConfig):
     """
 
     data_file: str = str(
-        get_akd_root() / "docs" / "repositories_with_embeddings_v4.csv"
+        get_akd_root()
+        / "docs"
+        / os.getenv("REPO_EMBEDDINGS_FILE", "repositories_with_embeddings_v4.csv")
     )
     google_drive_file_id: str = os.getenv(
         "CODE_SEARCH_FILE_ID",
@@ -515,7 +517,7 @@ class LocalRepoCodeSearchTool(CodeSearchTool):
 
         formatted_results = [
             SearchResultItem(
-                title=f"GitHub Repository: {result.pop('name', '')}",
+                title=str(result.pop("name", "")),
                 url=HttpUrlAdapter.validate_python(result.pop("URL", "")),
                 content=result.pop("text", ""),
                 query=query,
@@ -745,7 +747,7 @@ class SDECodeSearchTool(CodeSearchTool):
 
         formatted_results = [
             SearchResultItem(
-                title=f"SDE Code Search Result",
+                title=str(result.get("url", "")).split("/")[-1],
                 url=HttpUrlAdapter.validate_python(result.pop("url", "")),
                 content=result.pop("full_text", ""),
                 query=query,

--- a/tests/code_search_tool_test.py
+++ b/tests/code_search_tool_test.py
@@ -57,6 +57,11 @@ def sde_tool():
     config = SDECodeSearchToolConfig(debug=True)
     return SDECodeSearchTool(config=config)
 
+@pytest.fixture
+def embedder():
+    model = os.getenv("CODE_SEARCH_MODEL", "thenlper/gte-large")
+    return Embedder(model_name=model)
+
 
 """Test1: Google Drive Link"""
 
@@ -97,7 +102,7 @@ def test_data_file_validation(temp_data_file):
 """Test3: Vector Embedding"""
 
 
-def test_vector_embedding(embedder=Embedder(model_name="thenlper/gte-large")):
+def test_vector_embedding(embedder):
     texts = ["flood prediction", "earthquake classification"]
     embeddings = embedder.embed_texts(texts)
 

--- a/tests/code_search_tool_test.py
+++ b/tests/code_search_tool_test.py
@@ -97,7 +97,7 @@ def test_data_file_validation(temp_data_file):
 """Test3: Vector Embedding"""
 
 
-def test_vector_embedding(embedder=Embedder(model_name="all-MiniLM-L6-v2")):
+def test_vector_embedding(embedder=Embedder(model_name="thenlper/gte-large")):
     texts = ["flood prediction", "earthquake classification"]
     embeddings = embedder.embed_texts(texts)
 


### PR DESCRIPTION
### Summary :memo:
This PR fixes an issue where search result titles were shown with placeholders instead of the actual repository names. Additionally, filtered the repo dump and updated the embeddings.  

### Details
- Repository names were added to the repo dump and included in the embedding pipeline.
- Filtered repo dump based on SME curation (Astro) and word count filter on readme text (min 10).
- Switched embedding model to `thenlper/gte-large`
- Updated Google Drive link to the latest repo dump with embeddings.
- Switched reranker model to `cross-encoder/ms-marco-MiniLM-L12-v2`

### Bugfixes :bug:
- Fixed placeholder usage in result titles. 

### Checks
- [x] Tested Changes
- [ ] Stakeholder Approval
