### PR TITLE
Implement deep copy for Instructor-based base agent

### DIFF
--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -323,3 +323,30 @@ class InstructorBaseAgent[
         )
 
         return response
+
+    def __deepcopy__(self, memo):
+        """
+        Custom deepcopy implementation to handle unpickleable attributes.
+        """
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+
+        # Manually copy attributes, re-initializing the client
+        for k, v in self.__dict__.items():
+            if k == "client":
+                # Re-create the client instead of copying it
+                setattr(
+                    result,
+                    k,
+                    instructor.from_openai(
+                        openai.AsyncOpenAI(
+                            api_key=self.api_key,
+                            base_url=str(self.base_url),
+                        ),
+                    ),
+                )
+            else:
+                setattr(result, k, __import__("copy").deepcopy(v, memo))
+
+        return result

--- a/akd/guardrails.py
+++ b/akd/guardrails.py
@@ -1,5 +1,6 @@
 """Guardrails decorator and utilities for agent validation."""
 
+import copy
 from typing import List, Optional
 
 from loguru import logger
@@ -263,6 +264,7 @@ def apply_guardrails(
     config: GuardrailsConfig | None = None,
     input_guardrails: List[RiskDefinition] | None = None,
     output_guardrails: List[RiskDefinition] | None = None,
+    safe: bool = True,
 ) -> BaseAgent | BaseTool:
     """
     Apply guardrails to an agent or tool using the add_guardrails decorator.
@@ -275,6 +277,9 @@ def apply_guardrails(
         config: Configuration for RiskDefinition-style guardrails
         input_guardrails: RiskDefinition list for AI safety input validation
         output_guardrails: RiskDefinition list for AI safety output validation
+        safe: bool
+            If True, creates a deep copy of the component before applying guardrails.
+            Else, might lead to side-effects.
 
     Returns:
         A new instance with guardrails applied, or the original component if no guardrails
@@ -307,8 +312,16 @@ def apply_guardrails(
     if not isinstance(component, (BaseAgent, BaseTool)):
         raise TypeError("component must be an agent or tool. ")
 
-    # Only apply guardrails if we have non-empty lists or a config
+    # Try-catch to make sure we continue if deepcopy fails
     component_name = component.__class__.__name__
+    try:
+        component = copy.deepcopy(component) if safe else component
+    except Exception as e:
+        logger.warning(
+            f"Could not deepcopy {component_name}. Proceeding with inplace modification. Error: {e}",
+        )
+
+    # Only apply guardrails if we have non-empty lists or a config
     has_input_guardrails = input_guardrails and len(input_guardrails) > 0
     has_output_guardrails = output_guardrails and len(output_guardrails) > 0
     has_config = config is not None

--- a/akd/guardrails.py
+++ b/akd/guardrails.py
@@ -312,21 +312,20 @@ def apply_guardrails(
     if not isinstance(component, (BaseAgent, BaseTool)):
         raise TypeError("component must be an agent or tool. ")
 
-    # Try-catch to make sure we continue if deepcopy fails
-    component_name = component.__class__.__name__
-    try:
-        component = copy.deepcopy(component) if safe else component
-    except Exception as e:
-        logger.warning(
-            f"Could not deepcopy {component_name}. Proceeding with inplace modification. Error: {e}",
-        )
-
     # Only apply guardrails if we have non-empty lists or a config
+    component_name = component.__class__.__name__
     has_input_guardrails = input_guardrails and len(input_guardrails) > 0
     has_output_guardrails = output_guardrails and len(output_guardrails) > 0
     has_config = config is not None
 
     if has_input_guardrails or has_output_guardrails or has_config:
+        # Try-catch to make sure we continue if deepcopy fails
+        try:
+            component = copy.deepcopy(component) if safe else component
+        except Exception as e:
+            logger.warning(
+                f"Could not deepcopy {component_name}. Proceeding with inplace modification. Error: {e}",
+            )
         # Apply the decorator to create a guarded agent class
         logger.info(f"Applying guardrails to component {component_name}")
         GuardedComponentClass = add_guardrails(


### PR DESCRIPTION
Addresses some comments made in #189  regarding safer copy (see [this comment](https://github.com/NASA-IMPACT/accelerated-discovery/pull/189#discussion_r2335104011))

Minor Changes:
- Add `__deepcopy__` to `InstructorBaseAgent`
- Add `safe` parameter to `apply_guardrails` that by default creates a copy of incoming component to minimize side-effects (Copied only when guardrails has to be applied)


### Checks
- [x] Tested Changes
- [ ] Stakeholder Approval
