### PR TITLE
Add IO mapping strategy using jsonpath to SingleAgentNodeTemplate

### DIFF
--- a/akd/nodes/templates.py
+++ b/akd/nodes/templates.py
@@ -1,6 +1,6 @@
 import uuid
 from abc import abstractmethod
-from typing import Any, Awaitable, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict
 
 from jsonpath_ng import parse as jsonpath_parse
 from loguru import logger
@@ -34,10 +34,10 @@ class AbstractNodeTemplate(AbstractBase[GlobalState, NodeState]):
 
     def __init__(
         self,
-        node_id: Optional[str] = None,
-        input_guardrails: List[CallableSpec] | None = None,
-        output_guardrails: List[CallableSpec] | None = None,
-        tool_runner: Optional[ToolRunner] = None,
+        node_id: str | None = None,
+        input_guardrails: list[CallableSpec] | None = None,
+        output_guardrails: list[CallableSpec] | None = None,
+        tool_runner: ToolRunner | None = None,
         mutation: bool = False,
         debug: bool = False,
         **kwargs,
@@ -112,9 +112,9 @@ class AbstractNodeTemplate(AbstractBase[GlobalState, NodeState]):
 
     async def _apply_guardrails(
         self,
-        guardrails: List[CallableSpec],
-        data: Dict[str, Any],
-    ) -> Dict[str, Any]:
+        guardrails: list[CallableSpec],
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         """
         Note:
             If guardrails are callables,
@@ -125,7 +125,7 @@ class AbstractNodeTemplate(AbstractBase[GlobalState, NodeState]):
             If they are Tuple,
             the 2nd element is the mapping of input keys.
         """
-        results: Dict[str, Any] = {}
+        results: dict[str, Any] = {}
         for guard in guardrails:
             if isinstance(guard, tuple):
                 name = guard[0].__class__.__name__
@@ -182,10 +182,10 @@ class SupervisedNodeTemplate(AbstractNodeTemplate):
     def __init__(
         self,
         supervisor: BaseSupervisor,
-        input_guardrails: List[CallableSpec] | None = None,
-        output_guardrails: List[CallableSpec] | None = None,
-        node_id: Optional[str] = None,
-        tool_runner: Optional[ToolRunner] = None,
+        input_guardrails: list[CallableSpec] | None = None,
+        output_guardrails: list[CallableSpec] | None = None,
+        node_id: str | None = None,
+        tool_runner: ToolRunner | None = None,
         mutation: bool = False,
         debug: bool = False,
         **kwargs,
@@ -251,11 +251,11 @@ class SingleAgentNodeTemplate(AbstractNodeTemplate):
     def __init__(
         self,
         agent: BaseAgent,
-        node_id: Optional[str] = None,
-        input_guardrails: Optional[List[RiskDefinition]] = None,
-        output_guardrails: Optional[List[RiskDefinition]] = None,
-        guardrails_config: Optional[GuardrailsConfig] = None,
-        io_map: Optional[Dict[str, str]] = None,
+        node_id: str | None = None,
+        input_guardrails: list[RiskDefinition] | None = None,
+        output_guardrails: list[RiskDefinition] | None = None,
+        guardrails_config: GuardrailsConfig | None = None,
+        io_map: dict[str, str] | None = None,
         mutation: bool = False,
         debug: bool = False,
         **kwargs,
@@ -354,9 +354,9 @@ class SingleAgentNodeTemplate(AbstractNodeTemplate):
 
     def _apply_io_mapping(
         self,
-        base_inputs: Dict[str, Any],
-        context: Dict[str, Any],
-    ) -> Dict[str, Any]:
+        base_inputs: dict[str, Any],
+        context: dict[str, Any],
+    ) -> dict[str, Any]:
         """
         Apply io_map transformations to fill missing inputs using JSONPath.
 
@@ -408,8 +408,8 @@ class SingleAgentNodeTemplate(AbstractNodeTemplate):
 
     def _validate_resolved_inputs(
         self,
-        resolved_inputs: Dict[str, Any],
-    ) -> Dict[str, Any]:
+        resolved_inputs: dict[str, Any],
+    ) -> dict[str, Any]:
         """
         Validate that resolved inputs can create agent input schema.
 
@@ -441,7 +441,7 @@ class SingleAgentNodeTemplate(AbstractNodeTemplate):
         self,
         node_state: NodeState,
         global_state: GlobalState,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Resolve inputs for the agent using JSONPath for complex cross-node data access.
 

--- a/akd/nodes/templates.py
+++ b/akd/nodes/templates.py
@@ -2,6 +2,7 @@ import uuid
 from abc import abstractmethod
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
+from jsonpath_ng import parse as jsonpath_parse
 from loguru import logger
 
 from akd._base import AbstractBase
@@ -254,6 +255,7 @@ class SingleAgentNodeTemplate(AbstractNodeTemplate):
         input_guardrails: Optional[List[RiskDefinition]] = None,
         output_guardrails: Optional[List[RiskDefinition]] = None,
         guardrails_config: Optional[GuardrailsConfig] = None,
+        io_map: Optional[Dict[str, str]] = None,
         mutation: bool = False,
         debug: bool = False,
         **kwargs,
@@ -266,6 +268,7 @@ class SingleAgentNodeTemplate(AbstractNodeTemplate):
             input_guardrails: RiskDefinition list for AI safety input validation
             output_guardrails: RiskDefinition list for AI safety output validation
             guardrails_config: Configuration for RiskDefinition-style guardrails
+            io_map: Optional mapping of input fields to other node fields (e.g., {"query": "lit_search.query"})
             node_id: Unique identifier for this node
             tool_runner: Tool runner instance
             mutation: Whether to mutate global state in place
@@ -297,6 +300,9 @@ class SingleAgentNodeTemplate(AbstractNodeTemplate):
         self._input_schema = self.agent.input_schema
         self._output_schema = self.agent.output_schema
 
+        # Store io_map for cross-node input mapping with JSONPath support
+        self.io_map = io_map or {}
+
         # Call parent constructor with no CallableSpec guardrails (agent handles its own guardrails)
         super().__init__(
             input_guardrails=[],  # no need to run callable spec guardrails
@@ -307,15 +313,132 @@ class SingleAgentNodeTemplate(AbstractNodeTemplate):
             **kwargs,
         )
 
+    async def _resolve_inputs(
+        self,
+        node_state: NodeState,
+        global_state: GlobalState,
+    ) -> Dict[str, Any]:
+        """
+        Resolve inputs for the agent using JSONPath for complex cross-node data access.
+
+        Supports merging current node inputs with data from other nodes using JSONPath expressions.
+        Never overrides existing inputs in the current node - only fills missing fields.
+
+        Args:
+            node_state: Current node's state
+            global_state: Global state containing all node states
+
+        Returns:
+            Dictionary of resolved inputs for the agent
+
+        Examples:
+            io_map = {
+                "query": "$.lit_search.outputs.query",              # Simple field access
+                "context": "$.preprocessing.outputs.cleaned_text",  # Cross-node data
+                "limit": "$.config.inputs.params.limit",            # Nested access
+                "results": "$.search.outputs.items[*].title"        # Array extraction
+            }
+        """
+        # Start with node's existing inputs (never override existing)
+        resolved_inputs = node_state.inputs.copy()
+
+        # If no io_map configured, just validate and return current inputs
+        if not self.io_map:
+            try:
+                self.agent.input_schema(**resolved_inputs)
+                return resolved_inputs
+            except Exception as e:
+                raise ValueError(
+                    f"Node '{self.node_id}' missing required inputs for agent "
+                    f"{self.agent.__class__.__name__}: {e}. Consider using io_map parameter.",
+                )
+
+        # Create JSONPath context from global state
+        context = {
+            # Current node access
+            "current": {
+                "inputs": node_state.inputs,
+                "outputs": node_state.outputs,
+            },
+            # All other nodes
+            **{
+                node_id: {
+                    "inputs": ns.inputs,
+                    "outputs": ns.outputs,
+                }
+                for node_id, ns in global_state.node_states.items()
+            },
+        }
+
+        if self.debug:
+            logger.debug(
+                f"[SingleAgentNodeTemplate {self.node_id}] "
+                f"JSONPath context keys: {list(context.keys())}",
+            )
+
+        # Apply io_map using JSONPath to fill missing fields
+        for target_field, jsonpath_expr in self.io_map.items():
+            if target_field in resolved_inputs:
+                if self.debug:
+                    logger.debug(
+                        f"[SingleAgentNodeTemplate {self.node_id}] "
+                        f"Skipping '{target_field}' - already exists in inputs",
+                    )
+                continue  # Don't override existing inputs
+
+            try:
+                jsonpath = jsonpath_parse(jsonpath_expr)
+                matches = jsonpath.find(context)
+
+                if matches:
+                    # Use first match
+                    resolved_inputs[target_field] = matches[0].value
+                    if self.debug:
+                        logger.debug(
+                            f"[SingleAgentNodeTemplate {self.node_id}] "
+                            f"Mapped '{target_field}' from '{jsonpath_expr}': {matches[0].value}",
+                        )
+                else:
+                    if self.debug:
+                        logger.warning(
+                            f"[SingleAgentNodeTemplate {self.node_id}] "
+                            f"JSONPath '{jsonpath_expr}' returned no matches for field '{target_field}'",
+                        )
+
+            except Exception as e:
+                logger.warning(
+                    f"[SingleAgentNodeTemplate {self.node_id}] "
+                    f"JSONPath '{jsonpath_expr}' failed for field '{target_field}': {e}",
+                )
+
+        # Validate resolved inputs can create agent input
+        try:
+            self.agent.input_schema(**resolved_inputs)
+            if self.debug:
+                logger.debug(
+                    f"[SingleAgentNodeTemplate {self.node_id}] "
+                    f"Successfully resolved inputs: {resolved_inputs}",
+                )
+            return resolved_inputs
+
+        except Exception as validation_error:
+            raise ValueError(
+                f"Failed to resolve required inputs for agent {self.agent.__class__.__name__} "
+                f"in node '{self.node_id}'. After applying io_map, validation failed: {validation_error}",
+            )
+
     async def _execute(
         self,
         node_state: NodeState,
         global_state: GlobalState,
     ) -> NodeState:
-        """Execute the agent using the node state inputs."""
+        """Execute the agent using enhanced input resolution with cross-node data access."""
         try:
-            # Extract inputs from node state and create agent input schema instance
-            agent_input = self.agent.input_schema(**node_state.inputs)
+            # Resolve inputs using JSONPath-based cross-node mapping
+            resolved_inputs = await self._resolve_inputs(node_state, global_state)
+
+            # Create agent input schema instance
+            agent_input = self.agent.input_schema(**resolved_inputs)
 
             if self.debug:
                 logger.debug(

--- a/akd/nodes/templates.py
+++ b/akd/nodes/templates.py
@@ -313,47 +313,21 @@ class SingleAgentNodeTemplate(AbstractNodeTemplate):
             **kwargs,
         )
 
-    async def _resolve_inputs(
+    def _build_jsonpath_context(
         self,
         node_state: NodeState,
         global_state: GlobalState,
     ) -> Dict[str, Any]:
         """
-        Resolve inputs for the agent using JSONPath for complex cross-node data access.
-
-        Supports merging current node inputs with data from other nodes using JSONPath expressions.
-        Never overrides existing inputs in the current node - only fills missing fields.
+        Build JSONPath context from global state for cross-node data access.
 
         Args:
             node_state: Current node's state
             global_state: Global state containing all node states
 
         Returns:
-            Dictionary of resolved inputs for the agent
-
-        Examples:
-            io_map = {
-                "query": "$.lit_search.outputs.query",              # Simple field access
-                "context": "$.preprocessing.outputs.cleaned_text",  # Cross-node data
-                "limit": "$.config.inputs.params.limit",            # Nested access
-                "results": "$.search.outputs.items[*].title"        # Array extraction
-            }
+            Dictionary context for JSONPath expressions
         """
-        # Start with node's existing inputs (never override existing)
-        resolved_inputs = node_state.inputs.copy()
-
-        # If no io_map configured, just validate and return current inputs
-        if not self.io_map:
-            try:
-                self.agent.input_schema(**resolved_inputs)
-                return resolved_inputs
-            except Exception as e:
-                raise ValueError(
-                    f"Node '{self.node_id}' missing required inputs for agent "
-                    f"{self.agent.__class__.__name__}: {e}. Consider using io_map parameter.",
-                )
-
-        # Create JSONPath context from global state
         context = {
             # Current node access
             "current": {
@@ -375,6 +349,25 @@ class SingleAgentNodeTemplate(AbstractNodeTemplate):
                 f"[SingleAgentNodeTemplate {self.node_id}] "
                 f"JSONPath context keys: {list(context.keys())}",
             )
+
+        return context
+
+    def _apply_io_mapping(
+        self,
+        base_inputs: Dict[str, Any],
+        context: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """
+        Apply io_map transformations to fill missing inputs using JSONPath.
+
+        Args:
+            base_inputs: Starting inputs (never overridden)
+            context: JSONPath context for expression evaluation
+
+        Returns:
+            Dictionary with resolved inputs from io_map
+        """
+        resolved_inputs = base_inputs.copy()
 
         # Apply io_map using JSONPath to fill missing fields
         for target_field, jsonpath_expr in self.io_map.items():
@@ -411,7 +404,24 @@ class SingleAgentNodeTemplate(AbstractNodeTemplate):
                     f"JSONPath '{jsonpath_expr}' failed for field '{target_field}': {e}",
                 )
 
-        # Validate resolved inputs can create agent input
+        return resolved_inputs
+
+    def _validate_resolved_inputs(
+        self,
+        resolved_inputs: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """
+        Validate that resolved inputs can create agent input schema.
+
+        Args:
+            resolved_inputs: Dictionary of resolved inputs
+
+        Returns:
+            Same dictionary if validation passes
+
+        Raises:
+            ValueError: If validation fails
+        """
         try:
             self.agent.input_schema(**resolved_inputs)
             if self.debug:
@@ -426,6 +436,52 @@ class SingleAgentNodeTemplate(AbstractNodeTemplate):
                 f"Failed to resolve required inputs for agent {self.agent.__class__.__name__} "
                 f"in node '{self.node_id}'. After applying io_map, validation failed: {validation_error}",
             )
+
+    async def _resolve_inputs(
+        self,
+        node_state: NodeState,
+        global_state: GlobalState,
+    ) -> Dict[str, Any]:
+        """
+        Resolve inputs for the agent using JSONPath for complex cross-node data access.
+
+        Supports merging current node inputs with data from other nodes using JSONPath expressions.
+        Never overrides existing inputs in the current node - only fills missing fields.
+
+        Args:
+            node_state: Current node's state
+            global_state: Global state containing all node states
+
+        Returns:
+            Dictionary of resolved inputs for the agent
+
+        Examples:
+            io_map = {
+                "query": "$.lit_search.outputs.query",              # Simple field access
+                "context": "$.preprocessing.outputs.cleaned_text",  # Cross-node data
+                "limit": "$.config.inputs.params.limit",            # Nested access
+                "results": "$.search.outputs.items[*].title"        # Array extraction
+            }
+        """
+        # Start with node's existing inputs (never override existing)
+        resolved_inputs = node_state.inputs.copy()
+
+        # If no io_map configured, just validate and return current inputs
+        if not self.io_map:
+            try:
+                return self._validate_resolved_inputs(resolved_inputs)
+            except ValueError as e:
+                raise ValueError(
+                    f"Node '{self.node_id}' missing required inputs for agent "
+                    f"{self.agent.__class__.__name__}. Consider using io_map parameter.\nError: {e}",
+                ) from e
+
+        # Build JSONPath context and apply io_map transformations
+        context = self._build_jsonpath_context(node_state, global_state)
+        resolved_inputs = self._apply_io_mapping(resolved_inputs, context)
+
+        # Validate and return final inputs
+        return self._validate_resolved_inputs(resolved_inputs)
 
     async def _execute(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "tiktoken>=0.9.0",
     "rapidfuzz>=3.13.0",
     "undetected-chromedriver>=3.5.5",
+    "jsonpath-ng>=1.6.1",
     "pypaperbot @ git+https://github.com/NISH1001/PyPaperBot.git@develop",
 ]
 

--- a/tests/nodes/test_single_agent_node_template.py
+++ b/tests/nodes/test_single_agent_node_template.py
@@ -457,6 +457,207 @@ class TestSingleAgentNodeTemplateIntegration:
         # depends on how the decorator merges user-provided lists with config
 
 
+class TestSingleAgentNodeTemplateCrossNodeMapping:
+    """Test cross-node input mapping with JSONPath functionality."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_inputs_no_io_map(self):
+        """Test _resolve_inputs with complete inputs and no io_map."""
+        agent = TestAgent()
+        template = SingleAgentNodeTemplate(agent=agent)
+
+        node_state = NodeState(inputs={"query": "test query"})
+        global_state = GlobalState(node_states={"test": node_state})
+
+        resolved = await template._resolve_inputs(node_state, global_state)
+        assert resolved == {"query": "test query"}
+
+    @pytest.mark.asyncio
+    async def test_resolve_inputs_no_io_map_missing_required(self):
+        """Test _resolve_inputs fails when required inputs missing and no io_map."""
+        agent = TestAgent()
+        template = SingleAgentNodeTemplate(agent=agent, node_id="test_node")
+
+        node_state = NodeState(inputs={})  # Missing required "query" field
+        global_state = GlobalState(node_states={"test_node": node_state})
+
+        with pytest.raises(
+            ValueError,
+            match=r"(?s)Node.*missing required inputs.*Consider using io_map",
+        ):
+            await template._resolve_inputs(node_state, global_state)
+
+    @pytest.mark.asyncio
+    async def test_resolve_inputs_simple_jsonpath_mapping(self):
+        """Test _resolve_inputs with simple JSONPath cross-node mapping."""
+        agent = TestAgent()
+        template = SingleAgentNodeTemplate(
+            agent=agent,
+            io_map={"query": "$.lit_search.inputs.query"},
+            debug=True,
+        )
+
+        node_state = NodeState(inputs={})  # Empty inputs
+        global_state = GlobalState(
+            node_states={
+                "current": node_state,
+                "lit_search": NodeState(inputs={"query": "landslide nepal"}),
+            },
+        )
+
+        resolved = await template._resolve_inputs(node_state, global_state)
+        assert resolved["query"] == "landslide nepal"
+
+    @pytest.mark.asyncio
+    async def test_resolve_inputs_outputs_mapping(self):
+        """Test _resolve_inputs mapping from outputs instead of inputs."""
+        agent = TestAgent()
+        template = SingleAgentNodeTemplate(
+            agent=agent,
+            io_map={"query": "$.search.outputs.final_query"},
+            debug=True,
+        )
+
+        node_state = NodeState(inputs={})
+        global_state = GlobalState(
+            node_states={
+                "current": node_state,
+                "search": NodeState(outputs={"final_query": "earthquake detection"}),
+            },
+        )
+
+        resolved = await template._resolve_inputs(node_state, global_state)
+        assert resolved["query"] == "earthquake detection"
+
+    @pytest.mark.asyncio
+    async def test_resolve_inputs_no_override_existing(self):
+        """Test _resolve_inputs never overrides existing node inputs."""
+        agent = TestAgent()
+        template = SingleAgentNodeTemplate(
+            agent=agent,
+            io_map={"query": "$.other.inputs.query"},
+            debug=True,
+        )
+
+        node_state = NodeState(inputs={"query": "original query"})  # Existing input
+        global_state = GlobalState(
+            node_states={
+                "current": node_state,
+                "other": NodeState(inputs={"query": "should not override"}),
+            },
+        )
+
+        resolved = await template._resolve_inputs(node_state, global_state)
+        assert resolved["query"] == "original query"  # Should NOT be overridden
+
+    @pytest.mark.asyncio
+    async def test_resolve_inputs_missing_source_node(self):
+        """Test _resolve_inputs handles missing source node gracefully."""
+        agent = TestAgent()
+        template = SingleAgentNodeTemplate(
+            agent=agent,
+            io_map={"query": "$.nonexistent.inputs.query"},
+            debug=True,
+        )
+
+        node_state = NodeState(inputs={})
+        global_state = GlobalState(node_states={"current": node_state})
+
+        # Should fail validation since query is still missing after mapping attempt
+        with pytest.raises(ValueError, match="validation failed"):
+            await template._resolve_inputs(node_state, global_state)
+
+    @pytest.mark.asyncio
+    async def test_resolve_inputs_invalid_jsonpath(self):
+        """Test _resolve_inputs handles invalid JSONPath expressions."""
+        agent = TestAgent()
+        template = SingleAgentNodeTemplate(
+            agent=agent,
+            io_map={"query": "$.invalid..path..syntax"},
+            debug=True,
+        )
+
+        node_state = NodeState(inputs={})
+        global_state = GlobalState(
+            node_states={
+                "current": node_state,
+                "other": NodeState(inputs={"query": "good query"}),
+            },
+        )
+
+        # Should fail validation since JSONPath is invalid and query remains unmapped
+        with pytest.raises(ValueError, match="validation failed"):
+            await template._resolve_inputs(node_state, global_state)
+
+    @pytest.mark.asyncio
+    async def test_resolve_inputs_nested_jsonpath(self):
+        """Test _resolve_inputs with nested JSONPath expressions."""
+        agent = TestAgent()
+        template = SingleAgentNodeTemplate(
+            agent=agent,
+            io_map={"query": "$.config.inputs.search_params.query_text"},
+            debug=True,
+        )
+
+        node_state = NodeState(inputs={})
+        global_state = GlobalState(
+            node_states={
+                "current": node_state,
+                "config": NodeState(
+                    inputs={
+                        "search_params": {
+                            "query_text": "nested query value",
+                        },
+                    },
+                ),
+            },
+        )
+
+        resolved = await template._resolve_inputs(node_state, global_state)
+        assert resolved["query"] == "nested query value"
+
+    @pytest.mark.asyncio
+    async def test_cross_node_io_mapping_with_query_agent(self):
+        """Test cross-node input mapping using QueryAgent example."""
+        # Import QueryAgent here to avoid circular imports
+        from akd.agents.query import QueryAgent
+
+        _agent = QueryAgent()
+        _node = SingleAgentNodeTemplate(
+            _agent,
+            node_id="query",
+            input_guardrails=[RiskDefinition.HARM],
+            mutation=True,
+            io_map={"query": "$.lit_search.inputs.query"},
+            debug=True,
+        )
+
+        print(_node._input_schema, _node._output_schema)
+
+        _global_state = GlobalState(
+            node_states={
+                "query": NodeState(
+                    inputs={
+                        "num_queries": 10,
+                    },
+                ),
+                "lit_search": NodeState(
+                    inputs={
+                        "query": "landslide nepal throughout the years",
+                    },
+                ),
+            },
+        )
+
+        _node_output = await _node.arun(_global_state)
+        result = _node_output.model_dump()
+
+        # Verify that the mapping worked and query field was populated from lit_search
+        assert "outputs" in result
+        # The exact output format depends on QueryAgent implementation
+        # but we should have some response indicating successful execution
+
+
 # Prevent pytest from collecting test agent class
 TestAgent.__test__ = False
 


### PR DESCRIPTION

### Summary :memo:

This pull request introduces a powerful **JSONPath-based input/output (IO) mapping strategy** for the `SingleAgentNodeTemplate`. This feature allows a node to dynamically resolve its inputs by pulling data from the outputs or inputs of any other node within the global state. This greatly enhances the flexibility of graph composition by enabling complex, cross-node data flows without requiring custom code.

### Major Changes

  * **Introduced JSONPath-based IO Mapping**: A new `io_map` parameter was added to the `SingleAgentNodeTemplate` constructor. This enables a node to dynamically pull its required inputs from any other node's inputs or outputs in the `global_state` (e.g., `{"query": "$.lit_search.outputs.query"}`).
  * **New Input Resolution Logic**: The core logic was implemented in a new `_resolve_inputs` method. It safely maps data by only filling in missing fields and **will never override** an existing input value, ensuring predictable behavior.
  * **Added Comprehensive Tests**: A full new test suite was added to validate the IO mapping feature under various conditions, including nested paths, missing sources, and invalid expressions.

### Minor Changes

  * **Dependency Addition**: The `jsonpath-ng` library was added to `pyproject.toml` to support the new mapping functionality.

### Bugfixes :bug:

  * Addressed an issue in the newly created test suite for the IO mapping feature to ensure it provides accurate and reliable validation for the new functionality.

### Usage Example

The `io_map` parameter simplifies passing data between nodes. Previously, you had to ensure all necessary inputs were present in a node's own state. Now, you can map them from elsewhere in the graph.

#### Before: Explicit Input Definition

Without `io_map`, the `query` node required its inputs to be explicitly defined within its own `NodeState`.

```python
# Agent and Node setup
_agent = QueryAgent()
_node = SingleAgentNodeTemplate(
    _agent,
    node_id="query",
    input_guardrails=[RiskDefinition.HARM],
    debug=True,
)

# Global state where 'query' node has all its inputs
_global_state = GlobalState(
    node_states={
        "query": NodeState(
            inputs={
                "query": "landslide nepal",  # <-- Input is defined here
                "num_queries": 10,
            },
        ),
        "lit_search": NodeState(
            inputs={},
        ),
    },
)

_node_output = await _node.arun(_global_state)
print(_node_output.model_dump())
```

#### After: Dynamic Input Mapping with `io_map`

With `io_map`, the `query` node can pull its `query` input directly from the `lit_search` node's state, reducing redundant data definitions.

```python
# Agent and Node setup with io_map
_agent = QueryAgent()
_node = SingleAgentNodeTemplate(
    _agent,
    node_id="query",
    input_guardrails=[RiskDefinition.HARM],
    mutation=True,
    # Map the 'query' input from the 'lit_search' node's inputs
    io_map={"query": "$.lit_search.inputs.query"},
    debug=True,
)

# Global state where 'query' input is missing from the 'query' node
_global_state = GlobalState(
    node_states={
        "query": NodeState(
            inputs={
                "num_queries": 10, # <-- 'query' is missing here
            },
        ),
        "lit_search": NodeState(
            inputs={
                # The source of truth for the query
                "query": "landslide nepal throughout the years",
            },
        ),
    },
)

# The node runs successfully because it resolves the missing input via io_map
_node_output = await _node.arun(_global_state)
print(_node_output.model_dump())
```

### Checks

  - [x] Tested Changes
  - [ ] Stakeholder Approval