### PR TITLE
Change default ollama type in config

### DIFF
--- a/akd/configs/guardrails_config.py
+++ b/akd/configs/guardrails_config.py
@@ -39,7 +39,7 @@ class GuardrailsConfig(BaseConfig):
     )
 
     ollama_type: OllamaType = Field(
-        default=OllamaType.CHAT,
+        default=OllamaType.SERVER,
         description="Ollama interface type to use",
     )
 

--- a/akd/tools/granite_guardian_tool.py
+++ b/akd/tools/granite_guardian_tool.py
@@ -162,7 +162,7 @@ class GraniteGuardianTool(
     def _call_guardian(self, messages: List[Dict[str, str]]) -> Dict[str, Any]:
         try:
             if self.ollama_type == OllamaType.CHAT:
-                result = self.ollama_client.chat(model="granite3-guardian:2b", messages=messages)
+                result = self.ollama_client.chat(model=self.model, messages=messages)
                 #result = chat(model=self.model, messages=messages)
 
                 content = result.message.content

--- a/akd/tools/granite_guardian_tool.py
+++ b/akd/tools/granite_guardian_tool.py
@@ -94,10 +94,11 @@ class GraniteGuardianToolConfig(BaseToolConfig):
     """
     Configuration for Granite Guardian Tool.
     """
-
+    print("from core")
     ollama_base_url: HttpUrl = Field(
         default=HttpUrl(os.getenv("OLLAMA_BASE_URL", "http://ollama:11434/")),
     )
+    print("ollama base url is ",ollama_base_url )
     model: GuardianModelID = Field(
         default=GuardianModelID.GUARDIAN_8B,
         description="Granite Guardian model to use.",

--- a/akd/tools/granite_guardian_tool.py
+++ b/akd/tools/granite_guardian_tool.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 
 import requests
 from loguru import logger
-from ollama import chat, Client 
+from ollama import Client
 from pydantic import HttpUrl, model_validator
 from pydantic.fields import Field
 from typing_extensions import Self
@@ -94,6 +94,7 @@ class GraniteGuardianToolConfig(BaseToolConfig):
     """
     Configuration for Granite Guardian Tool.
     """
+
     ollama_base_url: HttpUrl = Field(
         default=HttpUrl(os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")),
     )
@@ -162,8 +163,10 @@ class GraniteGuardianTool(
     def _call_guardian(self, messages: List[Dict[str, str]]) -> Dict[str, Any]:
         try:
             if self.ollama_type == OllamaType.CHAT:
-                result = self.ollama_client.chat(model=self.model, messages=messages)
-                #result = chat(model=self.model, messages=messages)
+                result = self.ollama_client.chat(
+                    model="granite3-guardian:2b",
+                    messages=messages,
+                )
 
                 content = result.message.content
             elif self.ollama_type == OllamaType.SERVER:

--- a/akd/tools/granite_guardian_tool.py
+++ b/akd/tools/granite_guardian_tool.py
@@ -95,7 +95,7 @@ class GraniteGuardianToolConfig(BaseToolConfig):
     Configuration for Granite Guardian Tool.
     """
     ollama_base_url: HttpUrl = Field(
-        default=HttpUrl(os.getenv("OLLAMA_BASE_URL", "http://Ollama-Ollam-3YFf3jFSw3Dc-1401538839.us-west-2.elb.amazonaws.com")),
+        default=HttpUrl(os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")),
     )
     model: GuardianModelID = Field(
         default=GuardianModelID.GUARDIAN_2B,

--- a/akd/tools/granite_guardian_tool.py
+++ b/akd/tools/granite_guardian_tool.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 
 import requests
 from loguru import logger
-from ollama import Client
+from ollama import chat
 from pydantic import HttpUrl, model_validator
 from pydantic.fields import Field
 from typing_extensions import Self
@@ -99,11 +99,11 @@ class GraniteGuardianToolConfig(BaseToolConfig):
         default=HttpUrl(os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")),
     )
     model: GuardianModelID = Field(
-        default=GuardianModelID.GUARDIAN_2B,
+        default=GuardianModelID.GUARDIAN_8B,
         description="Granite Guardian model to use.",
     )
     ollama_type: OllamaType = Field(
-        default=OllamaType.CHAT,
+        default=OllamaType.SERVER,
         description="Ollama type to use (chat/server).",
     )
     default_risk_type: RiskDefinition = Field(
@@ -136,7 +136,6 @@ class GraniteGuardianTool(
         self.default_risk_type = config.default_risk_type
         self.snippet_n_chars = config.snippet_n_chars
         self.ollama_type = config.ollama_type
-        self.ollama_client = Client(host=str(config.ollama_base_url))
 
     async def _arun(
         self,
@@ -163,11 +162,7 @@ class GraniteGuardianTool(
     def _call_guardian(self, messages: List[Dict[str, str]]) -> Dict[str, Any]:
         try:
             if self.ollama_type == OllamaType.CHAT:
-                result = self.ollama_client.chat(
-                    model="granite3-guardian:2b",
-                    messages=messages,
-                )
-
+                result = chat(model=self.model, messages=messages)
                 content = result.message.content
             elif self.ollama_type == OllamaType.SERVER:
                 result = self._ollama_server_gen(messages)

--- a/akd/tools/granite_guardian_tool.py
+++ b/akd/tools/granite_guardian_tool.py
@@ -167,8 +167,8 @@ class GraniteGuardianTool(
 
         try:
             if self.ollama_type == OllamaType.CHAT:
-                print("i came here")
-                result = self.ollama_client.chat(model=self.model,model="granite3.3:2b", messages=messages)
+                print("i came here", self.model)
+                result = self.ollama_client.chat(model="granite3.3:2b", messages=messages)
                 #result = chat(model=self.model, messages=messages)
                 print("result is :", result)
 

--- a/akd/tools/granite_guardian_tool.py
+++ b/akd/tools/granite_guardian_tool.py
@@ -168,7 +168,7 @@ class GraniteGuardianTool(
         try:
             if self.ollama_type == OllamaType.CHAT:
                 print("i came here")
-                result = self.ollama_client.chat(model=self.model, messages=messages)
+                result = self.ollama_client.chat(model=self.model,model="granite3.3:2b", messages=messages)
                 #result = chat(model=self.model, messages=messages)
                 print("result is :", result)
 

--- a/akd/tools/granite_guardian_tool.py
+++ b/akd/tools/granite_guardian_tool.py
@@ -166,7 +166,7 @@ class GraniteGuardianTool(
         try:
             if self.ollama_type == OllamaType.CHAT:
                 print("i came here")
-                result = chat(model=self.model, messages=messages)
+                result = chat(model=self.model, messages=messages, host=str(self.config.ollama_base_url))
                 print("result is :", result)
 
                 content = result.message.content

--- a/akd/tools/granite_guardian_tool.py
+++ b/akd/tools/granite_guardian_tool.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 
 import requests
 from loguru import logger
-from ollama import chat
+from ollama import chat, Client 
 from pydantic import HttpUrl, model_validator
 from pydantic.fields import Field
 from typing_extensions import Self
@@ -137,6 +137,8 @@ class GraniteGuardianTool(
         self.default_risk_type = config.default_risk_type
         self.snippet_n_chars = config.snippet_n_chars
         self.ollama_type = config.ollama_type
+        self.ollama_client = Client(host=str(config.ollama_base_url))
+        print(f"Ollama client initialized with: {config.ollama_base_url}")
 
     async def _arun(
         self,
@@ -166,7 +168,8 @@ class GraniteGuardianTool(
         try:
             if self.ollama_type == OllamaType.CHAT:
                 print("i came here")
-                result = chat(model=self.model, messages=messages, host=str(self.config.ollama_base_url))
+                result = self.ollama_client.chat(model=self.model, messages=messages)
+                #result = chat(model=self.model, messages=messages)
                 print("result is :", result)
 
                 content = result.message.content

--- a/akd/tools/granite_guardian_tool.py
+++ b/akd/tools/granite_guardian_tool.py
@@ -94,11 +94,9 @@ class GraniteGuardianToolConfig(BaseToolConfig):
     """
     Configuration for Granite Guardian Tool.
     """
-    print("from core")
     ollama_base_url: HttpUrl = Field(
         default=HttpUrl(os.getenv("OLLAMA_BASE_URL", "http://Ollama-Ollam-3YFf3jFSw3Dc-1401538839.us-west-2.elb.amazonaws.com")),
     )
-    print("new ollama base url is ",ollama_base_url )
     model: GuardianModelID = Field(
         default=GuardianModelID.GUARDIAN_2B,
         description="Granite Guardian model to use.",
@@ -138,7 +136,6 @@ class GraniteGuardianTool(
         self.snippet_n_chars = config.snippet_n_chars
         self.ollama_type = config.ollama_type
         self.ollama_client = Client(host=str(config.ollama_base_url))
-        print(f"Ollama client initialized with: {config.ollama_base_url}")
 
     async def _arun(
         self,
@@ -163,14 +160,10 @@ class GraniteGuardianTool(
         return GraniteGuardianOutputSchema(risk_results=outputs)
 
     def _call_guardian(self, messages: List[Dict[str, str]]) -> Dict[str, Any]:
-        print("new url is",self.config.ollama_base_url )
-
         try:
             if self.ollama_type == OllamaType.CHAT:
-                print("i came here", self.model)
                 result = self.ollama_client.chat(model="granite3.3:2b", messages=messages)
                 #result = chat(model=self.model, messages=messages)
-                print("result is :", result)
 
                 content = result.message.content
             elif self.ollama_type == OllamaType.SERVER:
@@ -181,7 +174,6 @@ class GraniteGuardianTool(
                 label = re.findall(r"\b(yes|no)\b", content, flags=re.IGNORECASE)[
                     0
                 ].lower()
-                print("label is :", label)
             except Exception as e:
                 logger.error(f"[GuardianTool] Ollama error: {e}")
                 return {"error": str(e)}

--- a/akd/tools/granite_guardian_tool.py
+++ b/akd/tools/granite_guardian_tool.py
@@ -96,7 +96,7 @@ class GraniteGuardianToolConfig(BaseToolConfig):
     """
     print("from core")
     ollama_base_url: HttpUrl = Field(
-        default=HttpUrl(os.getenv("OLLAMA_BASE_URL", "http://ollama:11434/")),
+        default=HttpUrl(os.getenv("OLLAMA_BASE_URL", "http://Ollama-Ollam-3YFf3jFSw3Dc-1401538839.us-west-2.elb.amazonaws.com")),
     )
     print("ollama base url is ",ollama_base_url )
     model: GuardianModelID = Field(

--- a/akd/tools/granite_guardian_tool.py
+++ b/akd/tools/granite_guardian_tool.py
@@ -100,7 +100,7 @@ class GraniteGuardianToolConfig(BaseToolConfig):
     )
     print("new ollama base url is ",ollama_base_url )
     model: GuardianModelID = Field(
-        default=GuardianModelID.GUARDIAN_8B,
+        default=GuardianModelID.GUARDIAN_2B,
         description="Granite Guardian model to use.",
     )
     ollama_type: OllamaType = Field(

--- a/akd/tools/granite_guardian_tool.py
+++ b/akd/tools/granite_guardian_tool.py
@@ -162,7 +162,7 @@ class GraniteGuardianTool(
     def _call_guardian(self, messages: List[Dict[str, str]]) -> Dict[str, Any]:
         try:
             if self.ollama_type == OllamaType.CHAT:
-                result = self.ollama_client.chat(model="granite3.3:2b", messages=messages)
+                result = self.ollama_client.chat(model="granite3-guardian:2b", messages=messages)
                 #result = chat(model=self.model, messages=messages)
 
                 content = result.message.content

--- a/akd/tools/granite_guardian_tool.py
+++ b/akd/tools/granite_guardian_tool.py
@@ -161,9 +161,14 @@ class GraniteGuardianTool(
         return GraniteGuardianOutputSchema(risk_results=outputs)
 
     def _call_guardian(self, messages: List[Dict[str, str]]) -> Dict[str, Any]:
+        print("url is",self.config.ollama_base_url )
+
         try:
             if self.ollama_type == OllamaType.CHAT:
+                print("i came here")
                 result = chat(model=self.model, messages=messages)
+                print("result is :", result)
+
                 content = result.message.content
             elif self.ollama_type == OllamaType.SERVER:
                 result = self._ollama_server_gen(messages)
@@ -173,6 +178,7 @@ class GraniteGuardianTool(
                 label = re.findall(r"\b(yes|no)\b", content, flags=re.IGNORECASE)[
                     0
                 ].lower()
+                print("label is :", label)
             except Exception as e:
                 logger.error(f"[GuardianTool] Ollama error: {e}")
                 return {"error": str(e)}

--- a/akd/tools/granite_guardian_tool.py
+++ b/akd/tools/granite_guardian_tool.py
@@ -96,7 +96,7 @@ class GraniteGuardianToolConfig(BaseToolConfig):
     """
 
     ollama_base_url: HttpUrl = Field(
-        default=HttpUrl(os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")),
+        default=HttpUrl(os.getenv("OLLAMA_BASE_URL", "http://ollama:11434/")),
     )
     model: GuardianModelID = Field(
         default=GuardianModelID.GUARDIAN_8B,

--- a/akd/tools/granite_guardian_tool.py
+++ b/akd/tools/granite_guardian_tool.py
@@ -98,7 +98,7 @@ class GraniteGuardianToolConfig(BaseToolConfig):
     ollama_base_url: HttpUrl = Field(
         default=HttpUrl(os.getenv("OLLAMA_BASE_URL", "http://Ollama-Ollam-3YFf3jFSw3Dc-1401538839.us-west-2.elb.amazonaws.com")),
     )
-    print("ollama base url is ",ollama_base_url )
+    print("new ollama base url is ",ollama_base_url )
     model: GuardianModelID = Field(
         default=GuardianModelID.GUARDIAN_8B,
         description="Granite Guardian model to use.",
@@ -161,7 +161,7 @@ class GraniteGuardianTool(
         return GraniteGuardianOutputSchema(risk_results=outputs)
 
     def _call_guardian(self, messages: List[Dict[str, str]]) -> Dict[str, Any]:
-        print("url is",self.config.ollama_base_url )
+        print("new url is",self.config.ollama_base_url )
 
         try:
             if self.ollama_type == OllamaType.CHAT:


### PR DESCRIPTION
### Summary :memo:
The guardian-guardrails tool was using the default config from `akd/configs/guardrails_config.py`. 

### Details
_Describe more what you did on changes._
1. Changed `SERVER` as the default `ollama_type`

### Bugfixes :bug: (delete if dind't have any)
-

### Checks
- [ ] Closed #798
- [ ] Tested Changes
- [ ] Stakeholder Approval
