### PR TITLE
Bug fix for max_results being set to 10 unless set from arun parameters

### DIFF
--- a/akd/tools/search/_base.py
+++ b/akd/tools/search/_base.py
@@ -44,8 +44,8 @@ class SearchToolInputSchema(InputSchema):
         "science",
         description="Category of the search queries.",
     )
-    max_results: int = Field(
-        10,
+    max_results: Optional[int] = Field(  
+        None,
         description="Maximum number of search results to return.",
     )
 

--- a/tests/tools/search/test_searxng_unit.py
+++ b/tests/tools/search/test_searxng_unit.py
@@ -118,7 +118,7 @@ class TestSearxNGSearchToolSchemas:
         input_schema = SearxNGSearchToolInputSchema(queries=["test"])
 
         assert input_schema.category == "science"
-        assert input_schema.max_results == 10
+        assert input_schema.max_results == None
 
     def test_output_schema_validation(self, sample_search_result_items):
         """Test output schema validation."""


### PR DESCRIPTION
There was a major bug in our search tool because of which we always used to get 10 max_results unless we initialize the max_results in input schema  or in the params itself i.e. the search tool wouldn't be configured through its config which was caused due to the combined effect of default initialization in inputschema and the heirachy of max_results inside arun. Hence the following changes has been done. 

- max_results default set to None in inputschema so that it doesn't override the max_results in config when input schema is initialized without max_results
- max_results type Updated to use Optional[int] - optional is required because akd/tools/search/pipeline.py:326 will face validation results when max_results is not provided in params
