### PR TITLE
Feat: Make Base Agents Stateless by Default

### DIFF
--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -23,6 +23,10 @@ class BaseAgentConfig(BaseConfig):
     model_name: str | None = Field(default=CONFIG.model_config_settings.model_name)
     temperature: float = 0.0
     system_prompt: str | None = Field(default=DEFAULT_SYSTEM_PROMPT)
+    track_history: bool = Field(
+        default=False,
+        description="Whether to track conversation history",
+    )
 
 
 class BaseAgent[
@@ -228,6 +232,18 @@ class InstructorBaseAgent[
         """
         self.memory.clear()
 
+    def _default_system_message(self) -> dict[str, str]:
+        """
+        Returns the default system message.
+
+        Returns:
+            dict[str, str]: System message dictionary with role and content.
+        """
+        return {
+            "role": "system",
+            "content": self.system_prompt,
+        }
+
     def _create_instructor_compatible_model(self, response_model: type[OutputSchema]):
         """Create a model that's compatible with instructor but avoids IOSchema validation."""
         from pydantic import create_model
@@ -252,12 +268,16 @@ class InstructorBaseAgent[
 
     async def get_response_async(
         self,
+        messages: list[dict[str, str]],
         response_model: type[OutputSchema] | None = None,
     ) -> OutSchema:
         """
         Obtains a response from the language model asynchronously.
 
         Args:
+            messages (list[dict[str, str]], optional):
+                The messages to send to the model. If not provided,
+                builds from system prompt and memory.
             response_model (Type[BaseModel], optional):
                 The schema for the response data. If not set,
                 self.output_schema is used.
@@ -267,13 +287,6 @@ class InstructorBaseAgent[
         """
         response_model = response_model or self.output_schema
         instructor_model = self._create_instructor_compatible_model(response_model)
-
-        messages = [
-            {
-                "role": "system",
-                "content": self.system_prompt,
-            },
-        ] + self.memory
 
         response = await self.client.chat.completions.create(
             messages=messages,
@@ -303,8 +316,16 @@ class InstructorBaseAgent[
             OutputSchema: The response from the chat agent.
         """
 
+        # start fresh if no tracking required
+        messages = [] if not self.track_history else self.memory
+
+        # if empty, add system message
+        if not messages:
+            messages.append(self._default_system_message())
+
+        # add user message
         if params:
-            self.memory.append(
+            messages.append(
                 dict(
                     role="user",
                     content=params.model_dump_json(exclude={"type"}),
@@ -312,15 +333,19 @@ class InstructorBaseAgent[
             )
 
         response = await self.get_response_async(
+            messages=messages,
             response_model=self.output_schema,
         )
 
-        self.memory.append(
+        messages.append(
             dict(
                 role="assistant",
                 content=response.model_dump_json(exclude={"type"}),
             ),
         )
+
+        if self.track_history:
+            self._memory = messages
 
         return response
 

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -137,6 +137,7 @@ class LangBaseAgent[
 
     async def get_response_async(
         self,
+        messages: list | None = None,
         response_model: type[OutputSchema] | None = None,
     ) -> OutSchema:
         """
@@ -150,6 +151,7 @@ class LangBaseAgent[
         Returns:
             Type[BaseModel]: The response from the language model.
         """
+        messages = messages or self.memory.messages
         response_model = response_model or self.output_schema
         structured_client = self.client.with_structured_output(
             response_model,
@@ -158,7 +160,7 @@ class LangBaseAgent[
 
         # Format messages using the prompt template
         formatted_messages = self.prompt_template.format_messages(
-            memory=self.memory.messages,
+            memory=messages,
         )
 
         response = await structured_client.ainvoke(formatted_messages)
@@ -182,14 +184,21 @@ class LangBaseAgent[
             OutputSchema: The response from the chat agent.
         """
 
+        # reference new empty memory if stateless
+        _memory = ChatMessageHistory() if self.stateless else self.memory
+
         if params:
-            self.memory.add_user_message(params.model_dump_json(exclude={"type"}))
+            _memory.add_user_message(params.model_dump_json(exclude={"type"}))
 
         response = await self.get_response_async(
+            messages=_memory.messages,
             response_model=self.output_schema,
         )
 
-        self.memory.add_ai_message(response.model_dump_json(exclude={"type"}))
+        # Update memory only not stateless
+        if not self.stateless and params:
+            _memory.add_ai_message(response.model_dump_json(exclude={"type"}))
+            self._memory = _memory
 
         return response
 

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -23,9 +23,9 @@ class BaseAgentConfig(BaseConfig):
     model_name: str | None = Field(default=CONFIG.model_config_settings.model_name)
     temperature: float = 0.0
     system_prompt: str | None = Field(default=DEFAULT_SYSTEM_PROMPT)
-    track_history: bool = Field(
-        default=False,
-        description="Whether to track conversation history",
+    stateless: bool = Field(
+        default=True,
+        description="Whether to maintain conversation history/state",
     )
 
 
@@ -317,7 +317,7 @@ class InstructorBaseAgent[
         """
 
         # start fresh if no tracking required
-        messages = [] if not self.track_history else self.memory
+        messages = [] if self.stateless else self.memory
 
         # if empty, add system message
         if not messages:
@@ -344,7 +344,8 @@ class InstructorBaseAgent[
             ),
         )
 
-        if self.track_history:
+        # update memory only if stateful
+        if not self.stateless:
             self._memory = messages
 
         return response

--- a/tests/agents/test_base_agents.py
+++ b/tests/agents/test_base_agents.py
@@ -332,8 +332,9 @@ class TestInstructorBaseAgentFunctionality:
 
                 agent = TestInstructorBaseAgent()
 
-                # Test response generation
-                result = await agent.get_response_async()
+                # Test response generation with messages parameter
+                test_messages = [{"role": "user", "content": "test message"}]
+                result = await agent.get_response_async(messages=test_messages)
 
                 # Verify instructor call
                 mock_chat_completions.assert_called_once()
@@ -366,7 +367,9 @@ class TestBaseAgentSharedFunctionality:
             mock_structured_client.ainvoke.return_value = expected_response
             mock_chat_openai.return_value = mock_client
 
-            agent = TestLangBaseAgent()
+            # Create agent with stateless=False to test memory management
+            config = BaseAgentConfig(stateless=False)
+            agent = TestLangBaseAgent(config=config)
             test_input = AgentTestInputSchema(query="test query")
 
             # Execute arun - this will call base _arun which manages memory
@@ -377,7 +380,7 @@ class TestBaseAgentSharedFunctionality:
             assert result.response == "Test response"
             assert result.metadata == {"test": True}
 
-            # Verify memory was updated by base _arun
+            # Verify memory was updated by base _arun (only in stateful mode)
             assert len(agent.memory.messages) == 2  # user + assistant messages
 
     @pytest.mark.asyncio
@@ -397,7 +400,9 @@ class TestBaseAgentSharedFunctionality:
                 mock_chat_completions.return_value = mock_response
                 mock_instructor.return_value = mock_client
 
-                agent = TestInstructorBaseAgent()
+                # Create agent with stateless=False to test memory management
+                config = BaseAgentConfig(stateless=False)
+                agent = TestInstructorBaseAgent(config=config)
                 test_input = AgentTestInputSchema(query="test query")
 
                 # Execute arun - this will call base _arun which manages memory
@@ -408,8 +413,60 @@ class TestBaseAgentSharedFunctionality:
                 assert result.response == "Test instructor response"
                 assert result.metadata == {"test": True}
 
-                # Verify memory was updated by base _arun
-                assert len(agent.memory) == 2  # user + assistant messages
+                # Verify memory was updated by base _arun (only in stateful mode)
+                assert len(agent.memory) == 3  # system + user + assistant messages
+
+    @pytest.mark.asyncio
+    async def test_stateless_behavior_default(self):
+        """Test that agents are stateless by default and don't store memory."""
+        with patch("akd.agents._base.ChatOpenAI") as mock_chat_openai:
+            with patch("akd.agents._base.instructor.from_openai") as mock_instructor:
+                with patch("akd.agents._base.openai.AsyncOpenAI"):
+                    mock_client = MagicMock()
+                    mock_structured_client = AsyncMock()
+                    mock_chat_completions = AsyncMock()
+
+                    # Setup mocks for LangBaseAgent
+                    expected_response = AgentTestOutputSchema(response="Test response")
+                    mock_client.with_structured_output.return_value = (
+                        mock_structured_client
+                    )
+                    mock_structured_client.ainvoke.return_value = expected_response
+                    mock_chat_openai.return_value = mock_client
+
+                    # Setup mocks for InstructorBaseAgent
+                    mock_instructor_client = MagicMock()
+                    mock_instructor_response = MagicMock()
+                    mock_instructor_response.model_dump.return_value = {
+                        "response": "Instructor response",
+                        "metadata": {},
+                    }
+                    mock_instructor_client.chat.completions.create = (
+                        mock_chat_completions
+                    )
+                    mock_chat_completions.return_value = mock_instructor_response
+                    mock_instructor.return_value = mock_instructor_client
+
+                    # Test LangBaseAgent (default stateless)
+                    lang_agent = TestLangBaseAgent()
+                    assert lang_agent.stateless is True
+
+                    test_input = AgentTestInputSchema(query="test query")
+                    result = await lang_agent.arun(test_input)
+
+                    # Memory should remain empty in stateless mode
+                    assert len(lang_agent.memory.messages) == 0
+                    assert isinstance(result, AgentTestOutputSchema)
+
+                    # Test InstructorBaseAgent (default stateless)
+                    instructor_agent = TestInstructorBaseAgent()
+                    assert instructor_agent.stateless is True
+
+                    result = await instructor_agent.arun(test_input)
+
+                    # Memory should remain empty in stateless mode
+                    assert len(instructor_agent.memory) == 0
+                    assert isinstance(result, AgentTestOutputSchema)
 
     def test_schema_validation_integration(self):
         """Test that agents properly validate input/output schemas."""
@@ -465,7 +522,7 @@ class TestBaseAgentSharedFunctionality:
         # This test verifies agents can handle initialization gracefully
         # Even with potential configuration issues
         with patch("akd.agents._base.ChatOpenAI") as mock_chat_openai:
-            with patch("akd.agents._base.instructor.from_openai") as mock_instructor:
+            with patch("akd.agents._base.instructor.from_openai"):
                 with patch("akd.agents._base.openai.AsyncOpenAI"):
                     # Test that agents initialize even with mock failures
                     mock_chat_openai.side_effect = Exception(


### PR DESCRIPTION
### Summary :memo:

This PR refactors the base agent classes (`LangBaseAgent` and `InstructorBaseAgent`) to be **stateless by default**. A new `stateless` configuration flag has been introduced, which controls whether the agent maintains conversation history across multiple `arun` calls. When `stateless=True` (the new default), the agent's memory is not updated, making each call independent.

### Details

1.  **Added `stateless` Config Flag**: A new boolean field `stateless` was added to `BaseAgentConfig`, which defaults to `True`.
2.  **Refactored `_arun` Method**: The `_arun` method in the base classes now creates a temporary message history for each call when in stateless mode. The agent's persistent `self.memory` is only updated if `stateless` is set to `False`.
3.  **Updated Unit Tests**: Tests were updated to reflect the new default behavior. New tests were added to explicitly verify that memory remains empty in stateless mode and is correctly updated in stateful mode (`stateless=False`).


## Usage

The following example demonstrates how to use the agent in its default stateless mode. After the `arun` call, the agent's internal memory will remain empty. To persist the conversation history, set `stateless=False` in the configuration.

```python
from akd.agents.query import (
    QueryAgent,
    QueryAgentInputSchema,
    QueryAgentOutputSchema,
)

from akd.agents._base import BaseAgentConfig

# The 'stateless=True' flag ensures memory is not stored after the call.
# This is the default behavior.
_cfg = BaseAgentConfig(
    model_name="gpt-4o-mini", temperature=0.5, stateless=True
)

agent = QueryAgent(_cfg)

_query = "what is the meaning of life"

_output = await agent.arun(QueryAgentInputSchema(query=_query, num_queries=3))

print("Agent Output:")
print(_output)

# The agent's memory will be empty because it ran in stateless mode.
print("\nAgent Memory:")
print(agent.memory)
```

### Checks

  - [x] Tested Changes (local coverage 77%, no failure, 315 passed)
  - [ ] Stakeholder Approval