### PR TITLE
Enhance System Prompt with Input Schema Descriptions

### DIFF
--- a/akd/_base.py
+++ b/akd/_base.py
@@ -21,6 +21,7 @@ class BaseConfig(BaseModel):
         "extra": "forbid",  # Disallow extra fields
     }
 
+    description: str | None = None
     debug: bool = False  # Debug mode flag
 
 
@@ -163,6 +164,10 @@ class AbstractBase[
         self.__set_attrs_from_config()
         for key, value in self._kwargs.items():
             setattr(self, key, value)
+
+        self.description = (
+            getattr(self, "description", None) or self.__class__.__doc__ or ""
+        ).strip()
 
     def __set_attrs_from_config(self):
         if self.config is None:

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -11,7 +11,7 @@ from langchain_openai import ChatOpenAI
 from litellm import acompletion, get_model_info
 from litellm.utils import trim_messages
 from loguru import logger
-from pydantic import AnyUrl, BaseModel, Field, model_validator
+from pydantic import AnyUrl, BaseModel, Field, create_model, model_validator
 
 from akd._base import AbstractBase, BaseConfig, InputSchema, OutputSchema
 from akd.configs.project import CONFIG
@@ -34,6 +34,10 @@ class BaseAgentConfig(BaseConfig):
     stateless: bool = Field(
         default=True,
         description="Whether to maintain conversation history/state",
+    )
+    input_hints: bool = Field(
+        default=False,
+        description="Whether to include input schema field information in system prompt",
     )
 
     # Token management
@@ -287,6 +291,27 @@ class InstructorBaseAgent[
         """
         self.memory.clear()
 
+    @property
+    def _input_schema_info(self) -> str:
+        """
+        Extract field names and descriptions from input schema.
+
+        Returns:
+            str: Formatted string with field information, empty if no input schema.
+        """
+        if not hasattr(self, "input_schema") or not self.input_schema:
+            return ""
+
+        field_info = []
+        for field_name, field_info_obj in self.input_schema.model_fields.items():
+            description = field_info_obj.description or "No description provided"
+            field_info.append(f"- **{field_name}**: {description}")
+
+        if not field_info:
+            return ""
+
+        return "\n".join(field_info)
+
     def _default_system_message(self) -> dict[str, str]:
         """
         Returns the default system message.
@@ -294,14 +319,21 @@ class InstructorBaseAgent[
         Returns:
             dict[str, str]: System message dictionary with role and content.
         """
+        content = self.system_prompt
+
+        # Add input schema hints if enabled
+        if self.input_hints:
+            input_info = self._input_schema_info
+            if input_info:
+                content += f"\n\nINPUT FIELD DESCRIPTIONS:\n{input_info}"
+
         return {
             "role": "system",
-            "content": self.system_prompt,
+            "content": content,
         }
 
     def _create_instructor_compatible_model(self, response_model: type[OutputSchema]):
         """Create a model that's compatible with instructor but avoids IOSchema validation."""
-        from pydantic import create_model
 
         # Get the fields from the original model
         fields = {}

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -16,6 +16,7 @@ from pydantic import AnyUrl, BaseModel, Field, create_model, model_validator
 from akd._base import AbstractBase, BaseConfig, InputSchema, OutputSchema
 from akd.configs.project import CONFIG
 from akd.configs.prompts import DEFAULT_SYSTEM_PROMPT
+from akd.utils import get_model_fields
 
 
 class BaseAgentConfig(BaseConfig):
@@ -89,6 +90,11 @@ class BaseAgent[
     This class provides the basic structure for an agent that can handle
     asynchronous operations, manage memory, and utilize a language model
     for generating responses based on user input.
+
+    Notes:
+    - We internally use `_system_prompt` to access actual system prompt that the model sees.
+    - The `_system_prompt` has enhanced prompt based on `input_hints` flag.
+    - We also have `_default_system_message` in InstructorBaseAgent that creates a dict
     """
 
     config_schema = BaseAgentConfig
@@ -111,6 +117,43 @@ class BaseAgent[
 
     def reset_memory(self) -> None:
         pass
+
+    @property
+    def _input_schema_info(self) -> str:
+        """
+        Extract field names and descriptions from input schema.
+
+        Returns:
+            str: Formatted string with field information, empty if no input schema.
+        """
+        if not hasattr(self, "input_schema") or not self.input_schema:
+            return ""
+
+        fields = get_model_fields(self.input_schema, skip_no_description=True)
+        if not fields:
+            return ""
+
+        return "\n".join(
+            [f"- **{field['name']}**: {field['description']}" for field in fields],
+        )
+
+    @property
+    def _system_prompt(self) -> str:
+        """
+        Enhanced system prompt with optional input hints.
+
+        Returns:
+            str: System prompt with input schema information if enabled.
+        """
+        content = self.system_prompt
+
+        # Add input schema hints if enabled
+        if self.input_hints:
+            input_info = self._input_schema_info
+            if input_info:
+                content += f"\n\nINPUT FIELD DESCRIPTIONS:\n{input_info}"
+
+        return content
 
     @abstractmethod
     async def get_response_async(
@@ -168,7 +211,7 @@ class LangBaseAgent[
             [
                 {
                     "role": "system",
-                    "content": self.system_prompt,
+                    "content": self._system_prompt,
                 },
                 MessagesPlaceholder(variable_name="memory"),
             ],
@@ -291,27 +334,6 @@ class InstructorBaseAgent[
         """
         self.memory.clear()
 
-    @property
-    def _input_schema_info(self) -> str:
-        """
-        Extract field names and descriptions from input schema.
-
-        Returns:
-            str: Formatted string with field information, empty if no input schema.
-        """
-        if not hasattr(self, "input_schema") or not self.input_schema:
-            return ""
-
-        field_info = []
-        for field_name, field_info_obj in self.input_schema.model_fields.items():
-            description = field_info_obj.description or "No description provided"
-            field_info.append(f"- **{field_name}**: {description}")
-
-        if not field_info:
-            return ""
-
-        return "\n".join(field_info)
-
     def _default_system_message(self) -> dict[str, str]:
         """
         Returns the default system message.
@@ -319,17 +341,9 @@ class InstructorBaseAgent[
         Returns:
             dict[str, str]: System message dictionary with role and content.
         """
-        content = self.system_prompt
-
-        # Add input schema hints if enabled
-        if self.input_hints:
-            input_info = self._input_schema_info
-            if input_info:
-                content += f"\n\nINPUT FIELD DESCRIPTIONS:\n{input_info}"
-
         return {
             "role": "system",
-            "content": content,
+            "content": self._system_prompt,
         }
 
     def _create_instructor_compatible_model(self, response_model: type[OutputSchema]):

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -147,11 +147,18 @@ class BaseAgent[
         """
         content = self.system_prompt
 
-        # Add input schema hints if enabled
-        if self.input_hints:
-            input_info = self._input_schema_info
-            if input_info:
-                content += f"\n\nINPUT FIELD DESCRIPTIONS:\n{input_info}"
+        # Early return if input hints disabled
+        if not self.input_hints:
+            return content
+
+        # Add agent description if available
+        if self.description:
+            content += f"\n\nAGENT DESCRIPTION:\n{self.description}"
+
+        # Add input schema hints if available
+        input_info = self._input_schema_info
+        if input_info:
+            content += f"\n\nINPUT FIELD DESCRIPTIONS:\n{input_info}"
 
         return content
 

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -26,7 +26,7 @@ class BaseAgentConfig(BaseConfig):
     api_key: str | None = Field(default=CONFIG.model_config_settings.api_keys.openai)
     model_name: str | None = Field(default=CONFIG.model_config_settings.model_name)
     temperature: float = Field(
-        default=0.0,
+        default=CONFIG.model_config_settings.temperature,
         ge=0.0,
         le=2.0,
         description="Sampling temperature",

--- a/akd/tools/_base.py
+++ b/akd/tools/_base.py
@@ -12,7 +12,6 @@ class BaseToolConfig(BaseConfig):
     """
 
     title: Optional[str] = None
-    description: Optional[str] = None
 
 
 class BaseTool[

--- a/akd/utils.py
+++ b/akd/utils.py
@@ -3,10 +3,11 @@ import time
 from abc import abstractmethod
 from pathlib import Path
 from typing import Any, Dict, Optional
-from pydantic import HttpUrl
-import requests
+
 import gdown
+import requests
 from loguru import logger
+from pydantic import BaseModel, HttpUrl
 
 try:
     from langchain_core.tools.structured import StructuredTool
@@ -220,3 +221,41 @@ def is_server_available(url: str | HttpUrl) -> bool:
     except requests.RequestException:
         logger.warning(f"URL {url} is not reachable.")
         return False
+
+
+def get_model_fields(
+    model_class: type[BaseModel],
+    skip_no_description: bool = True,
+) -> list[dict[str, Any]]:
+    """
+    Extract field information from a Pydantic model using the most Pydantic-native approach.
+    Uses Pydantic's built-in model_json_schema() method.
+
+    Args:
+        model_class: Pydantic model class to extract fields from
+        skip_no_description: If True, skip fields without descriptions
+
+    Returns:
+        List of dictionaries containing field information with all schema properties
+        plus 'name' and 'is_required' keys
+    """
+    if not model_class or not hasattr(model_class, "model_json_schema"):
+        return []
+
+    schema = model_class.model_json_schema()
+    properties = schema.get("properties", {})
+    required_fields = set(schema.get("required", []))
+
+    fields_info = []
+    for field_name, field_schema in properties.items():
+        if skip_no_description and not field_schema.get("description"):
+            continue
+
+        field_data = {
+            "name": field_name,
+            "is_required": field_name in required_fields,
+            **field_schema,  # Include all schema properties
+        }
+        fields_info.append(field_data)
+
+    return fields_info

--- a/tests/agents/base/test_instructor_base.py
+++ b/tests/agents/base/test_instructor_base.py
@@ -287,3 +287,75 @@ class TestInstructorBaseAgentFunctionality:
         assert isinstance(result, AgentTestOutputSchema)
         assert result.response == "custom model response"
         assert result.metadata == {"custom": True}
+
+    def test_input_hints_disabled_by_default(
+        self,
+        mock_openai_client,
+        mock_instructor_client,
+    ):
+        """Test that input hints are disabled by default."""
+        agent = TestInstructorBaseAgent()
+
+        system_message = agent._default_system_message()
+
+        # Verify no input hints are present by default
+        assert "INPUT FIELD DESCRIPTIONS:" not in system_message["content"]
+        assert system_message["content"] == agent.system_prompt
+
+    def test_input_hints_enabled(
+        self,
+        mock_openai_client,
+        mock_instructor_client,
+    ):
+        """Test input hints functionality when enabled."""
+        config = BaseAgentConfig(input_hints=True)
+        agent = TestInstructorBaseAgent(config=config)
+
+        system_message = agent._default_system_message()
+
+        # Verify input hints are present
+        assert "INPUT FIELD DESCRIPTIONS:" in system_message["content"]
+        assert "**query**:" in system_message["content"]
+        assert "**optional_param**:" in system_message["content"]
+        assert "Test query input" in system_message["content"]
+        assert "Optional parameter" in system_message["content"]
+
+        # Verify original system prompt is still there
+        assert agent.system_prompt in system_message["content"]
+
+    def test_input_schema_info_property(
+        self,
+        mock_openai_client,
+        mock_instructor_client,
+    ):
+        """Test _input_schema_info property."""
+        agent = TestInstructorBaseAgent()
+
+        schema_info = agent._input_schema_info
+
+        # Verify schema info extraction
+        assert "**query**:" in schema_info
+        assert "**optional_param**:" in schema_info
+        assert "Test query input" in schema_info
+        assert "Optional parameter" in schema_info
+        assert schema_info.startswith("- **query**:")
+
+    def test_input_schema_info_no_schema(
+        self,
+        mock_openai_client,
+        mock_instructor_client,
+    ):
+        """Test _input_schema_info property when no input schema."""
+        agent = TestInstructorBaseAgent()
+
+        # Temporarily remove input schema
+        original_schema = agent.input_schema
+        agent.input_schema = None
+
+        schema_info = agent._input_schema_info
+
+        # Verify empty string returned
+        assert schema_info == ""
+
+        # Restore original schema
+        agent.input_schema = original_schema

--- a/tests/agents/base/test_instructor_base.py
+++ b/tests/agents/base/test_instructor_base.py
@@ -359,3 +359,79 @@ class TestInstructorBaseAgentFunctionality:
 
         # Restore original schema
         agent.input_schema = original_schema
+
+    def test_agent_description_disabled_by_default(
+        self,
+        mock_openai_client,
+        mock_instructor_client,
+    ):
+        """Test that agent description is not included when input hints are disabled."""
+        agent = TestInstructorBaseAgent()
+
+        system_message = agent._default_system_message()
+
+        # Should not include description when input_hints=False (default)
+        assert "AGENT DESCRIPTION:" not in system_message["content"]
+        assert system_message["content"] == agent.system_prompt
+
+    def test_agent_description_with_input_hints_enabled_no_description(
+        self,
+        mock_openai_client,
+        mock_instructor_client,
+    ):
+        """Test behavior when input hints enabled but no agent description available."""
+        config = BaseAgentConfig(input_hints=True)
+        agent = TestInstructorBaseAgent(config=config)
+
+        # Clear the description to simulate no description
+        agent.description = ""
+
+        system_message = agent._default_system_message()
+
+        # Should not include agent description section when description is empty
+        assert "AGENT DESCRIPTION:" not in system_message["content"]
+        # But should still include input hints
+        assert "INPUT FIELD DESCRIPTIONS:" in system_message["content"]
+
+    def test_agent_description_with_input_hints_enabled_with_description(
+        self,
+        mock_openai_client,
+        mock_instructor_client,
+    ):
+        """Test agent description inclusion when input hints enabled and description available."""
+        config = BaseAgentConfig(input_hints=True)
+        agent = TestInstructorBaseAgent(config=config)
+
+        # Set a test description
+        test_description = "This is a test instructor agent for testing purposes"
+        agent.description = test_description
+
+        system_message = agent._default_system_message()
+
+        # Should include both agent description and input hints
+        assert "AGENT DESCRIPTION:" in system_message["content"]
+        assert test_description in system_message["content"]
+        assert "INPUT FIELD DESCRIPTIONS:" in system_message["content"]
+        assert "**query**:" in system_message["content"]
+
+        # Verify order: original prompt, then description, then input hints
+        desc_pos = system_message["content"].find("AGENT DESCRIPTION:")
+        input_pos = system_message["content"].find("INPUT FIELD DESCRIPTIONS:")
+        assert desc_pos < input_pos
+
+    def test_agent_description_from_config(
+        self,
+        mock_openai_client,
+        mock_instructor_client,
+    ):
+        """Test that agent description can be set via config."""
+        test_description = "Instructor agent description from config"
+        config = BaseAgentConfig(input_hints=True, description=test_description)
+        agent = TestInstructorBaseAgent(config=config)
+
+        system_message = agent._default_system_message()
+
+        # Should include the description from config
+        assert "AGENT DESCRIPTION:" in system_message["content"]
+        assert test_description in system_message["content"]
+        assert agent.description == test_description

--- a/tests/agents/base/test_lang_base.py
+++ b/tests/agents/base/test_lang_base.py
@@ -209,3 +209,43 @@ class TestLangBaseAgentFunctionality:
             except Exception as e:
                 # Expected if client creation fails
                 assert "Mock initialization error" in str(e)
+
+    def test_input_hints_disabled_by_default(self, mock_chatopenai_client):
+        """Test that input hints are disabled by default for LangBaseAgent."""
+        agent = TestLangBaseAgent()
+
+        system_prompt = agent._system_prompt
+
+        # Verify no input hints are present by default
+        assert "INPUT FIELD DESCRIPTIONS:" not in system_prompt
+        assert system_prompt == agent.system_prompt
+
+    def test_input_hints_enabled(self, mock_chatopenai_client):
+        """Test input hints functionality when enabled for LangBaseAgent."""
+        config = BaseAgentConfig(input_hints=True)
+        agent = TestLangBaseAgent(config=config)
+
+        system_prompt = agent._system_prompt
+
+        # Verify input hints are present
+        assert "INPUT FIELD DESCRIPTIONS:" in system_prompt
+        assert "**query**:" in system_prompt
+        assert "**optional_param**:" in system_prompt
+        assert "Test query input" in system_prompt
+        assert "Optional parameter" in system_prompt
+
+        # Verify original system prompt is still there
+        assert agent.system_prompt in system_prompt
+
+    def test_prompt_template_uses_system_prompt_property(self, mock_chatopenai_client):
+        """Test that LangBaseAgent prompt template uses _system_prompt property."""
+        config = BaseAgentConfig(input_hints=True)
+        agent = TestLangBaseAgent(config=config)
+
+        # Get the system message from the prompt template
+        formatted_messages = agent.prompt_template.format_messages(memory=[])
+        system_message = formatted_messages[0]
+
+        # Verify the prompt template uses the enhanced system prompt
+        assert "INPUT FIELD DESCRIPTIONS:" in system_message.content
+        assert "**query**:" in system_message.content

--- a/tests/agents/base/test_lang_base.py
+++ b/tests/agents/base/test_lang_base.py
@@ -249,3 +249,82 @@ class TestLangBaseAgentFunctionality:
         # Verify the prompt template uses the enhanced system prompt
         assert "INPUT FIELD DESCRIPTIONS:" in system_message.content
         assert "**query**:" in system_message.content
+
+    def test_agent_description_disabled_by_default(self, mock_chatopenai_client):
+        """Test that agent description is not included when input hints are disabled."""
+        # Create agent with description via docstring
+        agent = TestLangBaseAgent()
+
+        system_prompt = agent._system_prompt
+
+        # Should not include description when input_hints=False (default)
+        assert "AGENT DESCRIPTION:" not in system_prompt
+        assert system_prompt == agent.system_prompt
+
+    def test_agent_description_with_input_hints_enabled_no_description(
+        self,
+        mock_chatopenai_client,
+    ):
+        """Test behavior when input hints enabled but no agent description available."""
+        config = BaseAgentConfig(input_hints=True)
+        agent = TestLangBaseAgent(config=config)
+
+        # Clear the description to simulate no description
+        agent.description = ""
+
+        system_prompt = agent._system_prompt
+
+        # Should not include agent description section when description is empty
+        assert "AGENT DESCRIPTION:" not in system_prompt
+        # But should still include input hints
+        assert "INPUT FIELD DESCRIPTIONS:" in system_prompt
+
+    def test_agent_description_with_input_hints_enabled_with_description(
+        self,
+        mock_chatopenai_client,
+    ):
+        """Test agent description inclusion when input hints enabled and description available."""
+        config = BaseAgentConfig(input_hints=True)
+        agent = TestLangBaseAgent(config=config)
+
+        # Set a test description
+        test_description = "This is a test agent for testing purposes"
+        agent.description = test_description
+
+        system_prompt = agent._system_prompt
+
+        # Should include both agent description and input hints
+        assert "AGENT DESCRIPTION:" in system_prompt
+        assert test_description in system_prompt
+        assert "INPUT FIELD DESCRIPTIONS:" in system_prompt
+        assert "**query**:" in system_prompt
+
+        # Verify order: original prompt, then description, then input hints
+        desc_pos = system_prompt.find("AGENT DESCRIPTION:")
+        input_pos = system_prompt.find("INPUT FIELD DESCRIPTIONS:")
+        assert desc_pos < input_pos
+
+    def test_agent_description_from_class_docstring(self, mock_chatopenai_client):
+        """Test that agent description is extracted from class docstring."""
+        config = BaseAgentConfig(input_hints=True)
+        agent = TestLangBaseAgent(config=config)
+
+        # The TestLangBaseAgent should have a docstring
+        system_prompt = agent._system_prompt
+
+        if agent.description:  # Only test if description exists
+            assert "AGENT DESCRIPTION:" in system_prompt
+            assert agent.description in system_prompt
+
+    def test_agent_description_from_config(self, mock_chatopenai_client):
+        """Test that agent description can be set via config."""
+        test_description = "Agent description from config"
+        config = BaseAgentConfig(input_hints=True, description=test_description)
+        agent = TestLangBaseAgent(config=config)
+
+        system_prompt = agent._system_prompt
+
+        # Should include the description from config
+        assert "AGENT DESCRIPTION:" in system_prompt
+        assert test_description in system_prompt
+        assert agent.description == test_description


### PR DESCRIPTION
### Summary :memo:
This PR introduces a new feature that enhances the agent's system prompt by automatically including descriptions of the `input_schema` fields. This is controlled by a new `input_hints` boolean flag in the `BaseAgentConfig`. When enabled, this "input hinting" provides the LLM with clearer context about the expected input, aiming to improve the accuracy and reliability of its responses.

Fields without descriptions are skipped automatically if this hinting is enabled.

### Details

1. **Added `input_hints` Flag**: A new boolean field `input_hints` was added to `BaseAgentConfig`, defaulting to `False`.
2. **Enhanced System Prompt**: Implemented a new `_system_prompt` property in `BaseAgent` that dynamically appends the formatted input schema information to the user-defined `system_prompt` if `input_hints` is `True`.
3. **Schema Utility**: Created a new utility function, `akd.utils.get_model_fields(...)`, to reliably extract field names, descriptions, and other metadata from a Pydantic model's schema (fields without descriptoins are skipped).
4. **Agent Integration**: Updated both `LangBaseAgent` and `InstructorBaseAgent` to use the new `_system_prompt` property, ensuring consistent behavior across all agent types.
5. **Added Unit Tests**: Wrote comprehensive tests for both agent base classes to verify the functionality of the `input_hints` flag, including scenarios where it is enabled, disabled, and when no input schema is present.

## Bugfix
- Fixed a bug in `akd.agents._base.BaseAgentConfig.temperature` value where it was defaulting to 0.0 hard-coded. Now, it's changed to reflect project global config. This way we can control globally this parameter if we want. Default value in the project config is 0.0 as well.
  - This fixes few things when we are running everything on gpt-5 models whose temperature is only 1.0 in the API. So, changing globally this model without this fix will throw error. Now the bug is fixed.


### Example

```python
from akd._base import InputSchema, OutputSchema
class HaikuAgentInputSchema(InputSchema):
    """
    Input schema that takes in query
    """

    query: str = Field(
        ...,
        description="Query to the haiku agent.",
    )

    topic_steer: str = Field(
        default="5-3-5 format",
        description="Steer in 5-3-5 syllable as possible. Also use sanksrit words in the middle line"
    )


class HaikuAgentOutputSchema(OutputSchema):
    """
    Generate a haiku from given query
    """

    haiku: str = Field(..., description="Haiku content")

class HaikuAgent(LiteLLMInstructorBaseAgent):
    input_schema = HaikuAgentInputSchema
    output_schema = HaikuAgentOutputSchema

config = BaseAgentConfig(input_hints=True, system_prompt="You're a haiku master.")

agent = HaikuAgent(config)

print(agent._system_prompt)
```

```
You're a haiku master.

INPUT FIELD DESCRIPTIONS:
- **query**: Query to the haiku agent.
- **topic_steer**: Steer in 5-3-5 syllable as possible. Also use sanksrit words in the middle line
```

### Checks
- [x] Tested Changes (356 passed, 0 failed, 79% coverage)
- [ ] Stakeholder Approval