### PR TITLE
Update license definition in pyproj.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "akd"
 version = "0.1.0"
 description = "Human-centric Multi-Agent System (MAS) framework for scientific discovery"
 readme = "README.md"
-license = "Apache-2.0"
+license = {text="Apache-2.0"}
 authors = [
     {name = "Nish", email = "np0069@uah.edu"},
     {name = "Kumar", email = "mr0051@uah.edu"}


### PR DESCRIPTION
Running into this error when trying to install AKD core in the backend repo: 

```bash
#12 5.400   × Failed to build `akd @
#12 5.400   │ git+[https://github.com/NASA-IMPACT/accelerated-discovery.git@63002e644be329b07e270b992a2fca3962978b06`](https://github.com/NASA-IMPACT/accelerated-discovery.git@63002e644be329b07e270b992a2fca3962978b06%60)
#12 5.400   ├─▶ The build backend returned an error
#12 5.400   ╰─▶ Call to `setuptools.build_meta.build_wheel` failed (exit status: 1)
#12 5.400 
#12 5.400       [stdout]
#12 5.400       configuration error: `project.license` must be valid exactly by one
#12 5.400       definition (2 matches found):
#12 5.400 
#12 5.400           - keys:
#12 5.400               'file': {type: string}
#12 5.400             required: ['file']
#12 5.400           - keys:
#12 5.400               'text': {type: string}
#12 5.400             required: ['text']
#12 5.400 
#12 5.400       DESCRIPTION:
#12 5.400           `Project license <https://peps.python.org/pep-0621/#license>`_.
#12 5.400 
#12 5.400       GIVEN VALUE:
#12 5.400           "Apache-2.0"
#12 5.400 
#12 5.400       OFFENDING RULE: 'oneOf'
#12 5.400           self.run_setup()
#12 5.400         File
#12 5.400       "/root/.cache/uv/builds-v0/.tmps455c7/lib/python3.12/site-packages/setuptools/build_meta.py",
#12 5.400       line 313, in run_setup
#12 5.400           exec(code, locals())
#12 5.400         File "<string>", line 1, in <module>
#12 5.400         File
#12 5.400       "/root/.cache/uv/builds-v0/.tmps455c7/lib/python3.12/site-packages/setuptools/__init__.py",
#12 5.400       line 103, in setup
#12 5.400           return distutils.core.setup(**attrs)
#12 5.400                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#12 5.400         File
#12 5.400       "/root/.cache/uv/builds-v0/.tmps455c7/lib/python3.12/site-packages/setuptools/_distutils/core.py",
#12 5.400       line 158, in setup
#12 5.400           dist.parse_config_files()
#12 5.400         File
#12 5.400       "/root/.cache/uv/builds-v0/.tmps455c7/lib/python3.12/site-packages/_virtualenv.py",
#12 5.400       line 20, in parse_config_files
#12 5.400           result = old_parse_config_files(self, *args, **kwargs)
#12 5.400                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#12 5.400         File
#12 5.400       "/root/.cache/uv/builds-v0/.tmps455c7/lib/python3.12/site-packages/setuptools/dist.py",
#12 5.400       line 632, in parse_config_files
#12 5.400           pyprojecttoml.apply_configuration(self, filename,
#12 5.400       ignore_option_errors)
#12 5.400         File
#12 5.400       "/root/.cache/uv/builds-v0/.tmps455c7/lib/python3.12/site-packages/setuptools/config/pyprojecttoml.py",
#12 5.400       line 70, in apply_configuration
#12 5.400           config = read_configuration(filepath, True, ignore_option_errors,
#12 5.400       dist)
#12 5.400       
#12 5.400       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
#12 5.400         File
#12 5.400       "/root/.cache/uv/builds-v0/.tmps455c7/lib/python3.12/site-packages/setuptools/config/pyprojecttoml.py",
#12 5.400       line 135, in read_configuration
#12 5.400           validate(subset, filepath)
#12 5.400         File
#12 5.400       "/root/.cache/uv/builds-v0/.tmps455c7/lib/python3.12/site-packages/setuptools/config/pyprojecttoml.py",
#12 5.400       line 59, in validate
#12 5.400           raise ValueError(f"{error}\n{summary}") from None
#12 5.400       ValueError: invalid pyproject.toml config: `project.license`.
#12 5.400       configuration error: `project.license` must be valid exactly by one
#12 5.400       definition (2 matches found):
#12 5.400 
#12 5.400           - keys:
#12 5.400               'file': {type: string}
#12 5.400             required: ['file']
#12 5.400           - keys:
#12 5.400               'text': {type: string}
#12 5.400             required: ['text']
#12 5.400 
#12 5.400 
#12 5.400       hint: This usually indicates a problem with the package or the build
#12 5.400       environment.
#12 5.400   help: `akd` was included because `akd-backend:akd-core` (v1.0.0) depends
#12 5.400         on `akd`
#12 DONE 6.1s
```
