### PR TITLE
Bugfix searchresult item pdf url to be empty in searxng

### DIFF
--- a/akd/tools/search/searxng_search.py
+++ b/akd/tools/search/searxng_search.py
@@ -377,7 +377,7 @@ class SearxNGSearchTool(SearchTool):
         results = [
             SearchResultItem(
                 url=result.pop("url", None),
-                pdf_url=result.pop("pdf_url", None),
+                pdf_url=result.pop("pdf_url", None) or None,
                 title=result.pop("title", None)
                 or "Untitled",  # Ensure title is never None
                 content=result.pop("content", None),


### PR DESCRIPTION
Just a tiny bugfix.

Since the type for `pdf_url` is AnyUrl or None, with empty string it
  was throwing validation error. This is because searxng rest api is giving empty url.