### PR TITLE
Bugfix: Add PDF Content Check to SimpleWebScraper

### DIFF
--- a/akd/tools/scrapers/web_scrapers.py
+++ b/akd/tools/scrapers/web_scrapers.py
@@ -37,6 +37,7 @@ class SimpleWebScraper(WebScraper):
         Raises:
             HTTPError: If the HTTP request fails
             ValueError: If content length exceeds maximum
+            RuntimeError: If the content is a PDF
             RequestException: For other request-related errors
         """
         try:
@@ -46,6 +47,15 @@ class SimpleWebScraper(WebScraper):
             ) as client:
                 response = await client.get(url, headers=self.headers)
                 response.raise_for_status()
+
+                # Check if response is actually a PDF based on Content-Type
+                content_type = response.headers.get("content-type", "").lower()
+                if self.debug:
+                    logger.debug(f"Fetched URL: {url}. Headers: {response.headers}")
+                if "application/pdf" in content_type:
+                    raise RuntimeError(
+                        f"URL returns PDF content (Content-Type: {content_type}), use PDF scraper instead: {url}",
+                    )
 
                 if len(response.content) > self.max_content_length:
                     raise ValueError(

--- a/akd/tools/scrapers/web_scrapers.py
+++ b/akd/tools/scrapers/web_scrapers.py
@@ -141,6 +141,13 @@ class SimpleWebScraper(WebScraper):
 
         html_content = await self._fetch_webpage(str(params.url))
 
+        # Additional check: detect if content is actually PDF binary data
+        # PDFs start with %PDF- magic bytes
+        if html_content.startswith("%PDF-"):
+            raise RuntimeError(
+                f"Fetched content appears to be PDF binary data (starts with %PDF-): {params.url}",
+            )
+
         # Parse HTML with BeautifulSoup
         soup = BeautifulSoup(html_content, "html.parser")
 


### PR DESCRIPTION
**Description:**

### Summary :memo:
This pull request enhances the `SimpleWebScraper` to proactively detect when a URL points to a PDF file. Previously, the scraper would attempt to parse PDF content as HTML, leading to errors or incorrect output. Now, it raises a specific `RuntimeError` with a helpful message guiding the user to use a PDF scraper instead. This fixes the bug introduced by #252 

### Details
_Describe more what you did on changes._
1.  **Content-Type Header Check**: In the `_fetch_webpage` method, the response's `Content-Type` header is now checked. If it contains `application/pdf`, the scraper immediately raises a `RuntimeError`.
2.  **Magic Byte Check**: As a fallback, the `_arun` method now inspects the first few bytes of the downloaded content. If the content begins with `%PDF-` (the magic number for PDF files), it also raises a `RuntimeError`. This handles cases where the server might not provide the correct `Content-Type` header.
3.  **Updated Docstrings**: The docstring for `_fetch_webpage` has been updated to include the new `RuntimeError` that can be raised.

### Bugfixes :bug: (delete if didn't have any)
- Fixes the issue where `SimpleWebScraper` would fail when provided with a URL that returns PDF content.

### Checks
- [x] Tested Changes
- [ ] Stakeholder Approval