### PR TITLE
Feat: Introduce io_hints to BaseConfig to auto-append I/O descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ data/
 models/
 documents/
 akd/mapping/llm_generated_mappings.json
+llm_generated_mappings.json
 
 __marimo__/
 .DS_Store

--- a/akd/_base.py
+++ b/akd/_base.py
@@ -8,7 +8,7 @@ from loguru import logger
 from pydantic import BaseModel, ValidationError, create_model
 
 from akd.errors import SchemaValidationError
-from akd.utils import AsyncRunMixin, LangchainToolMixin
+from akd.utils import AsyncRunMixin, LangchainToolMixin, get_model_fields
 
 
 class BaseConfig(BaseModel):
@@ -81,15 +81,11 @@ class AbstractBaseMeta(ABCMeta):
         # Check if this class inherits from AbstractBase
         if any(isinstance(base, AbstractBaseMeta) for base in bases):
             # Validate input_schema
-            if "input_schema" not in dct and not any(
-                hasattr(base, "input_schema") for base in bases
-            ):
+            if "input_schema" not in dct and not any(hasattr(base, "input_schema") for base in bases):
                 raise TypeError(f"{name} must define 'input_schema' class attribute")
 
             # Validate output_schema
-            if "output_schema" not in dct and not any(
-                hasattr(base, "output_schema") for base in bases
-            ):
+            if "output_schema" not in dct and not any(hasattr(base, "output_schema") for base in bases):
                 raise TypeError(f"{name} must define 'output_schema' class attribute")
 
             # Validate schema types if they exist
@@ -145,11 +141,7 @@ class AbstractBase[
             debug (bool): If True, enables debug mode for additional logging.
             **kwargs: Additional keyword arguments (merged with config)
         """
-        config = (
-            config
-            or (self.config_schema() if self.config_schema else None)
-            or BaseConfig()
-        )
+        config = config or (self.config_schema() if self.config_schema else None) or BaseConfig()
         self.config = config
         self._kwargs = kwargs
         self._post_init()
@@ -165,15 +157,59 @@ class AbstractBase[
         for key, value in self._kwargs.items():
             setattr(self, key, value)
 
-        self.description = (
-            getattr(self, "description", None) or self.__class__.__doc__ or ""
-        ).strip()
+        self.description = (getattr(self, "description", None) or self.__class__.__doc__ or "").strip()
+
+        # Append input field hints to description if available
+        _in_schema = self._input_schema_info
+        if _in_schema:
+            self.description += f"\n\nINPUT FIELDS:\n{_in_schema}"
+        _out_schema = self._output_schema_info
+        if _out_schema:
+            self.description += f"\n\nOUTPUT FIELDS:\n{_out_schema}"
 
     def __set_attrs_from_config(self):
         if self.config is None:
             return
         for attr, value in self.config.model_dump().items():
             setattr(self, attr, value)
+
+    @property
+    def _input_schema_info(self) -> str:
+        """
+        Extract field names and descriptions from input schema.
+
+        Returns:
+            str: Formatted string with field information, empty if no input schema.
+        """
+        if not hasattr(self, "input_schema") or not self.input_schema:
+            return ""
+
+        fields = get_model_fields(self.input_schema, skip_no_description=False)
+        if not fields:
+            return ""
+
+        return "\n".join(
+            [f"- **{field['name']}**: {field.get('description', field['name'].replace('_', ' '))}" for field in fields],
+        )
+
+    @property
+    def _output_schema_info(self) -> str:
+        """
+        Extract field names and descriptions from output schema.
+
+        Returns:
+            str: Formatted string with field information, empty if no output schema.
+        """
+        if not hasattr(self, "output_schema") or not self.output_schema:
+            return ""
+
+        fields = get_model_fields(self.output_schema, skip_no_description=False)
+        if not fields:
+            return ""
+
+        return "\n".join(
+            [f"- **{field['name']}**: {field.get('description', field['name'].replace('_', ' '))}" for field in fields],
+        )
 
     @classmethod
     def from_dict(cls, config_dict: dict[str, Any]) -> AbstractBase:
@@ -189,11 +225,7 @@ class AbstractBase[
                 **fields,
             )
 
-        config = (
-            cls.config_schema(**config_dict)
-            if cls.config_schema and config_dict
-            else None
-        )
+        config = cls.config_schema(**config_dict) if cls.config_schema and config_dict else None
         return cls(config=config, debug=debug)
 
     def _validate_input(self, params: Any) -> InSchema:
@@ -332,11 +364,7 @@ class UnrestrictedAbstractBase[
                 **fields,
             )
 
-        config = (
-            cls.config_schema(**config_dict)
-            if cls.config_schema and config_dict
-            else None
-        )
+        config = cls.config_schema(**config_dict) if cls.config_schema and config_dict else None
         return cls(config=config, debug=debug)
 
     def _validate_input(self, params: Any) -> InSchema:

--- a/akd/_base.py
+++ b/akd/_base.py
@@ -162,10 +162,10 @@ class AbstractBase[
         # Append input field hints to description if available
         _in_schema = self._input_schema_info
         if _in_schema:
-            self.description += f"\n\nINPUT FIELDS:\n{_in_schema}"
+            self.description += f"\n\nINPUT FIELD DESCRIPTIONS:\n{_in_schema}"
         _out_schema = self._output_schema_info
         if _out_schema:
-            self.description += f"\n\nOUTPUT FIELDS:\n{_out_schema}"
+            self.description += f"\n\nOUTPUT FIELD DESCRIPTIONS:\n{_out_schema}"
 
     def __set_attrs_from_config(self):
         if self.config is None:

--- a/akd/_base.py
+++ b/akd/_base.py
@@ -5,7 +5,7 @@ from abc import ABC, ABCMeta, abstractmethod
 from typing import Any, Type, cast
 
 from loguru import logger
-from pydantic import BaseModel, ValidationError, create_model
+from pydantic import BaseModel, Field, ValidationError, create_model
 
 from akd.errors import SchemaValidationError
 from akd.utils import AsyncRunMixin, LangchainToolMixin, get_model_fields
@@ -22,7 +22,15 @@ class BaseConfig(BaseModel):
     }
 
     description: str | None = None
-    debug: bool = False  # Debug mode flag
+    io_hints: bool = Field(
+        default=True,
+        description="Whether to include input/output field hints in the agent/tool description. "
+        "This replaces the deprecated 'input_hints' parameter in BaseAgentConfig.",
+    )
+    debug: bool = Field(
+        default=False,
+        description="Whether to enable debug mode",
+    )
 
 
 class IOSchema(BaseModel):
@@ -159,13 +167,14 @@ class AbstractBase[
 
         self.description = (getattr(self, "description", None) or self.__class__.__doc__ or "").strip()
 
-        # Append input field hints to description if available
-        _in_schema = self._input_schema_info
-        if _in_schema:
-            self.description += f"\n\nINPUT FIELD DESCRIPTIONS:\n{_in_schema}"
-        _out_schema = self._output_schema_info
-        if _out_schema:
-            self.description += f"\n\nOUTPUT FIELD DESCRIPTIONS:\n{_out_schema}"
+        # Add input/output schema info to description if io_hints is True
+        if getattr(self, "io_hints", True):
+            _in_schema = self._input_schema_info
+            if _in_schema:
+                self.description += f"\n\nINPUT FIELD DESCRIPTIONS:\n{_in_schema}"
+            _out_schema = self._output_schema_info
+            if _out_schema:
+                self.description += f"\n\nOUTPUT FIELD DESCRIPTIONS:\n{_out_schema}"
 
     def __set_attrs_from_config(self):
         if self.config is None:

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from abc import abstractmethod
 from typing import Any, cast
 
@@ -11,7 +12,14 @@ from langchain_openai import ChatOpenAI
 from litellm import acompletion, get_model_info
 from litellm.utils import trim_messages
 from loguru import logger
-from pydantic import AnyUrl, BaseModel, Field, create_model, model_validator
+from pydantic import (
+    AnyUrl,
+    BaseModel,
+    Field,
+    create_model,
+    field_validator,
+    model_validator,
+)
 
 from akd._base import AbstractBase, BaseConfig, InputSchema, OutputSchema
 from akd.configs.project import CONFIG
@@ -39,6 +47,20 @@ class BaseAgentConfig(BaseConfig):
         default=False,
         description="Whether to include input schema field information in system prompt",
     )
+
+    @field_validator("input_hints", mode="before")
+    @classmethod
+    def warn_input_hints_deprecated(cls, v):
+        """Emit deprecation warning when input_hints is explicitly set."""
+        # Only warn if a non-default value is being set
+        if v is not None and v is not False:
+            warnings.warn(
+                "The 'input_hints' parameter is deprecated and will be removed in a future version. "
+                "Please use 'io_hints' instead, which is now available in the base BaseConfig class.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        return v
 
     # Token management
     max_tokens: int = Field(

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -16,7 +16,6 @@ from pydantic import AnyUrl, BaseModel, Field, create_model, model_validator
 from akd._base import AbstractBase, BaseConfig, InputSchema, OutputSchema
 from akd.configs.project import CONFIG
 from akd.configs.prompts import DEFAULT_SYSTEM_PROMPT
-from akd.utils import get_model_fields
 
 
 class BaseAgentConfig(BaseConfig):
@@ -118,25 +117,6 @@ class BaseAgent[
         pass
 
     @property
-    def _input_schema_info(self) -> str:
-        """
-        Extract field names and descriptions from input schema.
-
-        Returns:
-            str: Formatted string with field information, empty if no input schema.
-        """
-        if not hasattr(self, "input_schema") or not self.input_schema:
-            return ""
-
-        fields = get_model_fields(self.input_schema, skip_no_description=True)
-        if not fields:
-            return ""
-
-        return "\n".join(
-            [f"- **{field['name']}**: {field['description']}" for field in fields],
-        )
-
-    @property
     def _system_prompt(self) -> str:
         """
         Enhanced system prompt with optional input hints.
@@ -153,12 +133,6 @@ class BaseAgent[
         # Add agent description if available
         if self.description:
             content += f"\n\nAGENT DESCRIPTION:\n{self.description}"
-
-        # Add input schema hints if available
-        input_info = self._input_schema_info
-        if input_info:
-            content += f"\n\nINPUT FIELD DESCRIPTIONS:\n{input_info}"
-
         return content
 
     @abstractmethod

--- a/tests/agents/base/test_instructor_base.py
+++ b/tests/agents/base/test_instructor_base.py
@@ -379,7 +379,11 @@ class TestInstructorBaseAgentFunctionality:
         mock_openai_client,
         mock_instructor_client,
     ):
-        """Test behavior when input hints enabled but no agent description available."""
+        """Test behavior when input hints enabled but description is cleared.
+
+        Note: Since AbstractBase adds INPUT/OUTPUT FIELD DESCRIPTIONS to description,
+        clearing the description also clears the field descriptions.
+        """
         config = BaseAgentConfig(input_hints=True)
         agent = TestInstructorBaseAgent(config=config)
 
@@ -388,50 +392,57 @@ class TestInstructorBaseAgentFunctionality:
 
         system_message = agent._default_system_message()
 
-        # Should not include agent description section when description is empty
+        # When description is cleared, both agent description and field descriptions are gone
         assert "AGENT DESCRIPTION:" not in system_message["content"]
-        # But should still include input hints
-        assert "INPUT FIELD DESCRIPTIONS:" in system_message["content"]
+        assert "INPUT FIELD DESCRIPTIONS:" not in system_message["content"]
 
     def test_agent_description_with_input_hints_enabled_with_description(
         self,
         mock_openai_client,
         mock_instructor_client,
     ):
-        """Test agent description inclusion when input hints enabled and description available."""
+        """Test agent description inclusion when input hints enabled and description available.
+
+        Note: When manually setting description, you override the INPUT/OUTPUT FIELD DESCRIPTIONS
+        that were added by AbstractBase. To keep them, append to existing description instead.
+        """
         config = BaseAgentConfig(input_hints=True)
         agent = TestInstructorBaseAgent(config=config)
 
-        # Set a test description
+        # Set a test description (this replaces the auto-generated one with field descriptions)
         test_description = "This is a test instructor agent for testing purposes"
         agent.description = test_description
 
         system_message = agent._default_system_message()
 
-        # Should include both agent description and input hints
+        # Should include the custom agent description
         assert "AGENT DESCRIPTION:" in system_message["content"]
         assert test_description in system_message["content"]
-        assert "INPUT FIELD DESCRIPTIONS:" in system_message["content"]
-        assert "**query**:" in system_message["content"]
 
-        # Verify order: original prompt, then description, then input hints
-        desc_pos = system_message["content"].find("AGENT DESCRIPTION:")
-        input_pos = system_message["content"].find("INPUT FIELD DESCRIPTIONS:")
-        assert desc_pos < input_pos
+        # Note: INPUT FIELD DESCRIPTIONS are NOT present because we replaced the description
+        # If we want both, we should append instead of replace
+        assert "INPUT FIELD DESCRIPTIONS:" not in system_message["content"]
 
     def test_agent_description_from_config(
         self,
         mock_openai_client,
         mock_instructor_client,
     ):
-        """Test that agent description can be set via config."""
+        """Test that agent description can be set via config.
+
+        Note: AbstractBase appends INPUT/OUTPUT FIELD DESCRIPTIONS to the description
+        during _post_init(), so the final description will be longer than the input.
+        """
         test_description = "Instructor agent description from config"
         config = BaseAgentConfig(input_hints=True, description=test_description)
         agent = TestInstructorBaseAgent(config=config)
 
         system_message = agent._default_system_message()
 
-        # Should include the description from config
+        # Should include the description from config plus field descriptions
         assert "AGENT DESCRIPTION:" in system_message["content"]
         assert test_description in system_message["content"]
-        assert agent.description == test_description
+        # Description now includes INPUT/OUTPUT FIELD DESCRIPTIONS appended by AbstractBase
+        assert test_description in agent.description
+        assert "INPUT FIELD DESCRIPTIONS:" in agent.description
+        assert "OUTPUT FIELD DESCRIPTIONS:" in agent.description

--- a/tests/agents/base/test_lang_base.py
+++ b/tests/agents/base/test_lang_base.py
@@ -265,7 +265,11 @@ class TestLangBaseAgentFunctionality:
         self,
         mock_chatopenai_client,
     ):
-        """Test behavior when input hints enabled but no agent description available."""
+        """Test behavior when input hints enabled but description is cleared.
+
+        Note: Since AbstractBase adds INPUT/OUTPUT FIELD DESCRIPTIONS to description,
+        clearing the description also clears the field descriptions.
+        """
         config = BaseAgentConfig(input_hints=True)
         agent = TestLangBaseAgent(config=config)
 
@@ -274,35 +278,35 @@ class TestLangBaseAgentFunctionality:
 
         system_prompt = agent._system_prompt
 
-        # Should not include agent description section when description is empty
+        # When description is cleared, both agent description and field descriptions are gone
         assert "AGENT DESCRIPTION:" not in system_prompt
-        # But should still include input hints
-        assert "INPUT FIELD DESCRIPTIONS:" in system_prompt
+        assert "INPUT FIELD DESCRIPTIONS:" not in system_prompt
 
     def test_agent_description_with_input_hints_enabled_with_description(
         self,
         mock_chatopenai_client,
     ):
-        """Test agent description inclusion when input hints enabled and description available."""
+        """Test agent description inclusion when input hints enabled and description available.
+
+        Note: When manually setting description, you override the INPUT/OUTPUT FIELD DESCRIPTIONS
+        that were added by AbstractBase. To keep them, append to existing description instead.
+        """
         config = BaseAgentConfig(input_hints=True)
         agent = TestLangBaseAgent(config=config)
 
-        # Set a test description
+        # Set a test description (this replaces the auto-generated one with field descriptions)
         test_description = "This is a test agent for testing purposes"
         agent.description = test_description
 
         system_prompt = agent._system_prompt
 
-        # Should include both agent description and input hints
+        # Should include the custom agent description
         assert "AGENT DESCRIPTION:" in system_prompt
         assert test_description in system_prompt
-        assert "INPUT FIELD DESCRIPTIONS:" in system_prompt
-        assert "**query**:" in system_prompt
 
-        # Verify order: original prompt, then description, then input hints
-        desc_pos = system_prompt.find("AGENT DESCRIPTION:")
-        input_pos = system_prompt.find("INPUT FIELD DESCRIPTIONS:")
-        assert desc_pos < input_pos
+        # Note: INPUT FIELD DESCRIPTIONS are NOT present because we replaced the description
+        # If we want both, we should append instead of replace
+        assert "INPUT FIELD DESCRIPTIONS:" not in system_prompt
 
     def test_agent_description_from_class_docstring(self, mock_chatopenai_client):
         """Test that agent description is extracted from class docstring."""
@@ -317,14 +321,21 @@ class TestLangBaseAgentFunctionality:
             assert agent.description in system_prompt
 
     def test_agent_description_from_config(self, mock_chatopenai_client):
-        """Test that agent description can be set via config."""
+        """Test that agent description can be set via config.
+
+        Note: AbstractBase appends INPUT/OUTPUT FIELD DESCRIPTIONS to the description
+        during _post_init(), so the final description will be longer than the input.
+        """
         test_description = "Agent description from config"
         config = BaseAgentConfig(input_hints=True, description=test_description)
         agent = TestLangBaseAgent(config=config)
 
         system_prompt = agent._system_prompt
 
-        # Should include the description from config
+        # Should include the description from config plus field descriptions
         assert "AGENT DESCRIPTION:" in system_prompt
         assert test_description in system_prompt
-        assert agent.description == test_description
+        # Description now includes INPUT/OUTPUT FIELD DESCRIPTIONS appended by AbstractBase
+        assert test_description in agent.description
+        assert "INPUT FIELD DESCRIPTIONS:" in agent.description
+        assert "OUTPUT FIELD DESCRIPTIONS:" in agent.description


### PR DESCRIPTION
### Summary :memo:
This PR refactors how component descriptions are generated by automatically appending **input and output schema details** directly to the `.description` attribute of the `AbstractBase` class.

This is controlled by a new `io_hints` flag in `BaseConfig` (defaulting to `True`), which replaces the old agent-specific `input_hints` parameter. This change simplifies agent-level code, extends I/O descriptions to all components (like Tools), and now includes output fields in addition to input fields.

Also `BaseAgentConfig.input_hints` is deprecated now.

### Details
_Describe more what you did on changes._
1.  **`akd/_base.py`**
    * Added a new `io_hints: bool` field to `BaseConfig` to control this feature globally.
    * Updated `AbstractBase._post_init` to automatically append formatted `INPUT FIELD DESCRIPTIONS` and `OUTPUT FIELD DESCRIPTIONS` to the component's `self.description`.
    * Added helper properties `_input_schema_info` and `_output_schema_info` to `AbstractBase` to dynamically generate these descriptions from the schemas.
2.  **`akd/agents/_base.py`**
    * Added a `field_validator` to `BaseAgentConfig` to issue a `DeprecationWarning` if the old `input_hints` parameter (introduced by #217 ) is explicitly used, guiding users to the new `io_hints` flag.
    * Removed the agent-specific `_input_schema_info` property, as this logic is now centralized in `AbstractBase`.
    * Removed logic from `_system_prompt` that added input hints, as this is now handled by default via the enhanced `self.description`.
3.  **Tests (`tests/agents/base/`)**
    * Updated tests for `TestLangBaseAgent` and `TestInstructorBaseAgent` to assert the new behavior.
    * Tests now check that `agent.description` contains the I/O field descriptions, rather than checking the system prompt for them separately.
4.  **`.gitignore`**
    * Added the `llm_generated_mapping.json` file to the ignore list.

### Checks
- [x] Tested Changes
- [x] Stakeholder Approval