### PR TITLE
Implement Reciprocal Rank Fusion (RRF) Utility

### DIFF
--- a/akd/utils.py
+++ b/akd/utils.py
@@ -334,10 +334,6 @@ def reciprocal_rank_fusion(
     if not results:
         return []
 
-    # Just return single result set if only one provided
-    if len(results) == 1:
-        return results[0]
-
     rrf_map = defaultdict(float)
     item_map = {}
 
@@ -358,6 +354,9 @@ def reciprocal_rank_fusion(
         item.extra = item.extra or {}
         item.extra["rrf_score"] = rrf_score
         fused_results.append(item)
+
+    if not fused_results:
+        return []
 
     # Normalize scores if requested
     if normalize:

--- a/akd/utils.py
+++ b/akd/utils.py
@@ -1,15 +1,20 @@
 import asyncio
 import time
 from abc import abstractmethod
+from collections import defaultdict
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 import dateparser
 import gdown
+import numpy as np
 import requests
 from loguru import logger
 from pydantic import BaseModel, HttpUrl
+
+if TYPE_CHECKING:
+    from akd.structures import SearchResultItem
 
 try:
     from langchain_core.tools.structured import StructuredTool
@@ -296,3 +301,77 @@ def parse_date(date_input: str | int | None) -> datetime | None:
         parsed_date = dateparser.parse(date_input)
 
     return parsed_date
+
+
+def reciprocal_rank_fusion(
+    *results: list["SearchResultItem"],
+    k: int = 60,
+    key: str = "url",
+    normalize: bool = True,
+) -> list["SearchResultItem"]:
+    """
+    Fuse multiple ranked lists using Reciprocal Rank Fusion (RRF).
+
+    Formula: RRF_score(item) = Σ(1 / (k + rank)) across all lists containing item
+
+    Args:
+        results: Variable number of ranked result lists (one per query).
+        k: RRF constant (default 60, standard value from literature).
+        key: Attribute name to use as deduplication key (default "url").
+        normalize: If True, apply min-max normalization to scores [0.1, 1.0] (default True).
+                  Raw RRF scores are always preserved in item.extra["rrf_score"].
+
+    Returns:
+        Fused list sorted by RRF score (descending).
+
+    Examples:
+        >>> results_q1 = [item_a, item_b, item_c]
+        >>> results_q2 = [item_b, item_d, item_a]
+        >>> fused = reciprocal_rank_fusion(results_q1, results_q2)
+        # item_b and item_a appear in both, so they get boosted
+    """
+    # Return empty if no results
+    if not results:
+        return []
+
+    # Just return single result set if only one provided
+    if len(results) == 1:
+        return results[0]
+
+    rrf_map = defaultdict(float)
+    item_map = {}
+
+    # Calculate RRF scores
+    for rank_list in results:
+        for rank, item in enumerate(rank_list, 1):
+            identifier = getattr(item, key, None)
+            if identifier:
+                rrf_map[identifier] += 1.0 / (rank + k)
+                if identifier not in item_map:
+                    item_map[identifier] = item.model_copy()  # Copy to avoid mutation
+
+    # Build results with RRF scores
+    fused_results = []
+    for identifier, rrf_score in sorted(rrf_map.items(), key=lambda x: x[1], reverse=True):
+        item = item_map[identifier]
+        item.score = rrf_score
+        item.extra = item.extra or {}
+        item.extra["rrf_score"] = rrf_score
+        fused_results.append(item)
+
+    # Normalize scores if requested
+    if normalize:
+        scores = np.array([item.score for item in fused_results])
+        score_range = scores.max() - scores.min()
+
+        if score_range > 0:
+            # Scale to [0.1, 1.0] range to avoid 0.0 scores
+            normalized_scores = 0.1 + 0.9 * (scores - scores.min()) / score_range
+        else:
+            # All scores are the same
+            normalized_scores = np.ones_like(scores)
+
+        for item, norm_score in zip(fused_results, normalized_scores):
+            item.score = float(norm_score)
+
+    return fused_results

--- a/tests/utils/test_rrf.py
+++ b/tests/utils/test_rrf.py
@@ -1,0 +1,155 @@
+"""Tests for reciprocal_rank_fusion utility function."""
+
+import pytest
+
+from akd.structures import SearchResultItem
+from akd.utils import reciprocal_rank_fusion
+
+
+class TestReciprocalRankFusion:
+    """Test suite for RRF (Reciprocal Rank Fusion) implementation."""
+
+    def test_single_query_maintains_order(self):
+        """Test that single query results maintain order with normalized scores."""
+        results = [
+            SearchResultItem(url="https://example.com/a", title="A", query="test", content="Content A"),
+            SearchResultItem(url="https://example.com/b", title="B", query="test", content="Content B"),
+            SearchResultItem(url="https://example.com/c", title="C", query="test", content="Content C"),
+        ]
+
+        fused = reciprocal_rank_fusion(results)
+
+        assert len(fused) == 3
+        # URLs should maintain order
+        assert str(fused[0].url) == "https://example.com/a"
+        assert str(fused[1].url) == "https://example.com/b"
+        assert str(fused[2].url) == "https://example.com/c"
+        # Top item gets 1.0, bottom gets 0.1
+        assert fused[0].score == pytest.approx(1.0)
+        assert fused[2].score == pytest.approx(0.1)
+
+    def test_common_items_get_boosted(self):
+        """Test that items appearing in multiple queries get higher scores."""
+        results_1 = [
+            SearchResultItem(url="https://example.com/a", title="A", query="q1", content=""),
+            SearchResultItem(url="https://example.com/b", title="B", query="q1", content=""),
+        ]
+
+        results_2 = [
+            SearchResultItem(url="https://example.com/b", title="B", query="q2", content=""),
+            SearchResultItem(url="https://example.com/c", title="C", query="q2", content=""),
+        ]
+
+        fused = reciprocal_rank_fusion(results_1, results_2)
+
+        # B appears in both queries, should be top
+        assert str(fused[0].url) == "https://example.com/b"
+        assert fused[0].score == pytest.approx(1.0)  # Highest normalized score
+
+    def test_rrf_score_in_extra(self):
+        """Test that raw RRF scores are preserved in extra field."""
+        results = [
+            SearchResultItem(url="https://example.com/a", title="A", query="test", content=""),
+        ]
+
+        fused = reciprocal_rank_fusion(results)
+
+        assert "rrf_score" in fused[0].extra
+        # Single item at rank 1: RRF = 1/(60+1)
+        assert fused[0].extra["rrf_score"] == pytest.approx(1.0 / 61)
+
+    def test_empty_results(self):
+        """Test handling of empty query results."""
+        fused = reciprocal_rank_fusion()
+        assert fused == []
+
+    def test_normalization_disabled(self):
+        """Test RRF without normalization returns raw scores."""
+        results = [
+            SearchResultItem(url="https://example.com/a", title="A", query="test", content=""),
+            SearchResultItem(url="https://example.com/b", title="B", query="test", content=""),
+        ]
+
+        fused = reciprocal_rank_fusion(results, normalize=False)
+
+        # Without normalization, scores are raw RRF
+        assert fused[0].score == pytest.approx(1.0 / 61)  # rank 1
+        assert fused[1].score == pytest.approx(1.0 / 62)  # rank 2
+
+    def test_normalization_range(self):
+        """Test that normalized scores are in [0.1, 1.0] range."""
+        results = [
+            SearchResultItem(url="https://example.com/a", title="A", query="test", content=""),
+            SearchResultItem(url="https://example.com/b", title="B", query="test", content=""),
+            SearchResultItem(url="https://example.com/c", title="C", query="test", content=""),
+        ]
+
+        fused = reciprocal_rank_fusion(results, normalize=True)
+
+        scores = [item.score for item in fused]
+        assert max(scores) == pytest.approx(1.0)
+        assert min(scores) == pytest.approx(0.1)
+
+    def test_custom_k_parameter(self):
+        """Test that custom k parameter affects RRF scoring."""
+        results = [
+            SearchResultItem(url="https://example.com/a", title="A", query="test", content=""),
+        ]
+
+        fused_k60 = reciprocal_rank_fusion(results, k=60, normalize=False)
+        fused_k10 = reciprocal_rank_fusion(results, k=10, normalize=False)
+
+        # Lower k means higher scores
+        assert fused_k10[0].score > fused_k60[0].score
+
+    def test_custom_deduplication_key(self):
+        """Test using custom deduplication key like DOI."""
+        results_1 = [
+            SearchResultItem(
+                url="https://example.com/a",
+                title="A",
+                query="q1",
+                content="",
+                doi="10.1234/a",
+            ),
+        ]
+
+        results_2 = [
+            SearchResultItem(
+                url="https://different.com/a",
+                title="A",
+                query="q2",
+                content="",
+                doi="10.1234/a",
+            ),
+        ]
+
+        # Using URL key - should get 2 items (different URLs)
+        fused_url = reciprocal_rank_fusion(results_1, results_2, key="url")
+        assert len(fused_url) == 2
+
+        # Using DOI key - should get 1 item (same DOI, deduplicated)
+        fused_doi = reciprocal_rank_fusion(results_1, results_2, key="doi")
+        assert len(fused_doi) == 1
+
+    def test_original_items_not_mutated(self):
+        """Test that original SearchResultItems are not mutated."""
+        original = SearchResultItem(url="https://example.com/a", title="A", query="test", content="")
+
+        fused = reciprocal_rank_fusion([original])
+
+        # Original should not have score set
+        assert original.score is None
+        # Result should have score
+        assert fused[0].score is not None
+
+    def test_single_item_normalized_to_one(self):
+        """Test that single item gets score 1.0 when normalized."""
+        results = [
+            SearchResultItem(url="https://example.com/a", title="A", query="test", content=""),
+        ]
+
+        fused = reciprocal_rank_fusion(results, normalize=True)
+
+        # Single item gets 1.0 (no range to normalize)
+        assert fused[0].score == pytest.approx(1.0)


### PR DESCRIPTION
### Summary :memo:
This PR introduces a new utility function, `reciprocal_rank_fusion`, in `akd/utils.py`. This function implements the Reciprocal Rank Fusion (RRF) algorithm to merge multiple lists of search results into a single, reranked list. It boosts items that appear in multiple result sets, providing a more relevant combined ranking.


### Details
_Describe more what you did on changes._
1.  **Added `reciprocal_rank_fusion` function:** This core function takes one or more lists of `SearchResultItem` objects and calculates their RRF scores using the formula $`\text{RRF\_score} = \sum (1 / (k + \text{rank}))`$.
2.  **Configurable Deduplication:** The function allows specifying a `key` (defaulting to `url`) to identify and merge items across lists (e.g., can be set to `doi`).
3.  **Score Normalization:** By default, the final scores are min-max normalized to a range of `[0.1, 1.0]` for consistent output. The raw, non-normalized RRF score is preserved in the `item.extra["rrf_score"]` field for reference.
4.  **Added Unit Tests:** A new test file, `tests/utils/test_rrf.py`, was created to validate the RRF implementation. Tests cover normalization, custom `k` values, custom deduplication keys, and edge cases like empty inputs.


## Usage

```python
from akd.structures import SearchResultItem
from akd.utils import reciprocal_rank_fusion

# --- Example 1: Basic fusion of two result lists ---
results_q1 = [
    SearchResultItem(url="https://example.com/a", title="A", ...),
    SearchResultItem(url="https://example.com/b", title="B", ...),
]
results_q2 = [
    SearchResultItem(url="https://example.com/b", title="B", ...), # This item will be boosted
    SearchResultItem(url="https://example.com/c", title="C", ...),
]

# Fuses lists, deduplicates by 'url', and normalizes scores to [0.1, 1.0]
fused_list = reciprocal_rank_fusion(results_q1, results_q2)

# fused_list[0].url will be "https://example.com/b" with a score of 1.0

# --- Example 2: Disabling normalization ---
# Returns raw RRF scores (e.g., 1/61, 1/62, ...)
raw_score_list = reciprocal_rank_fusion(results_q1, normalize=False)

# --- Example 3: Using a custom deduplication key (like DOI) ---
item1 = SearchResultItem(url="https://source1.com/a", doi="10.1234/a", ...)
item2 = SearchResultItem(url="https://source2.com/a", doi="10.1234/a", ...) # Same DOI, different URL

# This will merge item1 and item2 into a single entry based on their DOI
doi_fused_list = reciprocal_rank_fusion([item1], [item2], key="doi")
# len(doi_fused_list) == 1
```

### Checks
- [x] Tested Changes
- [ ] Stakeholder Approval

---


### PS

- I want to apply this RRF algorithm to all the search tool. So, sometimes later this week or early next week, there will be series of PR that incorporates better ranking to search tool