### PR TITLE
Changed DAGMetric type to Any in risk output schema to avoid JSON schema conversion error

### DIFF
--- a/akd/agents/risk/risk.py
+++ b/akd/agents/risk/risk.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Dict, List, Optional, Self
+from typing import Any, Dict, List, Optional, Self
 
 import yaml
 from deepeval.metrics import DAGMetric
@@ -66,11 +66,7 @@ class RiskAgentInputSchema(InputSchema):
                 raise ValueError(
                     f"risk_weights keys {sorted(extra)} are not in risk_ids {sorted(self.risk_ids)}",
                 )
-            nonpos = {
-                k: v
-                for k, v in self.risk_weights.items()
-                if not (isinstance(v, (int, float)) and v > 0)
-            }
+            nonpos = {k: v for k, v in self.risk_weights.items() if not (isinstance(v, (int, float)) and v > 0)}
             if nonpos:
                 raise ValueError(
                     f"risk_weights must be positive numbers; got {nonpos}",
@@ -115,7 +111,7 @@ class RiskAgentOutputSchema(OutputSchema):
         ...,
         description="A mapping of risk IDs to sructured evaluation criteria.",
     )
-    dag_metric: DAGMetric = Field(
+    dag_metric: Optional[Any] = Field(
         ...,
         description="A DeepEval DAG metric constructed from the risk criteria.",
     )
@@ -288,9 +284,7 @@ class RiskAgent(
 
                 node = TaskNode(
                     output_label=f"{risk_id}_{i + 1}",
-                    instructions=(
-                        f"{criterion.description}\nAnswer strictly with True or False."
-                    ),
+                    instructions=(f"{criterion.description}\nAnswer strictly with True or False."),
                     evaluation_params=[
                         LLMTestCaseParams.INPUT,
                         LLMTestCaseParams.ACTUAL_OUTPUT,
@@ -318,8 +312,7 @@ class RiskAgent(
             m_required = (m_total + 1) // 2  # ceil
             # Borderline = exactly one below required (only meaningful if m_total > 0)
             borderline_expr = (
-                "True if the count of True among the MEDIUM set equals "
-                f"{max(m_required - 1, 0)}; otherwise False."
+                f"True if the count of True among the MEDIUM set equals {max(m_required - 1, 0)}; otherwise False."
                 if m_total > 0
                 else "False"
             )


### PR DESCRIPTION
Changed DAGMetric type to Any in risk output schema to avoid JSON schema conversion error

### Summary :memo:
@NISH1001 As discussed yesterday, new output schema is:

```python
class RiskAgentOutputSchema(OutputSchema):
    """
    Output schema for Risk Agent.
    """

    criteria_by_risk: Dict[str, List[Criterion]] = Field(
        ...,
        description="A mapping of risk IDs to sructured evaluation criteria.",
    )
    dag_metric: Optional[Any] = Field(
        ...,
        description="A DeepEval DAG metric constructed from the risk criteria.",
    )
    model_config = ConfigDict(arbitrary_types_allowed=True)
```

### Details
1. Changed `dag_metric` type from `DAGMetric` to `Optional[Any]`

### Bugfixes :bug: 
- Fixed following failing unit tests:
```
FAILED tests/agents/risk/test_risk_agent.py::test_risk_agent_dag_generation - pydantic.errors.PydanticInvalidForJsonSchema: Cannot generate a JsonSchema for core_schema.IsInstanceSchema (<class 'deepeval.metrics.dag.dag.DAGMetric'>)
FAILED tests/agents/risk/test_risk_agent.py::test_build_dag_structure - pydantic.errors.PydanticInvalidForJsonSchema: Cannot generate a JsonSchema for core_schema.IsInstanceSchema (<class 'deepeval.metrics.dag.dag.DAGMetric'>)
```

### Checks
- [ ] Closed #798
- [x] Tested Changes
- [ ] Stakeholder Approval
