### PR TITLE
Bugfix(agent): Fix hardcoded result cap in Deep lit search agent

### DIFF
--- a/akd/agents/search/_base.py
+++ b/akd/agents/search/_base.py
@@ -71,6 +71,11 @@ class SearchAgentConfig(BaseAgentConfig):
         default=5,
         description="Maximum number of search iterations",
     )
+    # used to limit results per iteration
+    max_results: int = Field(
+        default=50,
+        description="Maximum number of search results to retrieve by the agent (hard limit). This is not used for capping search tool results, which is controlled by SearchMode or 'max_results' from kwargs.",
+    )
 
 
 class SearchAgent[TInput: SearchAgentInputSchema, TOutput: SearchAgentOutputSchema](

--- a/akd/agents/search/_base.py
+++ b/akd/agents/search/_base.py
@@ -27,9 +27,9 @@ class SearchMode(str, Enum):
         """Convert search mode to maximum number of results."""
         mapping = {
             SearchMode.FAST: 10,
-            SearchMode.MEDIUM: 20,
-            SearchMode.LONG: 50,
-            SearchMode.EXTENSIVE: 100,
+            SearchMode.MEDIUM: 50,
+            SearchMode.LONG: 100,
+            SearchMode.EXTENSIVE: 200,
         }
         return mapping[self]
 

--- a/akd/agents/search/_base.py
+++ b/akd/agents/search/_base.py
@@ -74,7 +74,7 @@ class SearchAgentConfig(BaseAgentConfig):
     # used to limit results per iteration
     max_results: int = Field(
         default=50,
-        description="Maximum number of search results to retrieve by the agent (hard limit). This is not used for capping search tool results, which is controlled by SearchMode or 'max_results' from kwargs.",
+        description="Maximum number of search results to retrieve by the agent (hard limit). This is not used for capping search tool results, which is controlled by SearchMode or 'search_max_results' from kwargs.",
     )
 
 

--- a/akd/agents/search/deep_search.py
+++ b/akd/agents/search/deep_search.py
@@ -548,14 +548,14 @@ class DeepLitSearchAgent(LitBaseAgent):
         5. Return structured results
 
         Note 1: The maximum number of results to retrieve while running the DeepLitSearchAgent.search_tool is controlled  either:
-        - By `SearchMode` from `params.search_mode` (if kwargs does not specify `max_results`). This is the user-facing paramter to control search.
-        - By passing `max_results` in `kwargs` (overrides SearchMode). This is useful for dev-mode
+        - By `SearchMode` from `params.search_mode` (if kwargs does not specify `search_max_results`). This is the user-facing paramter to control search.
+        - By passing `search_max_results` in `kwargs` (overrides SearchMode). This is useful for dev-mode
 
         Note 2:
         - The `DeepLitSearchAgentConfig.max_results` parameter is a hard cap on the total number of results the agent will keep track of during research to control the research iteration. (TODO: Implement reranking at before capping.)
         """
         original_query = params.query
-        max_results = kwargs.get("max_results", params.search_mode.to_max_results())
+        max_results = kwargs.get("search_max_results", params.search_mode.to_max_results())
         logger.info(f"DeepLitSearchAgent with params: {params}")
         logger.debug(f"DeepLitSearchAgent | max_results = {max_results}")
 

--- a/akd/agents/search/deep_search.py
+++ b/akd/agents/search/deep_search.py
@@ -225,6 +225,7 @@ class DeepLitSearchAgent(LitBaseAgent):
         self,
         instructions: str,
         original_query: str,
+        max_results: int,
     ) -> dict:
         """
         Perform the actual deep research using iterative search and synthesis.
@@ -254,8 +255,9 @@ class DeepLitSearchAgent(LitBaseAgent):
 
             # Perform searches
             search_results = await self._execute_searches(
-                initial_queries,
-                original_query,
+                queries=initial_queries,
+                max_results=max_results,
+                original_query=original_query,
                 is_reformulated=(iterations > 1),
             )
 
@@ -349,6 +351,7 @@ class DeepLitSearchAgent(LitBaseAgent):
     async def _execute_searches(
         self,
         queries: List[str],
+        max_results: int,
         original_query: str | None = None,
         is_reformulated: bool = False,
     ) -> List[SearchResultItem]:
@@ -369,7 +372,9 @@ class DeepLitSearchAgent(LitBaseAgent):
         try:
             tool_input = self.search_tool.input_schema(
                 queries=queries,
+                max_results=max_results,
             )
+            logger.debug(f"Executing search tool: {type(self.search_tool).__name__} with params: {tool_input}")
             tasks.append(
                 asyncio.create_task(
                     self.search_tool.arun(
@@ -545,6 +550,9 @@ class DeepLitSearchAgent(LitBaseAgent):
         5. Return structured results
         """
         original_query = params.query
+        max_results = kwargs.get("max_results", params.search_mode.to_max_results())
+        logger.info(f"DeepLitSearchAgent with params: {params}")
+        logger.debug(f"DeepLitSearchAgent | max_results = {max_results}")
 
         # Step 1: Triage the query using embedded component
         triage_result = await self._handle_triage(original_query)
@@ -582,6 +590,7 @@ class DeepLitSearchAgent(LitBaseAgent):
         research_output = await self._perform_deep_research(
             instructions,
             original_query,
+            max_results=max_results,
         )
 
         # Step 5: Generate shortform answer and report

--- a/akd/agents/search/deep_search.py
+++ b/akd/agents/search/deep_search.py
@@ -269,14 +269,11 @@ class DeepLitSearchAgent(LitBaseAgent):
             new_results = self._deduplicate_results(search_results, all_results)
             all_results.extend(new_results)
 
-            # Cap total results to prevent memory issues
-            if len(all_results) > 50:
-                all_results = all_results[:50]
+            # HARD Cap total results
+            # TODO: Implement reranking before capping
+            # Note: Search tool already implements reranking though. `new_results` is already reranked.
+            all_results = all_results[: self.config.max_results]
 
-                if self.debug:
-                    logger.debug(
-                        f"Capped results: keeping first {len(all_results)} results",
-                    )
             # Evaluate quality
             if new_results:
                 quality_score = await self._evaluate_research_quality(
@@ -322,6 +319,7 @@ class DeepLitSearchAgent(LitBaseAgent):
             "citations": research_output.citations,
             "iterations_performed": iterations,
             "results": all_results,
+            "research_traces": research_trace,
         }
 
     async def _generate_initial_queries(self, instructions: str) -> List[str]:
@@ -548,6 +546,13 @@ class DeepLitSearchAgent(LitBaseAgent):
         3. Build research instructions
         4. Perform deep research
         5. Return structured results
+
+        Note 1: The maximum number of results to retrieve while running the DeepLitSearchAgent.search_tool is controlled  either:
+        - By `SearchMode` from `params.search_mode` (if kwargs does not specify `max_results`). This is the user-facing paramter to control search.
+        - By passing `max_results` in `kwargs` (overrides SearchMode). This is useful for dev-mode
+
+        Note 2:
+        - The `DeepLitSearchAgentConfig.max_results` parameter is a hard cap on the total number of results the agent will keep track of during research to control the research iteration. (TODO: Implement reranking at before capping.)
         """
         original_query = params.query
         max_results = kwargs.get("max_results", params.search_mode.to_max_results())
@@ -617,5 +622,6 @@ class DeepLitSearchAgent(LitBaseAgent):
                 "evidence_quality_score": research_output["evidence_quality_score"],
                 "citations": research_output["citations"],
                 "answer_reasoning_traces": shortform_answer.reasoning_traces,
+                "research_traces": research_output.get("research_traces", []),
             },
         )

--- a/akd/tools/search/searxng.py
+++ b/akd/tools/search/searxng.py
@@ -162,8 +162,8 @@ class SearxNGSearchTool(SearchTool):
                 search_results.append(
                     SearchResultItem(
                         url=result.pop("url", None),
-                        title=result.pop("title", "Untitled"),
-                        content=result.pop("content", ""),
+                        title=result.pop("title", "Untitled") or "",
+                        content=result.pop("content", "") or "",
                         query=query,
                         pdf_url=result.pop("pdf_url", None),
                         category=result.pop("category", None),

--- a/tests/agents/search/test_deep_search.py
+++ b/tests/agents/search/test_deep_search.py
@@ -512,7 +512,7 @@ class TestDeepLitSearchAgentSearchExecution:
         agent = DeepLitSearchAgent(config=config, search_tool=mock_search_pipeline)
 
         queries = ["artificial intelligence applications", "machine learning research"]
-        results = await agent._execute_searches(queries)
+        results = await agent._execute_searches(queries, max_results=SearchMode.FAST.to_max_results())
 
         assert len(results) == 1
         assert results[0].title == "Research Paper 1"
@@ -544,7 +544,7 @@ class TestDeepLitSearchAgentSearchExecution:
         )
 
         queries = ["machine learning research"]
-        results = await agent._execute_searches(queries)
+        results = await agent._execute_searches(queries, max_results=SearchMode.FAST.to_max_results())
 
         assert len(results) == 1
         assert any(r.title == "Primary Paper" for r in results)
@@ -582,6 +582,7 @@ class TestDeepLitSearchAgentSearchExecution:
         queries = ["machine learning"]
         results = await agent._execute_searches(
             queries,
+            max_results=SearchMode.FAST.to_max_results(),
             original_query="machine learning",
         )
 
@@ -1102,7 +1103,7 @@ class TestDeepLitSearchAgentCoreMethods:
             search_tool=mock_search_pipeline,
         )
 
-        results = await agent._execute_searches(["test query"])
+        results = await agent._execute_searches(["test query"], max_results=SearchMode.FAST.to_max_results())
 
         assert len(results) == 2
         # First result: no full text enhancement


### PR DESCRIPTION
### Summary :memo:
This PR fixes two critical bugs in the `DeepLitSearchAgent` related to how search results were limited. Previously, the agent would hardcode a cap of 50 total results, and it also failed to pass any `max_results` limit to the search tool, causing it to use its own default.

This fix properly flows the `max_results` parameter (from the new `search_max_results` kwarg or `SearchMode`) down to the search tool, and replaces the hardcoded cap with a new configurable `max_results` on the `SearchAgentConfig`.

### Bugfixes :bug:
- **Fixed hardcoded total result limit**: In `_perform_deep_research`, the agent was incorrectly capping the total results to a hardcoded value of 50 (`all_results = all_results[:50]`). This has been replaced with `self.config.max_results` (which defaults to 50) to make this cap intentional and configurable.
- **Fixed search tool not receiving `max_results`**: The `_execute_searches` method was calling `self.search_tool.arun` *without* passing a `max_results` parameter. This meant the search tool was just using its own internal default, ignoring the agent's `SearchMode` settings. The `max_results` value is now correctly passed through.

### Details
_Describe more what you did on changes._
1.  **Added `search_max_results` kwarg**: The `_arun` method now checks for `kwargs.get("search_max_results")` to determine the *per-iteration* search limit. If not found, it defaults to the `SearchMode` value.
2.  **Propagated `max_results`**: This `max_results` variable is now correctly passed from `_arun` -> `_perform_deep_research` -> `_execute_searches` -> `self.search_tool.arun`.
3.  **Added `max_results` to `SearchAgentConfig`**: Introduced `max_results: int` in `akd/agents/search/_base.py`. This value is now used as the *total hard cap* for accumulated results, replacing the old hardcoded `[:50]`.
4.  **Updated Tests**: All calls to `_execute_searches` in `tests/agents/search/test_deep_search.py` were updated to pass the newly required `max_results` parameter, fixing the test suite.
5.  **Increased `SearchMode` defaults**: As part of this fix, the defaults in `to_max_results` were increased (`MEDIUM`: 50, `LONG`: 100, `EXTENSIVE`: 200).
6.  **`searxng` tool fix**: Added an `or ""` fallback when popping `title` and `content` to prevent errors if the keys exist but have `None` values.

### Checks
- [x] Tested Changes (Unit tests updated and passing)
- [ ] Stakeholder Approval