### PR TITLE
Add num_retries paramter to BaseAgentConfig

### DIFF
--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -64,6 +64,12 @@ class BaseAgentConfig(BaseConfig):
         default=True,
         description="Enable automatic message trimming",
     )
+    num_retries: int = Field(
+        default=1,
+        ge=1,
+        le=5,
+        description="Number of retries for LLM calls",
+    )
 
     @model_validator(mode="after")
     def validate_max_tokens_against_model(self):
@@ -539,6 +545,7 @@ class LiteLLMInstructorBaseAgent[
             response_model=instructor_model,
             api_base=str(self.base_url).rstrip("/") if self.base_url else None,
             api_key=self.api_key,
+            num_retries=self.num_retries,
         )
 
         response_data = response.model_dump()


### PR DESCRIPTION
### Summary :memo:

This PR introduces a **`num_retries`** parameter to the `BaseAgentConfig`. This update enhances agent resilience by allowing users to configure the number of retry attempts for failed LLM calls, which is particularly useful for handling intermittent network issues or API failures.

### Details

1.  Added a `num_retries` field to `BaseAgentConfig`, constrained with a default of 1, a minimum value of 1 (`ge=1`), and a maximum of 5 (`le=5`).
2.  Updated the `get_response_async` method in `LiteLLMInstructorBaseAgent` to pass the `self.num_retries` value from the config to the Instructor/LiteLLM client call.

### Checks
  - [x] Tested Changes
  - [ ] Stakeholder Approval

-----

## Usage

Here is an example of how to configure the `num_retries` parameter on an agent:

```python
class HaikuAgentInputSchema(InputSchema):
    """
    Input schema that takes in query
    """

    query: str = Field(
        ...,
        # description="Query to the haiku agent.",
    )

    topic_steer: str = Field(
        default="5-3-5 format",
        # description="Steer in 5-3-5 syllable as possible. Also use sanksrit words in the middle line",
    )


class HaikuAgentOutputSchema(OutputSchema):
    """
    Generate a haiku from given query
    """

    __response_field__ = "haiku"

    haiku: str = Field(..., description="Haiku content")

class HaikuAgent(LiteLLMInstructorBaseAgent):
    input_schema = HaikuAgentInputSchema
    output_schema = HaikuAgentOutputSchema

_cfg = BaseAgentConfig(
    # model_name="gpt-4o-mini",
    model_name="ollama/qwen3:4b",  # Just the model name
    # model_name="ollama/gemma3",
    # base_url="http://localhost:11434",
    # base_url="https://api.openai.com/v1",
    # system_prompt="You're a haiku master.",
    stateless=True,
    max_tokens=1000,
    trim_ratio=0.9,
    debug=True,
    enable_trimming=True,
    # api_key="lol",
    input_hints=True,
    temperature=1,
    description="A haiku agent for the existence\n\n",
    num_retries=2,  # <-- Set the number of retries here
)
agent = HaikuAgent(_cfg, debug=True)

# Example execution (in an async context)
# _output = await agent.arun(HaikuAgentInputSchema(query="love"))
# print(_output.model_dump())
# _output.model_dump_json()
```