### PR TITLE
Fixed key errors using safe key access

### DIFF
--- a/akd/tools/scrapers/_base.py
+++ b/akd/tools/scrapers/_base.py
@@ -241,9 +241,9 @@ class WebScraper(ScraperToolBase):
                 schema_data = json.loads(tag.string)
                 if isinstance(schema_data, dict):
                     if "datePublished" in schema_data:
-                        metadata["published_date"] = metadata["published_date"] or schema_data["datePublished"]
+                        metadata["published_date"] = metadata.get("published_date") or schema_data["datePublished"]
                     if "keywords" in schema_data:
-                        metadata["keywords"] = metadata["keywords"] or schema_data["keywords"]
+                        metadata["keywords"] = metadata.get("keywords") or schema_data["keywords"]
             except (json.JSONDecodeError, AttributeError):
                 pass
 
@@ -256,7 +256,7 @@ class WebScraper(ScraperToolBase):
         for twitter_name, meta_key in twitter_mappings.items():
             meta_tag = soup.find("meta", attrs={"name": twitter_name})
             if meta_tag and meta_tag.get("content"):
-                metadata[meta_key] = metadata[meta_key] or meta_tag.get("content")
+                metadata[meta_key] = metadata.get(meta_key) or meta_tag.get("content")
 
         # Extract citation metadata
         citation_mappings = {

--- a/akd/tools/scrapers/_base.py
+++ b/akd/tools/scrapers/_base.py
@@ -240,10 +240,8 @@ class WebScraper(ScraperToolBase):
             try:
                 schema_data = json.loads(tag.string)
                 if isinstance(schema_data, dict):
-                    if "datePublished" in schema_data:
-                        metadata["published_date"] = metadata.get("published_date") or schema_data["datePublished"]
-                    if "keywords" in schema_data:
-                        metadata["keywords"] = metadata.get("keywords") or schema_data["keywords"]
+                    metadata["published_date"] = metadata.get("published_date") or schema_data.get("datePublished")
+                    metadata["keywords"] = metadata.get("keywords") or schema_data.get("keywords")
             except (json.JSONDecodeError, AttributeError):
                 pass
 


### PR DESCRIPTION
Fix Summary

- Resolved KeyError caused by accessing published_date before it was set in metadata.
- Some URLs didn’t trigger the error because their schema_tags were empty, so that section of code was never executed.
- Applied .get() instead of direct dictionary access for both published_date and site_name to ensure safe lookups. Added safe lookups for other keys as well where required. 


Additional Findings

publication_date is never actually set before this section. because of that, the following citation generation doesn't execute unless a ROI is present:

```
if metadata["doi"] or (metadata["title"] and metadata["author"] and metadata["publication_date"]):
    citation_parts = []
    if metadata["author"]:
        citation_parts.append(metadata["author"])
    if metadata["title"]:
        citation_parts.append(f'"{metadata["title"]}"')
    if "publisher" in metadata:
        citation_parts.append(metadata["publisher"])
    if metadata["publication_date"]:
        citation_parts.append(metadata["publication_date"][:4])  # Just the year
    if metadata["doi"]:
        citation_parts.append(f"DOI: {metadata['doi']}")
    if citation_parts:
        metadata["citation"] = ". ".join(citation_parts)
```
