### PR TITLE
feat: Expose Parameters for external systems

### DIFF
--- a/akd/_base/__init__.py
+++ b/akd/_base/__init__.py
@@ -10,7 +10,7 @@ from ._base import (
     OutputSchema,
     UnrestrictedAbstractBase,
 )
-from .utils import exposed_param
+from .utils import ParamExposureMixin, exposed_param
 
 __all__ = [
     # Base classes
@@ -25,6 +25,7 @@ __all__ = [
     "BaseConfig",
     # Metadata and decorators
     "exposed_param",
+    "ParamExposureMixin",
     # Metaclass
     "AbstractBaseMeta",
 ]

--- a/akd/_base/__init__.py
+++ b/akd/_base/__init__.py
@@ -1,0 +1,30 @@
+"""Base classes and utilities for the AKD framework."""
+
+from ._base import (
+    AbstractBase,
+    AbstractBaseMeta,
+    AsyncRunMixin,
+    BaseConfig,
+    InputSchema,
+    IOSchema,
+    OutputSchema,
+    UnrestrictedAbstractBase,
+)
+from .utils import exposed_param
+
+__all__ = [
+    # Base classes
+    "AbstractBase",
+    "UnrestrictedAbstractBase",
+    "AsyncRunMixin",
+    # Schema classes
+    "IOSchema",
+    "InputSchema",
+    "OutputSchema",
+    # Config classes
+    "BaseConfig",
+    # Metadata and decorators
+    "exposed_param",
+    # Metaclass
+    "AbstractBaseMeta",
+]

--- a/akd/_base/_base.py
+++ b/akd/_base/_base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import inspect
 from abc import ABC, ABCMeta, abstractmethod
 from typing import Any, Type, cast
@@ -11,48 +10,7 @@ from pydantic import BaseModel, Field, ValidationError, computed_field, create_m
 from akd.errors import SchemaValidationError
 from akd.utils import get_model_fields
 
-
-def get_event_loop() -> asyncio.AbstractEventLoop:
-    try:
-        loop = asyncio.get_running_loop()
-    except RuntimeError:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-    return loop
-
-
-class AsyncRunMixin:
-    """
-    Mixin for adding interface to run
-    async methods in a sync context.
-    """
-
-    @abstractmethod
-    async def arun(self, *args, **kwargs) -> Any:
-        raise NotImplementedError("Subclasses should implement this method")
-
-    # async def ainvoke(self, *args, **kwargs) -> Any:
-    #     return await self.arun(*args, **kwargs)
-
-    def run(self, *args, **kwargs) -> Any:
-        """
-        Runs the async method in a sync context.
-        """
-        if not hasattr(self, "arun"):
-            raise AttributeError("Method 'arun' not implemented in the class")
-        try:
-            # Check if there's a running event loop
-            loop = get_event_loop()
-            # If we're already in an event loop, we need to use create_task and wait for it
-            if loop and loop.is_running():
-                # This creates a new task in the current event loop
-                future = asyncio.ensure_future(self.arun(*args, **kwargs))
-                return loop.run_until_complete(future)
-            else:
-                return asyncio.run(self.arun(*args, **kwargs))
-        except RuntimeError:
-            # No running event loop, create a new one
-            return asyncio.run(self.arun(*args, **kwargs))
+from .utils import AsyncRunMixin
 
 
 class BaseConfig(BaseModel):

--- a/akd/_base/utils.py
+++ b/akd/_base/utils.py
@@ -1,6 +1,6 @@
 import asyncio
 from abc import abstractmethod
-from typing import Any
+from typing import Any, Callable, overload
 
 from pydantic import BaseModel, Field
 
@@ -61,20 +61,96 @@ class ExposedParam(BaseModel):
     )
 
 
-def exposed_param(description: str, **kwargs):
+@overload
+def exposed_param[F: Callable](_func: F, /) -> F: ...
+
+
+@overload
+def exposed_param[F: Callable](
+    *,
+    description: str = "",
+    **kwargs,
+) -> Callable[[F], F]: ...
+
+
+def exposed_param[F: Callable](
+    _func: F | None = None,
+    /,
+    *,
+    description: str = "",
+    **kwargs,
+) -> F | Callable[[F], F]:
     """
-    Decorator to mark a property as exposed to external system
+    Decorator to mark a property as exposed to external system.
+
+    Can be used with or without parentheses:
+        @exposed_param
+        @exposed_param(description="...", extra_field="...")
 
     Args:
+        _func: The function being decorated (positional-only, internal use)
         description: Human readable description of the parameter
         **kwargs: Additional metadata stored in 'extra' field
     """
 
-    def decorator(func):
-        func._exposed_meta = ExposedParam(
-            description=description,
+    def decorator(func: F) -> F:
+        # Priority: explicit description > function docstring > prettified function name
+        final_description = description or (func.__doc__ or "").strip() or func.__name__.replace("_", " ").title()
+
+        func._exposed_meta = ExposedParam(  # type: ignore[attr-defined]
+            description=final_description,
             extra=kwargs or {},
         )
         return func
 
+    if _func is not None:
+        return decorator(_func)
+
     return decorator
+
+
+class ParamExposureMixin:
+    """Mixin to add parameter exposure capabilities to agents."""
+
+    def get_exposed_params(self, include_values: bool = False) -> dict[str, dict[str, Any]]:
+        """
+        Get metadata about exposed parameters.
+
+        Args:
+            include_values: If True, include current runtime values in the output
+
+        Returns:
+            Dict mapping parameter name to metadata containing:
+                - description: Human readable description
+                - type: Python type name
+                - editable: Whether the parameter has a setter
+                - extra: Additional metadata (if present)
+                - current_value: Current value (if include_values=True)
+        """
+        exposed = {}
+        for attr_name in dir(self):
+            attr = getattr(type(self), attr_name, None)
+            if isinstance(attr, property) and hasattr(attr.fget, "_exposed_meta"):
+                meta = attr.fget._exposed_meta
+                try:
+                    current_value = getattr(self, attr_name)
+                    param_type = type(current_value).__name__
+                except Exception:
+                    param_type = "unknown"
+                    current_value = None
+
+                exposed[attr_name] = {
+                    "description": meta.description,
+                    "type": param_type,
+                    "editable": attr.fset is not None,
+                }
+
+                # Add extra metadata if present
+                if meta.extra:
+                    exposed[attr_name]["extra"] = meta.extra
+
+                # Add current value if requested
+                if include_values:
+                    exposed[attr_name]["current_value"] = current_value
+
+        return exposed

--- a/akd/_base/utils.py
+++ b/akd/_base/utils.py
@@ -1,0 +1,80 @@
+import asyncio
+from abc import abstractmethod
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+def get_event_loop() -> asyncio.AbstractEventLoop:
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+    return loop
+
+
+class AsyncRunMixin:
+    """
+    Mixin for adding interface to run
+    async methods in a sync context.
+    """
+
+    @abstractmethod
+    async def arun(self, *args, **kwargs) -> Any:
+        raise NotImplementedError("Subclasses should implement this method")
+
+    # async def ainvoke(self, *args, **kwargs) -> Any:
+    #     return await self.arun(*args, **kwargs)
+
+    def run(self, *args, **kwargs) -> Any:
+        """
+        Runs the async method in a sync context.
+        """
+        if not hasattr(self, "arun"):
+            raise AttributeError("Method 'arun' not implemented in the class")
+        try:
+            # Check if there's a running event loop
+            loop = get_event_loop()
+            # If we're already in an event loop, we need to use create_task and wait for it
+            if loop and loop.is_running():
+                # This creates a new task in the current event loop
+                future = asyncio.ensure_future(self.arun(*args, **kwargs))
+                return loop.run_until_complete(future)
+            else:
+                return asyncio.run(self.arun(*args, **kwargs))
+        except RuntimeError:
+            # No running event loop, create a new one
+            return asyncio.run(self.arun(*args, **kwargs))
+
+
+### Exposed Param Decorator and Metadata ###
+
+
+class ExposedParam(BaseModel):
+    """Metadata for exposed paramters."""
+
+    description: str = Field(default="", description="Human readable description")
+    extra: dict[str, Any] | None = Field(
+        default_factory=dict,
+        description="Additional metadata for the parameter",
+    )
+
+
+def exposed_param(description: str, **kwargs):
+    """
+    Decorator to mark a property as exposed to external system
+
+    Args:
+        description: Human readable description of the parameter
+        **kwargs: Additional metadata stored in 'extra' field
+    """
+
+    def decorator(func):
+        func._exposed_meta = ExposedParam(
+            description=description,
+            extra=kwargs or {},
+        )
+        return func
+
+    return decorator

--- a/akd/_base/utils.py
+++ b/akd/_base/utils.py
@@ -62,7 +62,7 @@ class ExposedParam(BaseModel):
 
 
 @overload
-def exposed_param[F: Callable](_func: F, /) -> F: ...
+def exposed_param[F: Callable](_func: F, /) -> property: ...
 
 
 @overload
@@ -70,7 +70,7 @@ def exposed_param[F: Callable](
     *,
     description: str = "",
     **kwargs,
-) -> Callable[[F], F]: ...
+) -> Callable[[F], property]: ...
 
 
 def exposed_param[F: Callable](
@@ -79,9 +79,12 @@ def exposed_param[F: Callable](
     *,
     description: str = "",
     **kwargs,
-) -> F | Callable[[F], F]:
+) -> property | Callable[[F], property]:
     """
-    Decorator to mark a property as exposed to external system.
+    Decorator to mark a property as exposed to external systems (UI, backend, API, etc.).
+
+    This decorator combines @property functionality with parameter exposure metadata,
+    making the parameter accessible and configurable from external systems.
 
     Can be used with or without parentheses:
         @exposed_param
@@ -90,10 +93,10 @@ def exposed_param[F: Callable](
     Args:
         _func: The function being decorated (positional-only, internal use)
         description: Human readable description of the parameter
-        **kwargs: Additional metadata stored in 'extra' field
+        **kwargs: Additional metadata stored in 'extra' field (e.g., constraints, hints)
     """
 
-    def decorator(func: F) -> F:
+    def decorator(func: F) -> property:
         # Priority: explicit description > function docstring > prettified function name
         final_description = description or (func.__doc__ or "").strip() or func.__name__.replace("_", " ").title()
 
@@ -101,7 +104,7 @@ def exposed_param[F: Callable](
             description=final_description,
             extra=kwargs or {},
         )
-        return func
+        return property(func)  # type: ignore[return-value]
 
     if _func is not None:
         return decorator(_func)

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -17,7 +17,13 @@ from pydantic import (
     model_validator,
 )
 
-from akd._base import AbstractBase, BaseConfig, InputSchema, OutputSchema
+from akd._base import (
+    AbstractBase,
+    BaseConfig,
+    InputSchema,
+    OutputSchema,
+    ParamExposureMixin,
+)
 from akd.configs.project import CONFIG
 from akd.configs.prompts import DEFAULT_SYSTEM_PROMPT
 
@@ -104,7 +110,7 @@ class BaseAgentConfig(BaseConfig):
 class BaseAgent[
     InSchema: InputSchema,
     OutSchema: OutputSchema,
-](AbstractBase):
+](AbstractBase, ParamExposureMixin):
     """
     Base class for chat agents that interact with a language model.
 

--- a/akd/agents/search/deep_search.py
+++ b/akd/agents/search/deep_search.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional
 from loguru import logger
 from pydantic import Field
 
+from akd._base import exposed_param
 from akd.agents.query import (
     FollowUpQueryAgent,
     FollowUpQueryAgentInputSchema,
@@ -152,6 +153,15 @@ class DeepLitSearchAgent(LitBaseAgent):
         # Track research state
         self.research_history = []
         self.clarification_history = []
+
+    @property
+    @exposed_param(description="System prompt used for LLM clarification rounds.")
+    def clarification_prompt(self) -> str:
+        return self.clarification_component.config.system_prompt
+
+    @clarification_prompt.setter
+    def clarification_prompt(self, prompt: str) -> None:
+        self.clarification_component.config.system_prompt = prompt
 
     async def _handle_triage(self, query: str) -> dict:
         """Handle query triage using embedded component."""

--- a/akd/agents/search/deep_search.py
+++ b/akd/agents/search/deep_search.py
@@ -154,7 +154,6 @@ class DeepLitSearchAgent(LitBaseAgent):
         self.research_history = []
         self.clarification_history = []
 
-    @property
     @exposed_param(description="System prompt used for LLM clarification rounds.")
     def clarification_prompt(self) -> str:
         return self.clarification_component.config.system_prompt

--- a/tests/agents/base/test_exposed_params.py
+++ b/tests/agents/base/test_exposed_params.py
@@ -1,0 +1,249 @@
+"""Test cases for exposed parameter functionality."""
+
+from akd._base.utils import exposed_param
+
+from .conftest import TestInstructorBaseAgent
+
+
+class TestAgentWithExposedParams(TestInstructorBaseAgent):
+    """Test agent with exposed parameters."""
+
+    def __init__(self, config=None, **kwargs):
+        super().__init__(config=config, **kwargs)
+        self._clarification_prompt = "Default clarification prompt"
+        self._max_iterations = 5
+        self._temperature_override = 0.7
+
+    @exposed_param(description="System prompt for query clarification")
+    def clarification_prompt(self) -> str:
+        return self._clarification_prompt
+
+    @clarification_prompt.setter
+    def clarification_prompt(self, val: str) -> None:
+        self._clarification_prompt = val
+
+    @exposed_param(description="Maximum research iterations", min=1, max=20)
+    def max_iterations(self) -> int:
+        return self._max_iterations
+
+    @max_iterations.setter
+    def max_iterations(self, val: int) -> None:
+        self._max_iterations = val
+
+    @exposed_param  # No description - uses docstring or property name
+    def temperature_override(self) -> float:
+        """Temperature override for this agent"""
+        return self._temperature_override
+
+    @temperature_override.setter
+    def temperature_override(self, val: float) -> None:
+        self._temperature_override = val
+
+    @exposed_param(description="Read-only computed value")
+    def computed_value(self) -> str:
+        """This property has no setter, so it's read-only."""
+        return f"iterations={self._max_iterations}, temp={self._temperature_override}"
+
+
+# Prevent pytest from collecting this as a test
+TestAgentWithExposedParams.__test__ = False
+
+
+class TestExposedParamFunctionality:
+    """Test exposed parameter functionality."""
+
+    def test_get_exposed_params_without_values(
+        self,
+        mock_openai_client,
+        mock_instructor_client,
+    ):
+        """Test get_exposed_params returns metadata without values."""
+        agent = TestAgentWithExposedParams()
+
+        exposed = agent.get_exposed_params(include_values=False)
+
+        # Verify all exposed params are present
+        assert "clarification_prompt" in exposed
+        assert "max_iterations" in exposed
+        assert "temperature_override" in exposed
+        assert "computed_value" in exposed
+
+        # Verify metadata structure
+        assert exposed["clarification_prompt"]["description"] == "System prompt for query clarification"
+        assert exposed["clarification_prompt"]["type"] == "str"
+        assert exposed["clarification_prompt"]["editable"] is True
+
+        # Verify extra metadata
+        assert "extra" in exposed["max_iterations"]
+        assert exposed["max_iterations"]["extra"]["min"] == 1
+        assert exposed["max_iterations"]["extra"]["max"] == 20
+
+        # Verify no values included
+        assert "current_value" not in exposed["clarification_prompt"]
+
+    def test_get_exposed_params_with_values(
+        self,
+        mock_openai_client,
+        mock_instructor_client,
+    ):
+        """Test get_exposed_params returns metadata with current values."""
+        agent = TestAgentWithExposedParams()
+
+        exposed = agent.get_exposed_params(include_values=True)
+
+        # Verify values are included
+        assert exposed["clarification_prompt"]["current_value"] == "Default clarification prompt"
+        assert exposed["max_iterations"]["current_value"] == 5
+        assert exposed["temperature_override"]["current_value"] == 0.7
+
+    def test_exposed_param_auto_description_from_docstring(
+        self,
+        mock_openai_client,
+        mock_instructor_client,
+    ):
+        """Test that exposed_param uses docstring when no description provided."""
+        agent = TestAgentWithExposedParams()
+
+        exposed = agent.get_exposed_params()
+
+        # temperature_override has no explicit description, should use docstring
+        assert exposed["temperature_override"]["description"] == "Temperature override for this agent"
+
+    def test_exposed_param_editable_detection(
+        self,
+        mock_openai_client,
+        mock_instructor_client,
+    ):
+        """Test that editable flag is auto-detected from setter presence."""
+        agent = TestAgentWithExposedParams()
+
+        exposed = agent.get_exposed_params()
+
+        # Parameters with setters should be editable
+        assert exposed["clarification_prompt"]["editable"] is True
+        assert exposed["max_iterations"]["editable"] is True
+        assert exposed["temperature_override"]["editable"] is True
+
+        # Parameter without setter should be read-only
+        assert exposed["computed_value"]["editable"] is False
+
+    def test_exposed_param_setter_functionality(
+        self,
+        mock_openai_client,
+        mock_instructor_client,
+    ):
+        """Test that setters work correctly for exposed params."""
+        agent = TestAgentWithExposedParams()
+
+        # Test initial values
+        assert agent.clarification_prompt == "Default clarification prompt"
+        assert agent.max_iterations == 5
+
+        # Test setting new values
+        agent.clarification_prompt = "New prompt"
+        agent.max_iterations = 10
+
+        # Verify values changed
+        assert agent.clarification_prompt == "New prompt"
+        assert agent.max_iterations == 10
+
+        # Verify reflected in get_exposed_params
+        exposed = agent.get_exposed_params(include_values=True)
+        assert exposed["clarification_prompt"]["current_value"] == "New prompt"
+        assert exposed["max_iterations"]["current_value"] == 10
+
+    def test_exposed_param_extra_metadata(
+        self,
+        mock_openai_client,
+        mock_instructor_client,
+    ):
+        """Test that extra metadata is properly stored and retrieved."""
+        agent = TestAgentWithExposedParams()
+
+        exposed = agent.get_exposed_params()
+
+        # max_iterations has extra metadata (min, max)
+        assert "extra" in exposed["max_iterations"]
+        assert exposed["max_iterations"]["extra"]["min"] == 1
+        assert exposed["max_iterations"]["extra"]["max"] == 20
+
+        # clarification_prompt has no extra metadata
+        assert "extra" not in exposed["clarification_prompt"]
+
+    def test_exposed_param_type_inference(
+        self,
+        mock_openai_client,
+        mock_instructor_client,
+    ):
+        """Test that types are correctly inferred from current values."""
+        agent = TestAgentWithExposedParams()
+
+        exposed = agent.get_exposed_params()
+
+        assert exposed["clarification_prompt"]["type"] == "str"
+        assert exposed["max_iterations"]["type"] == "int"
+        assert exposed["temperature_override"]["type"] == "float"
+        assert exposed["computed_value"]["type"] == "str"
+
+    def test_regular_properties_not_exposed(
+        self,
+        mock_openai_client,
+        mock_instructor_client,
+    ):
+        """Test that regular @property decorated attributes are not exposed."""
+        agent = TestAgentWithExposedParams()
+
+        exposed = agent.get_exposed_params()
+
+        # These are regular properties from BaseAgent, should NOT be exposed
+        assert "memory" not in exposed
+        assert "description" not in exposed
+        assert "client" not in exposed
+
+    def test_exposed_param_with_complex_types(
+        self,
+        mock_openai_client,
+        mock_instructor_client,
+    ):
+        """Test exposed params with complex return types."""
+
+        class ComplexAgent(TestInstructorBaseAgent):
+            _config_dict = {"key": "value"}
+
+            @exposed_param(description="Configuration dictionary")
+            def config_dict(self) -> dict:
+                return self._config_dict
+
+            @config_dict.setter
+            def config_dict(self, val: dict) -> None:
+                self._config_dict = val
+
+        ComplexAgent.__test__ = False
+
+        agent = ComplexAgent()
+        exposed = agent.get_exposed_params(include_values=True)
+
+        assert exposed["config_dict"]["type"] == "dict"
+        assert exposed["config_dict"]["current_value"] == {"key": "value"}
+
+    def test_multiple_agents_independent_exposed_params(
+        self,
+        mock_openai_client,
+        mock_instructor_client,
+    ):
+        """Test that different agent instances have independent exposed params."""
+        agent1 = TestAgentWithExposedParams()
+        agent2 = TestAgentWithExposedParams()
+
+        # Modify agent1
+        agent1.max_iterations = 15
+
+        # Verify agent2 is unaffected
+        assert agent1.max_iterations == 15
+        assert agent2.max_iterations == 5
+
+        exposed1 = agent1.get_exposed_params(include_values=True)
+        exposed2 = agent2.get_exposed_params(include_values=True)
+
+        assert exposed1["max_iterations"]["current_value"] == 15
+        assert exposed2["max_iterations"]["current_value"] == 5


### PR DESCRIPTION
### Summary :memo:

This PR introduces a mechanism to dynamically expose and configure agent parameters via a new `@exposed_param` decorator, allowing external systems (like UIs or APIs) to discover and modify the agent attributes at runtime. Additionally, it refactors the `akd._base` module from a single file into a structured package to improve maintainability and separation of concerns.

### Details

*Describe more what you did on changes.*

1.  **Refactored Base Module:**

      * Converted `akd/_base.py` into a directory-based package `akd/_base/`.
      * Moved core logic to `akd/_base/_base.py` and utility logic (including `AsyncRunMixin`) to `akd/_base/utils.py`.
      * Ensured backward compatibility via `akd/_base/__init__.py` exports.

2.  **Parameter Exposure Mechanism (`akd/_base/utils.py`):**

      * Introduced `ParamExposureMixin`: A mixin that provides the `get_exposed_params()` method to retrieve metadata and current values of exposed properties.
      * Introduced `@exposed_param`: A decorator that functions similarly to `@property` but attaches metadata (description, types, editability) to the method.
      * Updated `BaseAgent` to inherit from `ParamExposureMixin`, making this feature available to all agents.

3.  **Agent Updates:**

      * Updated `DeepSearchAgent` to expose `clarification_prompt`, allowing it to be modified via the new mechanism.

4.  **Tests:**

      * Added comprehensive tests in `tests/agents/base/test_exposed_params.py` covering metadata retrieval, setter functionality, type inference, and instance isolation.

#### Usage Example

You can now expose internal parameters for external configuration like this:

```python

class HaikuAgentInputSchema(InputSchema):
    """
    Input schema that takes in query
    """

    query: str = Field(
        ...,
        # description="Query to the haiku agent.",
    )

    topic_steer: str = Field(
        default="5-3-5 format",
        # description="Steer in 5-3-5 syllable as possible. Also use sanksrit words in the middle line",
    )

class HaikuAgentOutputSchema(OutputSchema):
    """
    Generate a haiku from given query
    """

    __response_field__ = "haiku"

    haiku: str = Field(..., description="Haiku content")
class HaikuAgent(LiteLLMInstructorBaseAgent):
    input_schema = HaikuAgentInputSchema
    output_schema = HaikuAgentOutputSchema

    _fav: str = "Empty night unfolds\nStars whisper of nothingness\nSilence swallows all"

    # Use the decorator to expose this property
    @exposed_param(description="The agent's favorite haiku")
    # or without () 
    # @exposed_param 
    def favorite(self) -> str:
        return self._fav

    @favorite.setter
    def favorite(self, val: str) -> None:
        self._fav = val
```

**Retrieving params:**

```python
agent = HaikuAgent(...)
# Returns dict with description, type, current value, etc...
params = agent.get_exposed_params(include_values=True) 
```

### Checks

  - [x] Tested Changes
  - [ ] Stakeholder Approval
