### PR TITLE
Fix Deepcopy for Agents and Guardrails Attribute Conflicts

### DIFF
--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from abc import abstractmethod
 from typing import Any, cast
 
@@ -211,6 +212,41 @@ class InstructorBaseAgent[
         # Initialize memory
         self._memory = []
 
+    def __deepcopy__(self, memo: dict[int, Any]) -> InstructorBaseAgent:
+        """Custom deepcopy that recreates the client instead of copying it.
+
+        The instructor/openai client contains httpx connections and async state
+        that cannot be properly deepcopied. We copy all other attributes and
+        recreate the client fresh.
+
+        Args:
+            memo: Dictionary of already copied objects (used by copy.deepcopy).
+
+        Returns:
+            A deep copy of this agent with a fresh client.
+        """
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+
+        # Copy all attributes except the client
+        for k, v in self.__dict__.items():
+            if k == "client":
+                continue
+            setattr(result, k, copy.deepcopy(v, memo))
+
+        # Recreate the client fresh (api_key/base_url are dynamic properties from metaclass)
+        api_key = getattr(result, "api_key", None)
+        base_url = getattr(result, "base_url", None)
+        result.client = instructor.from_openai(
+            openai.AsyncOpenAI(
+                api_key=api_key,
+                base_url=str(base_url) if base_url else None,
+            ),
+        )
+
+        return result
+
     @property
     def memory(self) -> list[dict[str, str]]:
         return self._memory
@@ -339,33 +375,6 @@ class InstructorBaseAgent[
 
         return response
 
-    def __deepcopy__(self, memo):
-        """
-        Custom deepcopy implementation to handle unpickleable attributes.
-        """
-        cls = self.__class__
-        result = cls.__new__(cls)
-        memo[id(self)] = result
-
-        # Manually copy attributes, re-initializing the client
-        for k, v in self.__dict__.items():
-            if k == "client":
-                # Re-create the client instead of copying it
-                setattr(
-                    result,
-                    k,
-                    instructor.from_openai(
-                        openai.AsyncOpenAI(
-                            api_key=self.api_key,
-                            base_url=str(self.base_url),
-                        ),
-                    ),
-                )
-            else:
-                setattr(result, k, __import__("copy").deepcopy(v, memo))
-
-        return result
-
 
 class LiteLLMInstructorBaseAgent[
     InSchema: InputSchema,
@@ -388,6 +397,30 @@ class LiteLLMInstructorBaseAgent[
 
         # Replace instructor client with LiteLLM version
         self.client = instructor.from_litellm(acompletion)
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> LiteLLMInstructorBaseAgent:
+        """Custom deepcopy that recreates the LiteLLM client instead of copying it.
+
+        Args:
+            memo: Dictionary of already copied objects (used by copy.deepcopy).
+
+        Returns:
+            A deep copy of this agent with a fresh LiteLLM client.
+        """
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+
+        # Copy all attributes except the client
+        for k, v in self.__dict__.items():
+            if k == "client":
+                continue
+            setattr(result, k, copy.deepcopy(v, memo))
+
+        # Recreate the LiteLLM client fresh
+        result.client = instructor.from_litellm(acompletion)
+
+        return result
 
     async def get_response_async(
         self,

--- a/akd/guardrails.py
+++ b/akd/guardrails.py
@@ -69,11 +69,9 @@ def add_guardrails(
                     input_guardrails,
                     output_guardrails,
                 )
-                # Store field preferences
-                self.input_fields = input_fields or self.guardrails_config.input_fields
-                self.output_fields = (
-                    output_fields or self.guardrails_config.output_fields
-                )
+                # Store field preferences (prefixed to avoid conflicts with agent attributes)
+                self.guarded_input_fields = input_fields or self.guardrails_config.input_fields
+                self.guarded_output_fields = output_fields or self.guardrails_config.output_fields
 
             def _setup_guardrails_validation(
                 self,
@@ -85,12 +83,8 @@ def add_guardrails(
                 self.guardrails_config = (config or GuardrailsConfig()).model_copy(
                     deep=True,
                 )
-                self.guardrails_config.input_risk_types = (
-                    input_guardrails or self.guardrails_config.input_risk_types
-                )
-                self.guardrails_config.output_risk_types = (
-                    output_guardrails or self.guardrails_config.output_risk_types
-                )
+                self.guardrails_config.input_risk_types = input_guardrails or self.guardrails_config.input_risk_types
+                self.guardrails_config.output_risk_types = output_guardrails or self.guardrails_config.output_risk_types
 
                 self.guardrails_tool = None
                 if self.guardrails_config.enabled:
@@ -110,11 +104,7 @@ def add_guardrails(
                 is_input: bool = True,
             ) -> bool:
                 """Validate text with Granite Guardian model."""
-                if (
-                    not self.guardrails_config.enabled
-                    or not self.guardrails_tool
-                    or not text
-                ):
+                if not self.guardrails_config.enabled or not self.guardrails_tool or not text:
                     return True
 
                 try:
@@ -276,9 +266,7 @@ def add_guardrails(
                                 visited,
                             )
                     elif (
-                        isinstance(obj, (dict, type(None)))
-                        or hasattr(obj, "model_fields")
-                        or hasattr(obj, "__dict__")
+                        isinstance(obj, (dict, type(None))) or hasattr(obj, "model_fields") or hasattr(obj, "__dict__")
                     ):
                         # Handle all object types with unified field iteration
                         for key, value in self._iterate_object_fields(obj):
@@ -305,7 +293,7 @@ def add_guardrails(
                 if self.guardrails_config.enabled:
                     input_text = self._extract_text_content(
                         params,
-                        self.input_fields,
+                        self.guarded_input_fields,
                     )
                     input_passed = await self._validate_with_guardrails(
                         input_text,
@@ -322,7 +310,7 @@ def add_guardrails(
                 if self.guardrails_config.enabled:
                     output_text = self._extract_text_content(
                         response,
-                        self.output_fields,
+                        self.guarded_output_fields,
                     )
                     output_passed = await self._validate_with_guardrails(
                         output_text,
@@ -468,8 +456,14 @@ def apply_guardrails(
         guarded_component = GuardedComponentClass.__new__(GuardedComponentClass)
         guarded_component.__dict__.update(component.__dict__)
 
-        # Initialize the guardrails system
-        GuardedComponentClass.__init__(guarded_component)
+        # Only setup guardrails, don't re-initialize (which would overwrite config)
+        guarded_component._setup_guardrails_validation(
+            config,
+            input_guardrails,
+            output_guardrails,
+        )
+        guarded_component.guarded_input_fields = input_fields or guarded_component.guardrails_config.input_fields
+        guarded_component.guarded_output_fields = output_fields or guarded_component.guardrails_config.output_fields
 
         logger.info(
             f"Guardrails applied to {component_name}. Now, it has become {guarded_component.__class__.__name__}",

--- a/tests/guardrails/test_field_prioritization.py
+++ b/tests/guardrails/test_field_prioritization.py
@@ -68,10 +68,10 @@ async def test_field_prioritization():
         output_guardrails=[RiskDefinition.ANSWER_RELEVANCE],
     )
 
-    print(f"Default input fields: {guarded_agent_default.input_fields}")
-    print(f"Default output fields: {guarded_agent_default.output_fields}")
-    assert guarded_agent_default.input_fields == default_config.input_fields
-    assert guarded_agent_default.output_fields == default_config.output_fields
+    print(f"Default input fields: {guarded_agent_default.guarded_input_fields}")
+    print(f"Default output fields: {guarded_agent_default.guarded_output_fields}")
+    assert guarded_agent_default.guarded_input_fields == default_config.input_fields
+    assert guarded_agent_default.guarded_output_fields == default_config.output_fields
 
     # Test 2: Custom field priorities
     print("\n2. Testing custom field priorities...")
@@ -86,10 +86,10 @@ async def test_field_prioritization():
         output_fields=custom_output_fields,
     )
 
-    print(f"Custom input fields: {guarded_agent_custom.input_fields}")
-    print(f"Custom output fields: {guarded_agent_custom.output_fields}")
-    assert guarded_agent_custom.input_fields == custom_input_fields
-    assert guarded_agent_custom.output_fields == custom_output_fields
+    print(f"Custom input fields: {guarded_agent_custom.guarded_input_fields}")
+    print(f"Custom output fields: {guarded_agent_custom.guarded_output_fields}")
+    assert guarded_agent_custom.guarded_input_fields == custom_input_fields
+    assert guarded_agent_custom.guarded_output_fields == custom_output_fields
 
     # Test 3: Field extraction with different priorities
     print("\n3. Testing field extraction...")


### PR DESCRIPTION
### Summary :memo:
This PR resolves issues with deep-copying agent instances by manually re-initializing API clients and fixes an attribute naming collision in the Guardrails wrapper that was overwriting component fields.

### Details
_Describe more what you did on changes._
1. **Agent Deepcopy Support:** Implemented `__deepcopy__` in `InstructorBaseAgent` and `LiteLLMInstructorBaseAgent`. The `openai` and `httpx` clients contain async state/locks that cannot be pickled. The new implementation copies the agent's attributes but re-initializes the `client` fresh.
2. **Guardrails Field Isolation:** Renamed `input_fields` and `output_fields` to `guarded_input_fields` and `guarded_output_fields` within `akd/guardrails.py`. This prevents the Guardrails wrapper from accidentally overwriting existing attributes on the base component.
3. **Guardrails Initialization:** Updated `apply_guardrails` to set these specific fields manually rather than calling `__init__` (which was causing state reset issues) and updated `_extract_text_content` to use the new field names.
4. **Test Updates:** Updated `tests/guardrails/test_field_prioritization.py` to verify the new `guarded_*` attribute names.

### Bugfixes :bug:
- Fixed `TypeError` when attempting to `deepcopy` an agent due to unpickleable client objects.
- Fixed an issue where `apply_guardrails` would conflict with or overwrite a component's native `input_fields`.

### Checks
- [x] Tested Changes
- [ ] Stakeholder Approval
