### PR TITLE
Bugfix/SDE page indexing

### DIFF
--- a/akd/tools/search/code_search.py
+++ b/akd/tools/search/code_search.py
@@ -670,7 +670,7 @@ class SDECodeSearchTool(CodeSearchTool):
             logger.debug(f"Searching for query: '{query}' with top_k={max_results}")
 
         try:
-            for page in range(self.max_pages):
+            for page in range(1, self.config.max_pages + 1):
                 try:
                     results = self.sde_search(page=page, query=query)
                     if results:


### PR DESCRIPTION
### Summary :memo:
This PR fixes page indexing in the SDE Code Search Tool to align with the SDE API's updated pagination requirements.

### Details
- Updated page iteration from 0-based to 1-based indexing in `SDECodeSearchTool._arun_single_query()` method.
- Changed loop to start at page 1 instead of page 0 to match SDE team's API specification update.

### Bugfixes :bug:
- Fixed page indexing incompatibility causing failed requests to SDE API due to incorrect page numbers.

### Checks
- [x] Tested Changes
- [x] Stakeholder Approval
