### PR TITLE
Feat: Add Runtime Agent Registration & Unregistration Capability

### DIFF
--- a/akd/planner/registry.py
+++ b/akd/planner/registry.py
@@ -336,10 +336,8 @@ class AgentRegistry:
 
     def register_agent(
         self,
+        agent_class: type,
         agent_id: str | None = None,
-        agent_class: type | None = None,
-        module_path: str | None = None,
-        class_name: str | None = None,
         enabled: bool = True,
         tags: list[str] | None = None,
         persist: bool = False,
@@ -348,12 +346,9 @@ class AgentRegistry:
         Register a new agent with the registry at runtime.
 
         Args:
+            agent_class: Agent class to register. Must inherit from BaseAgent.
             agent_id: Unique identifier for the agent. If not provided, auto-generated
                       from class name (e.g., QueryAgent -> "query_agent", CMRAgent -> "cmr_agent")
-            agent_class: Agent class (provide this OR module_path+class_name).
-                         Must inherit from BaseAgent.
-            module_path: Module path for lazy loading
-            class_name: Class name for lazy loading
             enabled: Whether agent is enabled (default: True)
             tags: Optional tags for categorization
             persist: Save to JSON file (default: False, transient registration)
@@ -362,21 +357,16 @@ class AgentRegistry:
             The created AgentEntry
 
         Raises:
-            ValueError: If agent_id already exists or invalid arguments
+            ValueError: If agent_id already exists
             TypeError: If agent_class does not inherit from BaseAgent
 
         Example:
-            registry.register_agent(agent_class=CMRAgent)  # auto-generates id "cmr_agent"
-            registry.register_agent("cmr_search", CMRAgent)
-            registry.register_agent("cmr_search", module_path="akd_ext.agents.cmr", class_name="CMRAgent")
+            registry.register_agent(CMRAgent)  # auto-generates id "cmr_agent"
+            registry.register_agent(CMRAgent, agent_id="my_cmr")
         """
-        # Validate arguments
-        if agent_class is None and (module_path is None or class_name is None):
-            raise ValueError("Provide either agent_class OR both module_path and class_name")
-
         # Auto-generate agent_id from class name if not provided
         if agent_id is None:
-            name = agent_class.__name__ if agent_class else class_name
+            name = agent_class.__name__
             # Convert CamelCase to snake_case, handling acronyms properly
             # Step 1: Insert _ between lowercase and uppercase: deepLit -> deep_Lit
             agent_id = re.sub(r"([a-z])([A-Z])", r"\1_\2", name)
@@ -388,13 +378,7 @@ class AgentRegistry:
         if agent_id in self.registry_data.agents:
             raise ValueError(f"Agent '{agent_id}' already exists")
 
-        # Load class if not provided directly
-        if agent_class is None:
-            module = importlib.import_module(module_path)
-            agent_class = getattr(module, class_name)
-            agent_class_path = f"{module_path}.{class_name}"
-        else:
-            agent_class_path = f"{agent_class.__module__}.{agent_class.__name__}"
+        agent_class_path = f"{agent_class.__module__}.{agent_class.__name__}"
 
         # Type check: ensure agent inherits from BaseAgent (works with full inheritance chain)
         if not issubclass(agent_class, BaseAgent):

--- a/akd/planner/registry.py
+++ b/akd/planner/registry.py
@@ -436,6 +436,34 @@ class AgentRegistry:
 
         return entry
 
+    def unregister_agent(self, agent_id: str, persist: bool = False) -> AgentEntry | None:
+        """
+        Unregister an agent from the registry.
+
+        Args:
+            agent_id: Unique identifier of the agent to remove
+            persist: Save changes to JSON file (default: False)
+
+        Returns:
+            The removed AgentEntry, or None if agent_id not found
+
+        Example:
+            removed = registry.unregister_agent("cmr_agent")
+            if removed:
+                print(f"Removed: {removed.agent_id}")
+        """
+        if agent_id not in self.registry_data.agents:
+            logger.warning(f"Agent '{agent_id}' not found in registry")
+            return None
+
+        entry = self.registry_data.agents.pop(agent_id)
+        logger.info(f"Unregistered agent: {agent_id}")
+
+        if persist:
+            self._save_registry()
+
+        return entry
+
     def reload(self) -> None:
         """Reload the registry from file or re-discover."""
         self._load_or_discover()

--- a/akd/planner/registry.py
+++ b/akd/planner/registry.py
@@ -14,6 +14,7 @@ from loguru import logger
 from pydantic import BaseModel, Field
 
 from akd._base import IOSchema
+from akd.agents._base import BaseAgent
 
 from .config import AgentRegistryConfig
 
@@ -103,6 +104,35 @@ class AgentRegistry:
             self.registry_data: AgentRegistryData = AgentRegistryData()
             self._load_or_discover()
             AgentRegistry._initialized = True
+
+    def __repr__(self) -> str:
+        """Return a detailed string representation of the registry."""
+        lines = ["AgentRegistry:"]
+        lines.append(f"  Version: {self.registry_data.version}")
+        lines.append(f"  Updated: {self.registry_data.updated_at}")
+        lines.append(f"  Total Agents: {len(self.registry_data.agents)}")
+        lines.append(f"  Enabled: {len(self.get_enabled_agents())}")
+        lines.append("")
+        lines.append("  Registered Agents:")
+        for agent_id, agent in self.registry_data.agents.items():
+            status = "enabled" if agent.enabled else "disabled"
+            tags = ", ".join(agent.tags) if agent.tags else "none"
+            lines.append(f"    - {agent_id} [{status}]")
+            lines.append(f"        Class: {agent.agent_class}")
+            lines.append(f"        Description: {agent.description}")
+            lines.append(f"        Tags: {tags}")
+            input_fields = [f.name for f in agent.input_schema.fields]
+            output_fields = [f.name for f in agent.output_schema.fields]
+            lines.append(f"        Input: {input_fields}")
+            lines.append(f"        Output: {output_fields}")
+        return "\n".join(lines)
+
+    def __str__(self) -> str:
+        """Return a concise string representation."""
+        enabled = len(self.get_enabled_agents())
+        total = len(self.registry_data.agents)
+        agent_ids = list(self.registry_data.agents.keys())
+        return f"AgentRegistry({enabled}/{total} enabled): {agent_ids}"
 
     def _load_or_discover(self) -> None:
         """
@@ -302,6 +332,95 @@ class AgentRegistry:
             self._save_registry()
             return True
         return False
+
+    def register_agent(
+        self,
+        agent_id: str,
+        agent_class: type | None = None,
+        module_path: str | None = None,
+        class_name: str | None = None,
+        enabled: bool = True,
+        tags: list[str] | None = None,
+        persist: bool = True,
+    ) -> AgentEntry:
+        """
+        Register a new agent with the registry at runtime.
+
+        Args:
+            agent_id: Unique identifier for the agent
+            agent_class: Agent class (provide this OR module_path+class_name).
+                         Must inherit from BaseAgent.
+            module_path: Module path for lazy loading
+            class_name: Class name for lazy loading
+            enabled: Whether agent is enabled (default: True)
+            tags: Optional tags for categorization
+            persist: Save to JSON file (default: True)
+
+        Returns:
+            The created AgentEntry
+
+        Raises:
+            ValueError: If agent_id already exists or invalid arguments
+            TypeError: If agent_class does not inherit from BaseAgent
+
+        Example:
+            registry.register_agent("cmr_search", CMRAgent)
+            registry.register_agent("cmr_search", module_path="akd_ext.agents.cmr", class_name="CMRAgent")
+        """
+        # Validate arguments
+        if agent_id in self.registry_data.agents:
+            raise ValueError(f"Agent '{agent_id}' already exists")
+
+        if agent_class is None and (module_path is None or class_name is None):
+            raise ValueError("Provide either agent_class OR both module_path and class_name")
+
+        # Load class if not provided directly
+        if agent_class is None:
+            module = importlib.import_module(module_path)
+            agent_class = getattr(module, class_name)
+            agent_class_path = f"{module_path}.{class_name}"
+        else:
+            agent_class_path = f"{agent_class.__module__}.{agent_class.__name__}"
+
+        # Type check: ensure agent inherits from BaseAgent (works with full inheritance chain)
+        if not issubclass(agent_class, BaseAgent):
+            raise TypeError(
+                f"Agent class '{agent_class.__name__}' must inherit from BaseAgent",
+            )
+
+        # Extract schemas using existing method
+        input_schema = self._extract_schema(getattr(agent_class, "input_schema", None))
+        output_schema = self._extract_schema(getattr(agent_class, "output_schema", None))
+
+        # Get description from docstring
+        description = agent_class.__doc__
+        if description:
+            description = description.strip().split("\n")[0]
+        else:
+            description = f"Agent for {agent_id.replace('_', ' ')}"
+
+        # Create entry
+        entry = AgentEntry(
+            agent_id=agent_id,
+            name=agent_id.replace("_", " ").title(),
+            description=description,
+            agent_class=agent_class_path,
+            input_schema=input_schema,
+            output_schema=output_schema,
+            enabled=enabled,
+            tags=tags or ["external"],
+            use_cases=[description],
+        )
+
+        # Add to registry
+        self.registry_data.agents[agent_id] = entry
+        logger.info(f"Registered agent: {agent_id}")
+
+        # Persist if requested
+        if persist:
+            self._save_registry()
+
+        return entry
 
     def reload(self) -> None:
         """Reload the registry from file or re-discover."""

--- a/akd/planner/registry.py
+++ b/akd/planner/registry.py
@@ -7,6 +7,7 @@ This module provides agent registration and discovery capabilities for the AKD f
 import importlib
 import json
 import os
+import re
 from datetime import datetime, timezone
 from typing import Any, Optional, Type
 
@@ -335,7 +336,7 @@ class AgentRegistry:
 
     def register_agent(
         self,
-        agent_id: str,
+        agent_id: str | None = None,
         agent_class: type | None = None,
         module_path: str | None = None,
         class_name: str | None = None,
@@ -347,7 +348,8 @@ class AgentRegistry:
         Register a new agent with the registry at runtime.
 
         Args:
-            agent_id: Unique identifier for the agent
+            agent_id: Unique identifier for the agent. If not provided, auto-generated
+                      from class name (e.g., QueryAgent -> "query_agent", CMRAgent -> "cmr_agent")
             agent_class: Agent class (provide this OR module_path+class_name).
                          Must inherit from BaseAgent.
             module_path: Module path for lazy loading
@@ -364,15 +366,27 @@ class AgentRegistry:
             TypeError: If agent_class does not inherit from BaseAgent
 
         Example:
+            registry.register_agent(agent_class=CMRAgent)  # auto-generates id "cmr_agent"
             registry.register_agent("cmr_search", CMRAgent)
             registry.register_agent("cmr_search", module_path="akd_ext.agents.cmr", class_name="CMRAgent")
         """
         # Validate arguments
-        if agent_id in self.registry_data.agents:
-            raise ValueError(f"Agent '{agent_id}' already exists")
-
         if agent_class is None and (module_path is None or class_name is None):
             raise ValueError("Provide either agent_class OR both module_path and class_name")
+
+        # Auto-generate agent_id from class name if not provided
+        if agent_id is None:
+            name = agent_class.__name__ if agent_class else class_name
+            # Convert CamelCase to snake_case, handling acronyms properly
+            # Step 1: Insert _ between lowercase and uppercase: deepLit -> deep_Lit
+            agent_id = re.sub(r"([a-z])([A-Z])", r"\1_\2", name)
+            # Step 2: Insert _ between acronym and next word: CMRAgent -> CMR_Agent
+            agent_id = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", agent_id)
+            # Step 3: Lowercase everything
+            agent_id = agent_id.lower()
+
+        if agent_id in self.registry_data.agents:
+            raise ValueError(f"Agent '{agent_id}' already exists")
 
         # Load class if not provided directly
         if agent_class is None:

--- a/akd/planner/registry.py
+++ b/akd/planner/registry.py
@@ -342,7 +342,7 @@ class AgentRegistry:
         class_name: str | None = None,
         enabled: bool = True,
         tags: list[str] | None = None,
-        persist: bool = True,
+        persist: bool = False,
     ) -> AgentEntry:
         """
         Register a new agent with the registry at runtime.
@@ -356,7 +356,7 @@ class AgentRegistry:
             class_name: Class name for lazy loading
             enabled: Whether agent is enabled (default: True)
             tags: Optional tags for categorization
-            persist: Save to JSON file (default: True)
+            persist: Save to JSON file (default: False, transient registration)
 
         Returns:
             The created AgentEntry

--- a/tests/planner/test_registry.py
+++ b/tests/planner/test_registry.py
@@ -519,5 +519,259 @@ class TestRegistryWithFieldMapping:
         assert len(required_inputs) > 0
 
 
+class TestRegisterUnregisterAgent:
+    """Test register_agent and unregister_agent methods."""
+
+    @pytest.fixture(autouse=True)
+    def reset_registry(self):
+        """Auto-reset singleton before and after each test."""
+        AgentRegistry._reset_singleton()
+        yield
+        AgentRegistry._reset_singleton()
+
+    def test_register_agent_with_class(self):
+        """Test registering an agent with class directly."""
+        from akd.agents.intents import IntentAgent
+
+        registry = get_agent_registry()
+        entry = registry.register_agent(agent_class=IntentAgent)
+
+        assert entry.agent_id == "intent_agent"
+        assert entry.agent_class == "akd.agents.intents.IntentAgent"
+        assert "external" in entry.tags
+        assert entry.enabled is True
+
+        # Verify it's in the registry
+        assert registry.get_agent("intent_agent") is not None
+
+    def test_register_agent_with_custom_id(self):
+        """Test registering an agent with custom agent_id."""
+        from akd.agents.intents import IntentAgent
+
+        registry = get_agent_registry()
+        entry = registry.register_agent(agent_id="my_custom_intent", agent_class=IntentAgent)
+
+        assert entry.agent_id == "my_custom_intent"
+        assert registry.get_agent("my_custom_intent") is not None
+
+    def test_register_agent_with_module_path(self):
+        """Test registering an agent with module_path and class_name."""
+        registry = get_agent_registry()
+        entry = registry.register_agent(
+            agent_id="intent_from_path",
+            module_path="akd.agents.intents",
+            class_name="IntentAgent",
+        )
+
+        assert entry.agent_id == "intent_from_path"
+        assert entry.agent_class == "akd.agents.intents.IntentAgent"
+
+    def test_register_agent_with_custom_tags(self):
+        """Test registering an agent with custom tags."""
+        from akd.agents.intents import IntentAgent
+
+        registry = get_agent_registry()
+        entry = registry.register_agent(
+            agent_class=IntentAgent,
+            tags=["custom", "test", "external"],
+        )
+
+        assert "custom" in entry.tags
+        assert "test" in entry.tags
+
+    def test_register_agent_auto_id_from_class_name(self):
+        """Test auto-generation of agent_id from class name."""
+        from akd.agents.query import QueryAgent
+        from akd.agents.relevancy import RelevancyAgent
+
+        registry = get_agent_registry()
+
+        # QueryAgent -> query_agent
+        entry1 = registry.register_agent(agent_class=QueryAgent)
+        assert entry1.agent_id == "query_agent"
+
+        # RelevancyAgent -> relevancy_agent
+        entry2 = registry.register_agent(agent_class=RelevancyAgent)
+        assert entry2.agent_id == "relevancy_agent"
+
+    def test_register_agent_duplicate_raises_error(self):
+        """Test that registering duplicate agent_id raises ValueError."""
+        from akd.agents.intents import IntentAgent
+
+        registry = get_agent_registry()
+        registry.register_agent(agent_id="duplicate_test", agent_class=IntentAgent)
+
+        with pytest.raises(ValueError, match="already exists"):
+            registry.register_agent(agent_id="duplicate_test", agent_class=IntentAgent)
+
+    def test_register_agent_non_base_agent_raises_error(self):
+        """Test that registering non-BaseAgent class raises TypeError."""
+        registry = get_agent_registry()
+
+        with pytest.raises(TypeError, match="must inherit from BaseAgent"):
+            registry.register_agent(agent_id="invalid", agent_class=str)
+
+    def test_register_agent_missing_args_raises_error(self):
+        """Test that missing required args raises ValueError."""
+        registry = get_agent_registry()
+
+        with pytest.raises(ValueError, match="Provide either agent_class"):
+            registry.register_agent(agent_id="no_class")
+
+    def test_register_agent_extracts_schemas(self):
+        """Test that schemas are correctly extracted from agent class."""
+        from akd.agents.query import QueryAgent
+
+        registry = get_agent_registry()
+        entry = registry.register_agent(agent_class=QueryAgent)
+
+        # Verify input schema has fields
+        input_field_names = [f.name for f in entry.input_schema.fields]
+        assert "query" in input_field_names
+
+        # Verify output schema has fields
+        output_field_names = [f.name for f in entry.output_schema.fields]
+        assert len(output_field_names) > 0
+
+    def test_register_agent_persist_false_by_default(self, temp_registry_file):
+        """Test that persist=False is the default (transient registration)."""
+        from akd.agents.intents import IntentAgent
+
+        config = AgentRegistryConfig(registry_path=temp_registry_file, auto_discover=True)
+        registry = AgentRegistry(config)
+
+        # Register without persist (default)
+        registry.register_agent(agent_class=IntentAgent)
+
+        # Read file - should not contain the new agent
+        with open(temp_registry_file, "r") as f:
+            data = json.load(f)
+
+        assert "intent_agent" not in data.get("agents", {})
+
+    def test_register_agent_persist_true(self, temp_registry_file):
+        """Test that persist=True saves to JSON file."""
+        from akd.agents.intents import IntentAgent
+
+        config = AgentRegistryConfig(registry_path=temp_registry_file, auto_discover=True)
+        registry = AgentRegistry(config)
+
+        # Register with persist=True
+        registry.register_agent(agent_class=IntentAgent, persist=True)
+
+        # Read file - should contain the new agent
+        with open(temp_registry_file, "r") as f:
+            data = json.load(f)
+
+        assert "intent_agent" in data.get("agents", {})
+
+    def test_unregister_agent_returns_entry(self):
+        """Test unregistering an agent returns the removed entry."""
+        from akd.agents.intents import IntentAgent
+
+        registry = get_agent_registry()
+        registry.register_agent(agent_class=IntentAgent)
+
+        removed = registry.unregister_agent("intent_agent")
+
+        assert removed is not None
+        assert removed.agent_id == "intent_agent"
+        assert registry.get_agent("intent_agent") is None
+
+    def test_unregister_agent_not_found_returns_none(self):
+        """Test unregistering non-existent agent returns None."""
+        registry = get_agent_registry()
+
+        removed = registry.unregister_agent("does_not_exist")
+
+        assert removed is None
+
+    def test_unregister_agent_persist_false_by_default(self, temp_registry_file):
+        """Test that unregister persist=False is the default."""
+        config = AgentRegistryConfig(registry_path=temp_registry_file, auto_discover=True)
+        registry = AgentRegistry(config)
+
+        # Get an existing agent from file
+        agents_before = list(registry.registry_data.agents.keys())
+        if agents_before:
+            agent_to_remove = agents_before[0]
+            registry.unregister_agent(agent_to_remove)
+
+            # Read file - should still contain the agent
+            with open(temp_registry_file, "r") as f:
+                data = json.load(f)
+
+            assert agent_to_remove in data.get("agents", {})
+
+    def test_unregister_agent_persist_true(self, temp_registry_file):
+        """Test that unregister with persist=True updates JSON file."""
+        from akd.agents.intents import IntentAgent
+
+        config = AgentRegistryConfig(registry_path=temp_registry_file, auto_discover=True)
+        registry = AgentRegistry(config)
+
+        # Register with persist
+        registry.register_agent(agent_class=IntentAgent, persist=True)
+
+        # Verify it's in file
+        with open(temp_registry_file, "r") as f:
+            data = json.load(f)
+        assert "intent_agent" in data.get("agents", {})
+
+        # Unregister with persist
+        registry.unregister_agent("intent_agent", persist=True)
+
+        # Verify it's removed from file
+        with open(temp_registry_file, "r") as f:
+            data = json.load(f)
+        assert "intent_agent" not in data.get("agents", {})
+
+    def test_register_unregister_cycle(self):
+        """Test registering and unregistering multiple times."""
+        from akd.agents.intents import IntentAgent
+
+        registry = get_agent_registry()
+
+        # Register
+        entry1 = registry.register_agent(agent_class=IntentAgent)
+        assert registry.get_agent("intent_agent") is not None
+
+        # Unregister
+        removed = registry.unregister_agent("intent_agent")
+        assert removed.agent_id == entry1.agent_id
+        assert registry.get_agent("intent_agent") is None
+
+        # Register again
+        entry2 = registry.register_agent(agent_class=IntentAgent)
+        assert registry.get_agent("intent_agent") is not None
+        assert entry2.agent_id == "intent_agent"
+
+    def test_registered_agent_appears_in_enabled_agents(self):
+        """Test that registered agent appears in get_enabled_agents()."""
+        from akd.agents.intents import IntentAgent
+
+        registry = get_agent_registry()
+        registry.register_agent(agent_class=IntentAgent)
+
+        enabled = registry.get_enabled_agents()
+        enabled_ids = [a.agent_id for a in enabled]
+
+        assert "intent_agent" in enabled_ids
+
+    def test_registered_agent_with_disabled_flag(self):
+        """Test registering an agent as disabled."""
+        from akd.agents.intents import IntentAgent
+
+        registry = get_agent_registry()
+        entry = registry.register_agent(agent_class=IntentAgent, enabled=False)
+
+        assert entry.enabled is False
+
+        enabled = registry.get_enabled_agents()
+        enabled_ids = [a.agent_id for a in enabled]
+
+        assert "intent_agent" not in enabled_ids
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
### Summary :memo:

This PR expands the `AgentRegistry` to support dynamic, runtime management of agents. It introduces the ability to programmatically register and unregister agents without solely relying on the static configuration file. This includes support for transient registration (memory only) and persistent registration (saving to disk), along with automatic ID generation and validation.

### Details

*Describe more what you did on changes.*

1. **Added `register_agent` method:**
* Allows registering agents via Class reference or module path/class name strings.
* **Auto-ID Generation:** Automatically converts CamelCase class names to snake_case IDs if no ID is provided (e.g., `CMRAgent` -> `cmr_agent`).
* **Validation:** Enforces that registered classes inherit from `BaseAgent` and prevents duplicate IDs.
* **Schema Extraction:** Automatically pulls input/output schemas and descriptions from the agent class.


2. **Added `unregister_agent` method:** Allows removing an agent from the registry by ID. Returns the removed `AgentEntry`.
3. **Persistence Control:** Added a `persist` boolean flag to both methods. Default is `False` (transient/runtime only), but setting it to `True` saves the changes to the underlying JSON registry file.
5. **Test Coverage:** Added `tests/planner/test_registry.py` with comprehensive tests for registration, unregistration, ID generation, validation errors, and persistence.


## Usage

```python
from akd.planner.registry import get_agent_registry
from akd_ext.agents import CustomAgent

registry = get_agent_registry()

# 1. Register by Class (Auto-ID generation: 'custom_agent')
registry.register_agent(agent_class=CustomAgent)

# 2. Register with explicit ID and Persistence (saves to registry.json)
registry.register_agent(
    agent_id="my_special_agent", 
    agent_class=CustomAgent, 
    persist=True
)


# 3. Unregister an agent
registry.unregister_agent("my_special_agent", persist=True)
```

### Checks

* [x] Tested Changes
* [ ] Stakeholder Approval

---

  ---

# Notes

## Backend Integration

In akd-framework/src/api/runtime/app/main.py, register external agents during app startup in the lifespan function:

```python
from contextlib import asynccontextmanager
from fastapi import FastAPI

from akd.planner.registry import get_agent_registry
from akd_ext.agents.cmr import CMRAgent  # External agent from akd-ext package


@asynccontextmanager
async def lifespan(app: FastAPI):
    """App startup and shutdown lifecycle."""

    # ... existing redis/db setup ...

    # Register external agents at startup (transient - re-registers each restart)
    registry = get_agent_registry()
    registry.register_agent(agent_class=CMRAgent)
    # registry.register_agent(agent_class=EarthdataAgent)

    print(registry)  # Shows: AgentRegistry(N/N enabled): ['deep_search', 'gap_analysis', 'code_search', 'cmr_agent']

    yield

    # ... existing cleanup ...

```

Why this works:
- get_agent_registry() returns the singleton registry instance
- All create_planner() calls share this same registry
- Agents registered at startup are available to all subsequent planner requests
- Using persist=False (default) ensures the agent is only available when akd_ext is actually installed

No changes needed in chat endpoints - they continue using create_planner() as before:
# In chats.py - unchanged
planner = await create_planner()  # Automatically sees registered agents

---