### PR TITLE
Feat: Groundwork for streaming support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,7 @@ jobs:
           set +e  # Don't exit on command failure
 
           # Run tests with real-time output and capture for parsing
-          python -m pytest tests/ -v --cov --cov-report=xml --cov-report=term 2>&1 | tee test_output.log
+          python -m pytest tests/ -v -n auto --dist=loadfile --cov --cov-report=xml --cov-report=term 2>&1 | tee test_output.log
           test_exit_code=${PIPESTATUS[0]}
 
           echo ""

--- a/akd/_base/__init__.py
+++ b/akd/_base/__init__.py
@@ -11,6 +11,7 @@ from ._base import (
     UnrestrictedAbstractBase,
 )
 from .exposure import ParamExposureMixin, exposed_param
+from .streaming import StreamEvent, StreamEventType, StreamingMixin
 
 __all__ = [
     # Base classes
@@ -28,4 +29,8 @@ __all__ = [
     "ParamExposureMixin",
     # Metaclass
     "AbstractBaseMeta",
+    # Streaming
+    "StreamEvent",
+    "StreamEventType",
+    "StreamingMixin",
 ]

--- a/akd/_base/_base.py
+++ b/akd/_base/_base.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field, ValidationError, computed_field, create_m
 from akd.errors import SchemaValidationError
 from akd.utils import get_model_fields
 
+from .streaming import StreamingMixin
 from .utils import AsyncRunMixin
 
 
@@ -230,7 +231,7 @@ class AbstractBaseMeta(ABCMeta):
 class AbstractBase[
     InSchema: InputSchema,
     OutSchema: OutputSchema,
-](AsyncRunMixin, ABC, metaclass=AbstractBaseMeta):
+](StreamingMixin, AsyncRunMixin, ABC, metaclass=AbstractBaseMeta):
     """
     Abstract base class for agents and tools that interact with a language model.
     This class provides the basic structure for an agent or tool that can handle
@@ -414,7 +415,7 @@ class AbstractBase[
 class UnrestrictedAbstractBase[
     InSchema: BaseModel,
     OutSchema: BaseModel,
-](AsyncRunMixin, ABC, metaclass=AbstractBaseMeta):
+](StreamingMixin, AsyncRunMixin, ABC, metaclass=AbstractBaseMeta):
     """
     Abstract base class for agents and tools that interact with a language model.
     This class provides the basic structure for an agent or tool that can handle

--- a/akd/_base/streaming.py
+++ b/akd/_base/streaming.py
@@ -2,7 +2,7 @@
 
 import uuid
 from collections.abc import AsyncIterator
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
@@ -61,7 +61,7 @@ class StreamEvent(BaseModel):
 
     # Core envelope
     event_type: StreamEventType
-    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
     event_id: str = Field(default_factory=lambda: uuid.uuid4().hex[:8])
     source: str | None = None  # Class name that generated this event
     message: str | None = None

--- a/akd/_base/streaming.py
+++ b/akd/_base/streaming.py
@@ -69,6 +69,12 @@ class StreamEvent(BaseModel):
     # Flexible payload
     data: dict[str, Any] = Field(default_factory=dict)
 
+    # Execution context
+    context: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Execution context (node_id, query, etc.)",
+    )
+
     # Convenience properties
 
     @property
@@ -121,6 +127,7 @@ class StreamingMixin:
     async def astream(
         self,
         params: Any,
+        context: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> AsyncIterator[StreamEvent]:
         """Stream execution with events.
@@ -129,6 +136,7 @@ class StreamingMixin:
 
         Args:
             params: Input parameters
+            context: Execution context (node_id, query, etc.). Auto-generates run_id if not provided.
             **kwargs: Passed to arun()
 
         Yields:
@@ -139,10 +147,16 @@ class StreamingMixin:
         """
         class_name = self.__class__.__name__
 
+        # Auto-generate run_id for event correlation
+        run_context = context.copy() if context else {}
+        if "run_id" not in run_context:
+            run_context["run_id"] = uuid.uuid4().hex[:8]
+
         yield StreamEvent(
             event_type=StreamEventType.STARTING,
             source=class_name,
             message=f"Starting {class_name}",
+            context=run_context,
         )
 
         try:
@@ -150,6 +164,7 @@ class StreamingMixin:
                 event_type=StreamEventType.RUNNING,
                 source=class_name,
                 message=f"Running {class_name}",
+                context=run_context,
             )
 
             output = await self.arun(params, **kwargs)
@@ -159,6 +174,7 @@ class StreamingMixin:
                 source=class_name,
                 message=f"Completed {class_name}",
                 data={"output": output},
+                context=run_context,
             )
         except Exception as e:
             yield StreamEvent(
@@ -166,6 +182,7 @@ class StreamingMixin:
                 source=class_name,
                 message=f"Failed: {e!s}",
                 data={"error": str(e), "error_type": type(e).__name__},
+                context=run_context,
             )
             raise
 

--- a/akd/_base/streaming.py
+++ b/akd/_base/streaming.py
@@ -37,6 +37,7 @@ class StreamEvent(BaseModel):
         event_type: Type of event (STARTING, COMPLETED, FAILED, etc.)
         timestamp: UTC timestamp when event was created
         event_id: Unique identifier for this event
+        source: Class name that generated this event
         message: Human-readable description
         data: Flexible payload for all event-specific data
 
@@ -62,6 +63,7 @@ class StreamEvent(BaseModel):
     event_type: StreamEventType
     timestamp: datetime = Field(default_factory=datetime.utcnow)
     event_id: str = Field(default_factory=lambda: uuid.uuid4().hex[:8])
+    source: str | None = None  # Class name that generated this event
     message: str | None = None
 
     # Flexible payload
@@ -139,12 +141,14 @@ class StreamingMixin:
 
         yield StreamEvent(
             event_type=StreamEventType.STARTING,
+            source=class_name,
             message=f"Starting {class_name}",
         )
 
         try:
             yield StreamEvent(
                 event_type=StreamEventType.RUNNING,
+                source=class_name,
                 message=f"Running {class_name}",
             )
 
@@ -152,12 +156,14 @@ class StreamingMixin:
 
             yield StreamEvent(
                 event_type=StreamEventType.COMPLETED,
+                source=class_name,
                 message=f"Completed {class_name}",
                 data={"output": output},
             )
         except Exception as e:
             yield StreamEvent(
                 event_type=StreamEventType.FAILED,
+                source=class_name,
                 message=f"Failed: {e!s}",
                 data={"error": str(e), "error_type": type(e).__name__},
             )

--- a/akd/_base/streaming.py
+++ b/akd/_base/streaming.py
@@ -1,0 +1,171 @@
+"""Streaming support for akd agents and tools."""
+
+import uuid
+from collections.abc import AsyncIterator
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class StreamEventType(str, Enum):
+    """Types of events emitted during streaming."""
+
+    # Lifecycle
+    STARTING = "starting"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+    # Execution
+    RUNNING = "running"
+    THINKING = "thinking"
+
+    # Tool calling (Stage 2)
+    TOOL_CALLING = "tool_calling"
+    TOOL_RESULT = "tool_result"
+
+
+class StreamEvent(BaseModel):
+    """Streaming event with CloudEvents-inspired design.
+
+    Minimal core envelope with flexible payload. All event-specific
+    data goes in `data` dict. Convenience properties provide ergonomic
+    access to common fields.
+
+    Core Fields:
+        event_type: Type of event (STARTING, COMPLETED, FAILED, etc.)
+        timestamp: UTC timestamp when event was created
+        event_id: Unique identifier for this event
+        message: Human-readable description
+        data: Flexible payload for all event-specific data
+
+    Data Keys by Event Type:
+        COMPLETED: {"output": <OutputSchema>}
+        FAILED: {"error": str, "error_type": str}
+        THINKING: {"content": str, "source": str}
+        TOOL_CALLING: {"tool_name": str, "tool_input": dict}
+        TOOL_RESULT: {"tool_name": str, "tool_output": Any}
+
+    Example:
+        async for event in agent.astream(input_data):
+            match event.event_type:
+                case StreamEventType.COMPLETED:
+                    result = event.output
+                case StreamEventType.FAILED:
+                    print(f"Error: {event.error}")
+    """
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    # Core envelope
+    event_type: StreamEventType
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+    event_id: str = Field(default_factory=lambda: uuid.uuid4().hex[:8])
+    message: str | None = None
+
+    # Flexible payload
+    data: dict[str, Any] = Field(default_factory=dict)
+
+    # Convenience properties
+
+    @property
+    def output(self) -> Any | None:
+        """COMPLETED event output."""
+        return self.data.get("output")
+
+    @property
+    def error(self) -> str | None:
+        """FAILED event error message."""
+        return self.data.get("error")
+
+    @property
+    def tool_name(self) -> str | None:
+        """TOOL_CALLING/TOOL_RESULT tool name."""
+        return self.data.get("tool_name")
+
+    @property
+    def tool_input(self) -> dict[str, Any] | None:
+        """TOOL_CALLING input parameters."""
+        return self.data.get("tool_input")
+
+    @property
+    def tool_output(self) -> Any | None:
+        """TOOL_RESULT output value."""
+        return self.data.get("tool_output")
+
+
+class StreamingMixin:
+    """Mixin that adds astream() capability.
+
+    Wraps arun() with streaming events. arun() handles validation,
+    logging, and calls _arun() internally.
+
+    Flow:
+        astream() → STARTING → arun() → COMPLETED/FAILED
+
+    Override astream() for custom streaming (tool calling, thinking events).
+
+    Usage:
+        # Just get result
+        result = await agent.arun(input_data)
+
+        # Observe execution
+        async for event in agent.astream(input_data):
+            if event.event_type == StreamEventType.COMPLETED:
+                result = event.output
+    """
+
+    async def astream(
+        self,
+        params: Any,
+        **kwargs: Any,
+    ) -> AsyncIterator[StreamEvent]:
+        """Stream execution with events.
+
+        Wraps arun() with STARTING/COMPLETED/FAILED events.
+
+        Args:
+            params: Input parameters
+            **kwargs: Passed to arun()
+
+        Yields:
+            StreamEvent: STARTING, then COMPLETED (with output) or FAILED
+
+        Raises:
+            Exception: Re-raises after yielding FAILED event.
+        """
+        class_name = self.__class__.__name__
+
+        yield StreamEvent(
+            event_type=StreamEventType.STARTING,
+            message=f"Starting {class_name}",
+        )
+
+        try:
+            yield StreamEvent(
+                event_type=StreamEventType.RUNNING,
+                message=f"Running {class_name}",
+            )
+
+            output = await self.arun(params, **kwargs)
+
+            yield StreamEvent(
+                event_type=StreamEventType.COMPLETED,
+                message=f"Completed {class_name}",
+                data={"output": output},
+            )
+        except Exception as e:
+            yield StreamEvent(
+                event_type=StreamEventType.FAILED,
+                message=f"Failed: {e!s}",
+                data={"error": str(e), "error_type": type(e).__name__},
+            )
+            raise
+
+
+__all__ = [
+    "StreamEvent",
+    "StreamEventType",
+    "StreamingMixin",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,9 @@ python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = [
+    "-n",
+    "auto",
+    "--dist=loadfile",
     "--strict-markers",
     "--strict-config",
     "-ra",
@@ -97,6 +100,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=1.0.0",
     "pytest-cov>=6.0.0",
+    "pytest-xdist>=3.5.0",
     "pre-commit>=4.2.0",
     "memray>=1.18.0",
     "scalene>=1.5.55",

--- a/tests/agents/base/test_streaming.py
+++ b/tests/agents/base/test_streaming.py
@@ -1,0 +1,68 @@
+"""Tests for streaming support."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from .conftest import LiteLLMTestInputSchema, LiteLLMTestOutputSchema, TestLiteLLMAgent
+
+
+@pytest.fixture
+def mock_litellm():
+    """Mock LiteLLM instructor."""
+    with patch("instructor.from_litellm") as mock:
+        client = AsyncMock()
+        mock.return_value = client
+        client.chat.completions.create = AsyncMock(
+            return_value=LiteLLMTestOutputSchema(response="Test", confidence=0.9),
+        )
+        yield client
+
+
+@pytest.fixture
+def agent(mock_litellm, litellm_config):
+    """Create agent with mock."""
+    return TestLiteLLMAgent(config=litellm_config)
+
+
+class TestStreaming:
+    """Streaming tests."""
+
+    @pytest.mark.asyncio
+    async def test_astream_emits_events(self, agent, mock_litellm):
+        """Test astream emits STARTING, RUNNING, COMPLETED."""
+        events = [e async for e in agent.astream(LiteLLMTestInputSchema(query="test"))]
+
+        assert [e.event_type for e in events] == ["starting", "running", "completed"]
+
+    @pytest.mark.asyncio
+    async def test_astream_sets_source(self, agent, mock_litellm):
+        """Test source is set on all events."""
+        events = [e async for e in agent.astream(LiteLLMTestInputSchema(query="test"))]
+
+        assert all(e.source == "TestLiteLLMAgent" for e in events)
+
+    @pytest.mark.asyncio
+    async def test_astream_completed_has_output(self, agent, mock_litellm):
+        """Test COMPLETED event has output."""
+        events = [e async for e in agent.astream(LiteLLMTestInputSchema(query="test"))]
+
+        assert events[-1].output.response == "Test"
+
+    @pytest.mark.asyncio
+    async def test_astream_error_yields_failed(self, litellm_config):
+        """Test error yields FAILED event."""
+        with patch("instructor.from_litellm") as mock:
+            client = AsyncMock()
+            mock.return_value = client
+            client.chat.completions.create = AsyncMock(side_effect=ValueError("Error!"))
+
+            agent = TestLiteLLMAgent(config=litellm_config)
+            events = []
+
+            with pytest.raises(ValueError):
+                async for e in agent.astream(LiteLLMTestInputSchema(query="test")):
+                    events.append(e)
+
+            assert events[-1].event_type == "failed"
+            assert events[-1].error == "Error!"


### PR DESCRIPTION
> Disclaimer: THis is one of multiple PRs i will send out iteratively for streaming support across akd. next pr will potentially consists of converitng llm's partial stream repsonse to stream event here...

### Summary :memo:
Adds execution-level streaming support (`astream()`) for all akd agents and tools. This provides observability into agent execution via structured `StreamEvent` objects emitted during the lifecycle of `arun()`.

### Details
1. Created `akd/_base/streaming.py` with:
   - `StreamEventType` enum: STARTING, RUNNING, THINKING, COMPLETED, FAILED, TOOL_CALLING, TOOL_RESULT
   - `StreamEvent` Pydantic model with CloudEvents-inspired design (minimal envelope + flexible `data` payload)
   - `StreamingMixin` that provides default `astream()` implementation wrapping `arun()`

2. Modified `akd/_base/_base.py`:
   - Added `StreamingMixin` to `AbstractBase` and `UnrestrictedAbstractBase` inheritance

3. Updated `akd/_base/__init__.py`:
   - Exported `StreamEvent`, `StreamEventType`, `StreamingMixin`

4. Added `tests/agents/base/test_streaming.py`:
   - 4 tests covering event emission, source tracking, output handling, and error handling

## Usage

```python
from akd._base import StreamEvent, StreamEventType

# Traditional (unchanged)
result = await agent.arun(input_data)

# With streaming - observe execution lifecycle
async for event in agent.astream(input_data):
    print(f"[{event.event_type}] {event.source}: {event.message}")

    if event.event_type == StreamEventType.COMPLETED:
        result = event.output  # Access output via convenience property
    elif event.event_type == StreamEventType.FAILED:
        print(f"Error: {event.error}")
```

**StreamEvent fields:**
- `event_type` - Event type enum
- `timestamp` - UTC datetime
- `event_id` - Unique 8-char hex ID
- `source` - Class name that generated event
- `message` - Human-readable description
- `data` - Flexible payload dict (output, error, tool info, etc.)

**Convenience properties:** `event.output`, `event.error`, `event.tool_name`, `event.tool_input`, `event.tool_output`

### Checks
- [x] Tested Changes
- [ ] Stakeholder Approval
