### PR TITLE
Lazy Load Heavy Dependencies

### DIFF
--- a/akd/tools/misc.py
+++ b/akd/tools/misc.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
+import os
+
 import numpy as np
+import openai
+import tiktoken
 from loguru import logger
 from pydantic import HttpUrl, TypeAdapter
-from sentence_transformers import SentenceTransformer
-import openai
-import os
-import tiktoken
 
 HttpUrlAdapter = TypeAdapter(HttpUrl)
 
@@ -23,6 +23,10 @@ class Embedder:
     ):
         self.model_name = model_name
         logger.info(f"Loading SentenceTransformer model: {self.model_name}")
+
+        # lazy load
+        from sentence_transformers import SentenceTransformer
+
         self.model = SentenceTransformer(
             self.model_name,
             trust_remote_code=trust_remote_code,
@@ -110,7 +114,10 @@ class OpenAIEmbedder(Embedder):
         self.debug = debug
 
     def truncate_text(
-        self, text: str, max_tokens: int = 8192, buffer: int = 200
+        self,
+        text: str,
+        max_tokens: int = 8192,
+        buffer: int = 200,
     ) -> str:
         """Use tiktoken to truncate text to a maximum number of tokens."""
         enc = tiktoken.encoding_for_model(self.model_name)
@@ -124,12 +131,7 @@ class OpenAIEmbedder(Embedder):
             texts = [texts]
 
         # Ensure all elements are non-null strings
-        texts = [
-            str(t)
-            if t is not None and str(t).strip() != ""
-            else "No ReadMe or Description"
-            for t in texts
-        ]
+        texts = [str(t) if t is not None and str(t).strip() != "" else "No ReadMe or Description" for t in texts]
 
         if not texts:
             raise ValueError("No valid input texts provided for embedding.")

--- a/akd/tools/reranker.py
+++ b/akd/tools/reranker.py
@@ -5,7 +5,6 @@ from typing import Literal
 
 import numpy as np
 from pydantic.fields import Field
-from sentence_transformers import CrossEncoder
 
 from akd._base import InputSchema, OutputSchema
 from akd.structures import SearchResultItem
@@ -131,6 +130,8 @@ class CrossEncoderRerankerTool(RerankerTool):
 
     def __init__(self, config: RerankerToolConfig | None = None, debug: bool = False):
         super().__init__(config=config, debug=debug)
+        from sentence_transformers import CrossEncoder
+
         self.reranker_model = CrossEncoder(self.config.model_name)
         self.debug = debug
 

--- a/akd/tools/scrapers/__init__.py
+++ b/akd/tools/scrapers/__init__.py
@@ -1,3 +1,6 @@
+import importlib
+from typing import TYPE_CHECKING
+
 from ._base import (
     ScrapedMetadata,
     ScraperToolBase,
@@ -6,10 +9,27 @@ from ._base import (
     ScraperToolOutputSchema,
 )
 from .composite import CompositeScraper
-from .omni import DoclingScraper, DoclingScraperConfig, OmniScraperInputSchema
 from .pdf_scrapers import PDFScraperInputSchema, SimplePDFScraper
 from .pypaperbot import PyPaperBotScraper, PyPaperBotScraperConfig
 from .web_scrapers import Crawl4AIScraperConfig, Crawl4AIWebScraper, SimpleWebScraper
+
+# Lazy imports for heavy dependencies (docling)
+if TYPE_CHECKING:
+    from .omni import DoclingScraper, DoclingScraperConfig, OmniScraperInputSchema
+
+_LAZY_IMPORTS = {
+    "DoclingScraper": ".omni",
+    "DoclingScraperConfig": ".omni",
+    "OmniScraperInputSchema": ".omni",
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        module = importlib.import_module(_LAZY_IMPORTS[name], __name__)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "SimplePDFScraper",

--- a/akd/tools/search/__init__.py
+++ b/akd/tools/search/__init__.py
@@ -1,5 +1,8 @@
 """Search tools for the AKD framework."""
 
+import importlib
+from typing import TYPE_CHECKING
+
 # Re-export SearchResultItem from structures for backward compatibility
 from akd.structures import SearchResultItem
 
@@ -24,7 +27,6 @@ from .code_search import (
     SDECodeSearchToolConfig,
 )
 from .composite import CompositeSearchTool, CompositeSearchToolConfig
-from .pipeline import SearchPipeline, SearchPipelineConfig, SearchPipelineScrapingMode
 from .searxng import (
     SearxNGSearchTool,
     SearxNGSearchToolConfig,
@@ -43,6 +45,28 @@ from .serper import (
     SerperSearchToolInputSchema,
     SerperSearchToolOutputSchema,
 )
+
+# Lazy imports for heavy dependencies (pipeline depends on scrapers.omni -> docling)
+if TYPE_CHECKING:
+    from .pipeline import (
+        SearchPipeline,
+        SearchPipelineConfig,
+        SearchPipelineScrapingMode,
+    )
+
+_LAZY_IMPORTS = {
+    "SearchPipeline": ".pipeline",
+    "SearchPipelineConfig": ".pipeline",
+    "SearchPipelineScrapingMode": ".pipeline",
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        module = importlib.import_module(_LAZY_IMPORTS[name], __name__)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     # Re-exported structures
@@ -71,7 +95,7 @@ __all__ = [
     "SemanticScholarSearchToolInputSchema",
     "SemanticScholarSearchToolOutputSchema",
     "SemanticScholarSearchToolConfig",
-    # Text Search Pipeline
+    # Text Search Pipeline (lazy loaded)
     "SearchPipeline",
     "SearchPipelineConfig",
     "SearchPipelineScrapingMode",


### PR DESCRIPTION
### Summary :memo:


This Pull Request optimizes the `akd` package by implementing **lazy loading** for heavy dependencies. The primary goal is likely to reduce the initial import time and memory footprint of the package by deferring the loading of large models (like `sentence-transformers`) and complex sub-modules (like `docling`) until they are explicitly required.

### Details

The changes focus on moving import statements from the global scope to local scopes or utilizing `__getattr__` for module-level lazy loading.

1. **`akd/tools/misc.py` & `akd/tools/reranker.py**`:
* Moved `from sentence_transformers import SentenceTransformer` and `CrossEncoder` inside the `__init__` methods of their respective classes.
* This prevents loading the heavy PyTorch/HuggingFace stack just by importing the tool classes.


2. **`akd/tools/scrapers/__init__.py`**:
* Implemented a lazy import mechanism for `DoclingScraper` and related configs.
* Uses `TYPE_CHECKING` for static analysis support but defers actual runtime imports via a custom `__getattr__` function.


3. **`akd/tools/search/__init__.py`**:
* Similarly applied lazy loading for the `SearchPipeline` components (which depend on the heavy scrapers).


### Checks

* [x] **Mergeable:** The branches can be automatically merged.
* [ ] **Reviews:** No reviews yet (requires at least 1 approval).
