### PR TITLE
Feat: Add streaming support for Base Agent, DeepLitSearchAgent and CodeSearchAgent

### DIFF
--- a/akd/_base/streaming.py
+++ b/akd/_base/streaming.py
@@ -19,7 +19,9 @@ class StreamEventType(str, Enum):
 
     # Execution
     RUNNING = "running"
-    THINKING = "thinking"
+    STREAMING = "streaming"  # Raw tokens as they arrive
+    THINKING = "thinking"  # Reasoning tokens (Claude extended thinking, o1)
+    GENERATING = "generating"  # Partial structured output as it streams
 
     # Tool calling (Stage 2)
     TOOL_CALLING = "tool_calling"
@@ -44,13 +46,19 @@ class StreamEvent(BaseModel):
     Data Keys by Event Type:
         COMPLETED: {"output": <OutputSchema>}
         FAILED: {"error": str, "error_type": str}
-        THINKING: {"content": str, "source": str}
+        STREAMING: {"token": str} for raw tokens as they arrive
+        THINKING: {"thinking_content": str} for reasoning tokens (Claude/o1)
+        GENERATING: {"partial_output": Any} for partial structured output
         TOOL_CALLING: {"tool_name": str, "tool_input": dict}
         TOOL_RESULT: {"tool_name": str, "tool_output": Any}
 
     Example:
         async for event in agent.astream(input_data):
             match event.event_type:
+                case StreamEventType.THINKING:
+                    print(f"Reasoning: {event.thinking_content}")
+                case StreamEventType.GENERATING:
+                    print(f"Partial: {event.partial_output}")
                 case StreamEventType.COMPLETED:
                     result = event.output
                 case StreamEventType.FAILED:
@@ -101,6 +109,21 @@ class StreamEvent(BaseModel):
     def tool_output(self) -> Any | None:
         """TOOL_RESULT output value."""
         return self.data.get("tool_output")
+
+    @property
+    def partial_output(self) -> Any | None:
+        """THINKING event partial output (partial structured response as it builds)."""
+        return self.data.get("partial_output")
+
+    @property
+    def thinking_content(self) -> str | None:
+        """THINKING event reasoning content (Claude extended thinking, o1 reasoning)."""
+        return self.data.get("thinking_content")
+
+    @property
+    def token(self) -> str | None:
+        """STREAMING event raw token."""
+        return self.data.get("token")
 
 
 class StreamingMixin:

--- a/akd/_base/streaming.py
+++ b/akd/_base/streaming.py
@@ -21,7 +21,7 @@ class StreamEventType(str, Enum):
     RUNNING = "running"
     STREAMING = "streaming"  # Raw tokens as they arrive
     THINKING = "thinking"  # Reasoning tokens (Claude extended thinking, o1)
-    GENERATING = "generating"  # Partial structured output as it streams
+    PARTIAL = "partial"  # Partial structured output as it streams
 
     # Tool calling (Stage 2)
     TOOL_CALLING = "tool_calling"
@@ -48,7 +48,7 @@ class StreamEvent(BaseModel):
         FAILED: {"error": str, "error_type": str}
         STREAMING: {"token": str} for raw tokens as they arrive
         THINKING: {"thinking_content": str} for reasoning tokens (Claude/o1)
-        GENERATING: {"partial_output": Any} for partial structured output
+        PARTIAL: {"partial_output": Any} for partial structured output
         TOOL_CALLING: {"tool_name": str, "tool_input": dict}
         TOOL_RESULT: {"tool_name": str, "tool_output": Any}
 
@@ -59,7 +59,7 @@ class StreamEvent(BaseModel):
                     print(event.token, end="")  # Raw tokens
                 case StreamEventType.THINKING:
                     print(f"Reasoning: {event.thinking_content}")
-                case StreamEventType.GENERATING:
+                case StreamEventType.PARTIAL:
                     print(f"Partial: {event.partial_output}")
                 case StreamEventType.COMPLETED:
                     result = event.output
@@ -114,7 +114,7 @@ class StreamEvent(BaseModel):
 
     @property
     def partial_output(self) -> Any | None:
-        """GENERATING event partial output (validated partial model as JSON builds)."""
+        """PARTIAL event partial output (validated partial model as JSON builds)."""
         return self.data.get("partial_output")
 
     @property

--- a/akd/_base/streaming.py
+++ b/akd/_base/streaming.py
@@ -55,6 +55,8 @@ class StreamEvent(BaseModel):
     Example:
         async for event in agent.astream(input_data):
             match event.event_type:
+                case StreamEventType.STREAMING:
+                    print(event.token, end="")  # Raw tokens
                 case StreamEventType.THINKING:
                     print(f"Reasoning: {event.thinking_content}")
                 case StreamEventType.GENERATING:
@@ -112,7 +114,7 @@ class StreamEvent(BaseModel):
 
     @property
     def partial_output(self) -> Any | None:
-        """THINKING event partial output (partial structured response as it builds)."""
+        """GENERATING event partial output (validated partial model as JSON builds)."""
         return self.data.get("partial_output")
 
     @property

--- a/akd/_base/streaming.py
+++ b/akd/_base/streaming.py
@@ -129,21 +129,19 @@ class StreamEvent(BaseModel):
 
 
 class StreamingMixin:
-    """Mixin that adds astream() capability.
+    """Mixin that adds astream() capability with validation.
 
-    Wraps arun() with streaming events. arun() handles validation,
-    logging, and calls _arun() internally.
+    Pattern:
+        astream() → validate_input → _astream() → validate_output on COMPLETED → yield
 
-    Flow:
-        astream() → STARTING → arun() → COMPLETED/FAILED
-
-    Override astream() for custom streaming (tool calling, thinking events).
+    Subclasses override _astream() for custom streaming logic.
+    Default _astream() yields STARTING/RUNNING, calls _arun(), yields COMPLETED/FAILED.
 
     Usage:
         # Just get result
         result = await agent.arun(input_data)
 
-        # Observe execution
+        # Observe execution with streaming
         async for event in agent.astream(input_data):
             if event.event_type == StreamEventType.COMPLETED:
                 result = event.output
@@ -155,20 +153,72 @@ class StreamingMixin:
         context: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> AsyncIterator[StreamEvent]:
-        """Stream execution with events.
+        """Public streaming API with input/output validation.
 
-        Wraps arun() with STARTING/COMPLETED/FAILED events.
+        Wraps _astream() with validation:
+        - Input validation before any events are yielded
+        - Output validation on COMPLETED event before yielding
 
         Args:
             params: Input parameters
             context: Execution context (node_id, query, etc.). Auto-generates run_id if not provided.
-            **kwargs: Passed to arun()
+            **kwargs: Passed to _astream()
 
         Yields:
-            StreamEvent: STARTING, then COMPLETED (with output) or FAILED
+            StreamEvent: Events from _astream() (typically STARTING, RUNNING, COMPLETED/FAILED)
 
         Raises:
-            Exception: Re-raises after yielding FAILED event.
+            Exception: Re-raises after _astream() yields FAILED event.
+        """
+        # Input validation (before any events are yielded)
+        params = self._validate_input(params)
+
+        # Stream from internal implementation
+        async for event in self._astream(params, context, **kwargs):
+            if event.event_type == StreamEventType.COMPLETED:
+                # Validate output before yielding COMPLETED
+                output = event.data.get("output")
+                if output is not None:
+                    output = self._validate_output(output)
+                    # Yield event with validated output
+                    yield StreamEvent(
+                        event_type=event.event_type,
+                        timestamp=event.timestamp,
+                        event_id=event.event_id,
+                        source=event.source,
+                        message=event.message,
+                        data={"output": output},
+                        context=event.context,
+                    )
+                    continue
+            yield event
+
+    async def _astream(
+        self,
+        params: Any,
+        context: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[StreamEvent]:
+        """Internal streaming implementation. Override for custom streaming.
+
+        Default implementation yields STARTING/RUNNING, calls _arun(), yields COMPLETED/FAILED.
+
+        Subclasses should:
+        - Yield STARTING at the beginning
+        - Yield RUNNING events for progress updates
+        - Yield COMPLETED with {"output": result} on success
+        - Yield FAILED with {"error": str, "error_type": str} on error, then re-raise
+
+        Note: Input/output validation is handled by the parent astream() method.
+        Do NOT call _validate_input() or _validate_output() here.
+
+        Args:
+            params: Input parameters (already validated by astream())
+            context: Execution context
+            **kwargs: Additional arguments
+
+        Yields:
+            StreamEvent: STARTING, RUNNING, then COMPLETED or FAILED
         """
         class_name = self.__class__.__name__
 
@@ -192,7 +242,7 @@ class StreamingMixin:
                 context=run_context,
             )
 
-            output = await self.arun(params, **kwargs)
+            output = await self._arun(params, **kwargs)
 
             yield StreamEvent(
                 event_type=StreamEventType.COMPLETED,

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -32,7 +32,7 @@ from akd._base.streaming import StreamEvent, StreamEventType
 from akd.configs.project import CONFIG
 from akd.configs.prompts import DEFAULT_SYSTEM_PROMPT
 from akd.tools._base import BaseTool
-from akd.utils import PartialSchema
+from akd.utils import PartialModel
 
 
 class BaseAgentConfig(BaseConfig):
@@ -551,7 +551,7 @@ class LiteLLMInstructorBaseAgent[
             - {"type": StreamEventType.COMPLETED, "output": OutputSchema} for final output
         """
         response_model = response_model or self.output_schema
-        PartialModel = PartialSchema[response_model]
+        PartialResponseModel = PartialModel[response_model]
 
         completion_kwargs: dict[str, Any] = {
             "model": self.model_name,
@@ -606,7 +606,7 @@ class LiteLLMInstructorBaseAgent[
                 if parsed and parsed != last_partial_dict:
                     last_partial_dict = parsed
                     try:
-                        partial = PartialModel.model_validate(parsed)
+                        partial = PartialResponseModel.model_validate(parsed)
                         yield {"type": StreamEventType.PARTIAL, "partial": partial}
                     except Exception:
                         pass  # Skip invalid partials

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -5,7 +5,7 @@ import json
 import uuid
 from abc import abstractmethod
 from collections.abc import AsyncIterator
-from typing import Any, Literal, Optional, cast
+from typing import Any, Literal, cast
 
 import instructor
 import openai
@@ -32,6 +32,7 @@ from akd._base.streaming import StreamEvent, StreamEventType
 from akd.configs.project import CONFIG
 from akd.configs.prompts import DEFAULT_SYSTEM_PROMPT
 from akd.tools._base import BaseTool
+from akd.utils import PartialSchema
 
 
 class BaseAgentConfig(BaseConfig):
@@ -326,13 +327,6 @@ class InstructorBaseAgent[
 
         return instructor_model
 
-    def _create_partial_model(self, model: type[OutputSchema]) -> type[BaseModel]:
-        """Create partial model with all fields Optional for streaming validation."""
-        fields = {}
-        for name, info in model.model_fields.items():
-            fields[name] = (Optional[info.annotation], Field(default=None))
-        return create_model(f"Partial{model.__name__}", **fields)
-
     def _build_response_format_schema(self, model: type[OutputSchema]) -> dict[str, Any]:
         """Build JSON schema for response_format (OpenAI strict mode)."""
         schema = model.model_json_schema()
@@ -557,7 +551,7 @@ class LiteLLMInstructorBaseAgent[
             - {"type": StreamEventType.COMPLETED, "output": OutputSchema} for final output
         """
         response_model = response_model or self.output_schema
-        PartialModel = self._create_partial_model(response_model)
+        PartialModel = PartialSchema[response_model]
 
         completion_kwargs: dict[str, Any] = {
             "model": self.model_name,

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -551,10 +551,10 @@ class LiteLLMInstructorBaseAgent[
             token_batch_size: Batch N tokens before emitting STREAMING event (default=1)
 
         Yields:
-            - {"type": "streaming", "token": str} for batched raw tokens
-            - {"type": "thinking", "content": str} for reasoning tokens
-            - {"type": "partial", "partial": PartialModel} for validated partials
-            - {"type": "final", "output": OutputSchema} for final output
+            - {"type": StreamEventType.STREAMING, "token": str} for batched raw tokens
+            - {"type": StreamEventType.THINKING, "content": str} for reasoning tokens
+            - {"type": StreamEventType.PARTIAL, "partial": PartialModel} for validated partials
+            - {"type": StreamEventType.COMPLETED, "output": OutputSchema} for final output
         """
         response_model = response_model or self.output_schema
         PartialModel = self._create_partial_model(response_model)
@@ -595,7 +595,7 @@ class LiteLLMInstructorBaseAgent[
                 None,
             )
             if reasoning:
-                yield {"type": "thinking", "content": reasoning}
+                yield {"type": StreamEventType.THINKING, "content": reasoning}
 
             # Content tokens - batch, then accumulate and validate as partial
             if delta.content:
@@ -604,7 +604,7 @@ class LiteLLMInstructorBaseAgent[
 
                 # Emit batched tokens
                 if len(token_buffer) >= token_batch_size:
-                    yield {"type": "streaming", "token": token_buffer}
+                    yield {"type": StreamEventType.STREAMING, "token": token_buffer}
                     token_buffer = ""
 
                 # Try to validate as partial
@@ -613,40 +613,42 @@ class LiteLLMInstructorBaseAgent[
                     last_partial_dict = parsed
                     try:
                         partial = PartialModel.model_validate(parsed)
-                        yield {"type": "partial", "partial": partial}
+                        yield {"type": StreamEventType.PARTIAL, "partial": partial}
                     except Exception:
                         pass  # Skip invalid partials
 
         # Emit remaining tokens
         if token_buffer:
-            yield {"type": "streaming", "token": token_buffer}
+            yield {"type": StreamEventType.STREAMING, "token": token_buffer}
 
         # Final validation
         output = response_model.model_validate_json(accumulated)
-        yield {"type": "final", "output": output}
+        yield {"type": StreamEventType.COMPLETED, "output": output}
 
-    async def astream(
+    async def _astream(
         self,
         params: InSchema,
         context: dict[str, Any] | None = None,
         token_batch_size: int = 10,
         **kwargs: Any,
     ) -> AsyncIterator[StreamEvent]:
-        """Stream execution with thinking tokens and partial output.
+        """Internal streaming with thinking tokens and partial output.
 
-        Overrides base astream() to emit:
+        Emits:
         - STREAMING events for raw tokens (batched)
         - THINKING events for reasoning tokens (Claude extended thinking, o1)
-        - GENERATING events for partial structured output as it streams
+        - PARTIAL events for partial structured output as it streams
+
+        Note: Input/output validation is handled by parent astream() method.
 
         Args:
-            params: Input parameters
+            params: Input parameters (already validated by astream())
             context: Execution context (node_id, query, etc.)
             token_batch_size: Batch N characters before emitting STREAMING event (default=10)
             **kwargs: Additional keyword arguments
 
         Yields:
-            StreamEvent: STARTING, RUNNING, STREAMING, GENERATING, then COMPLETED or FAILED
+            StreamEvent: STARTING, RUNNING, STREAMING, PARTIAL, then COMPLETED or FAILED
 
         Example:
             async for event in agent.astream(input_data, token_batch_size=20):
@@ -655,7 +657,7 @@ class LiteLLMInstructorBaseAgent[
                         print(event.token, end="")  # Raw tokens
                     case StreamEventType.THINKING:
                         print(f"Reasoning: {event.thinking_content}")
-                    case StreamEventType.GENERATING:
+                    case StreamEventType.PARTIAL:
                         print(f"Partial: {event.partial_output}")
                     case StreamEventType.COMPLETED:
                         print(f"Final: {event.output}")
@@ -677,8 +679,7 @@ class LiteLLMInstructorBaseAgent[
         )
 
         try:
-            # Validate input
-            params = self._validate_input(params)
+            # Note: Input validation handled by parent astream()
 
             # Build messages (same logic as _arun)
             messages = [] if self.stateless else self.memory
@@ -712,14 +713,14 @@ class LiteLLMInstructorBaseAgent[
             # Stream LLM response with raw tokens, thinking, and partial output
             final_output = None
             async for chunk in self._stream_llm_response(messages, token_batch_size=token_batch_size):
-                if chunk["type"] == "streaming":
+                if chunk["type"] == StreamEventType.STREAMING:
                     yield StreamEvent(
                         event_type=StreamEventType.STREAMING,
                         source=class_name,
                         data={"token": chunk["token"]},
                         context=run_context,
                     )
-                elif chunk["type"] == "thinking":
+                elif chunk["type"] == StreamEventType.THINKING:
                     yield StreamEvent(
                         event_type=StreamEventType.THINKING,
                         source=class_name,
@@ -727,22 +728,22 @@ class LiteLLMInstructorBaseAgent[
                         data={"thinking_content": chunk["content"]},
                         context=run_context,
                     )
-                elif chunk["type"] == "partial":
+                elif chunk["type"] == StreamEventType.PARTIAL:
                     yield StreamEvent(
-                        event_type=StreamEventType.GENERATING,
+                        event_type=StreamEventType.PARTIAL,
                         source=class_name,
-                        message="Generating...",
+                        message="Partial...",
                         data={"partial_output": chunk["partial"]},
                         context=run_context,
                     )
-                elif chunk["type"] == "final":
+                elif chunk["type"] == StreamEventType.COMPLETED:
                     final_output = chunk["output"]
 
             if final_output is None:
                 raise ValueError("No output received from LLM")
 
-            # Validate output
-            output = self._validate_output(final_output)
+            # Note: Output validation handled by parent astream()
+            output = final_output
 
             # Update memory if stateful
             messages.append(

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -539,7 +539,7 @@ class LiteLLMInstructorBaseAgent[
         self,
         messages: list[dict[str, str]],
         response_model: type[OutputSchema] | None = None,
-        token_batch_size: int = 1,
+        token_batch_size: int = 10,
     ) -> AsyncIterator[dict[str, Any]]:
         """Stream LLM response with thinking tokens and validated partial output.
 

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import copy
+import json
+import uuid
 from abc import abstractmethod
-from typing import Any, Literal, cast
+from collections.abc import AsyncIterator
+from typing import Any, Literal, Optional, cast
 
 import instructor
 import openai
@@ -25,6 +28,7 @@ from akd._base import (
     OutputSchema,
     ParamExposureMixin,
 )
+from akd._base.streaming import StreamEvent, StreamEventType
 from akd.configs.project import CONFIG
 from akd.configs.prompts import DEFAULT_SYSTEM_PROMPT
 from akd.tools._base import BaseTool
@@ -322,6 +326,29 @@ class InstructorBaseAgent[
 
         return instructor_model
 
+    def _create_partial_model(self, model: type[OutputSchema]) -> type[BaseModel]:
+        """Create partial model with all fields Optional for streaming validation."""
+        fields = {}
+        for name, info in model.model_fields.items():
+            fields[name] = (Optional[info.annotation], Field(default=None))
+        return create_model(f"Partial{model.__name__}", **fields)
+
+    def _build_response_format_schema(self, model: type[OutputSchema]) -> dict[str, Any]:
+        """Build JSON schema for response_format (OpenAI strict mode)."""
+        schema = model.model_json_schema()
+        schema.pop("$defs", None)
+        if schema.get("type") == "object" and "properties" in schema:
+            schema["additionalProperties"] = False
+            schema["required"] = list(schema["properties"].keys())
+        return schema
+
+    def _try_parse_json(self, content: str) -> dict[str, Any] | None:
+        """Try to parse content as JSON."""
+        try:
+            return json.loads(content)
+        except json.JSONDecodeError:
+            return None
+
     async def get_response_async(
         self,
         messages: list[dict[str, str]],
@@ -507,3 +534,240 @@ class LiteLLMInstructorBaseAgent[
         response_data = response.model_dump()
         response = response_model(**response_data)
         return cast(OutSchema, response)
+
+    async def _stream_llm_response(
+        self,
+        messages: list[dict[str, str]],
+        response_model: type[OutputSchema] | None = None,
+        token_batch_size: int = 1,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Stream LLM response with thinking tokens and validated partial output.
+
+        Uses raw LiteLLM streaming to access thinking tokens (reasoning_content).
+
+        Args:
+            messages: Chat messages
+            response_model: Output schema (defaults to self.output_schema)
+            token_batch_size: Batch N tokens before emitting STREAMING event (default=1)
+
+        Yields:
+            - {"type": "streaming", "token": str} for batched raw tokens
+            - {"type": "thinking", "content": str} for reasoning tokens
+            - {"type": "partial", "partial": PartialModel} for validated partials
+            - {"type": "final", "output": OutputSchema} for final output
+        """
+        response_model = response_model or self.output_schema
+        PartialModel = self._create_partial_model(response_model)
+
+        completion_kwargs: dict[str, Any] = {
+            "model": self.model_name,
+            "messages": messages,
+            "stream": True,
+            "temperature": self.temperature,
+            "api_base": str(self.base_url).rstrip("/") if self.base_url else None,
+            "api_key": self.api_key,
+            "drop_params": True,  # Allow unsupported params to be dropped
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": response_model.__name__,
+                    "strict": True,
+                    "schema": self._build_response_format_schema(response_model),
+                },
+            },
+        }
+
+        if self.reasoning_effort:
+            completion_kwargs["reasoning_effort"] = self.reasoning_effort
+
+        accumulated = ""
+        token_buffer = ""
+        last_partial_dict = None
+
+        response = await acompletion(**completion_kwargs)
+        async for chunk in response:
+            delta = chunk.choices[0].delta
+
+            # Thinking tokens (Claude extended thinking, o1 reasoning)
+            reasoning = getattr(delta, "reasoning_content", None) or getattr(
+                delta,
+                "thinking",
+                None,
+            )
+            if reasoning:
+                yield {"type": "thinking", "content": reasoning}
+
+            # Content tokens - batch, then accumulate and validate as partial
+            if delta.content:
+                token_buffer += delta.content
+                accumulated += delta.content
+
+                # Emit batched tokens
+                if len(token_buffer) >= token_batch_size:
+                    yield {"type": "streaming", "token": token_buffer}
+                    token_buffer = ""
+
+                # Try to validate as partial
+                parsed = self._try_parse_json(accumulated)
+                if parsed and parsed != last_partial_dict:
+                    last_partial_dict = parsed
+                    try:
+                        partial = PartialModel.model_validate(parsed)
+                        yield {"type": "partial", "partial": partial}
+                    except Exception:
+                        pass  # Skip invalid partials
+
+        # Emit remaining tokens
+        if token_buffer:
+            yield {"type": "streaming", "token": token_buffer}
+
+        # Final validation
+        output = response_model.model_validate_json(accumulated)
+        yield {"type": "final", "output": output}
+
+    async def astream(
+        self,
+        params: InSchema,
+        context: dict[str, Any] | None = None,
+        token_batch_size: int = 10,
+        **kwargs: Any,
+    ) -> AsyncIterator[StreamEvent]:
+        """Stream execution with thinking tokens and partial output.
+
+        Overrides base astream() to emit:
+        - STREAMING events for raw tokens (batched)
+        - THINKING events for reasoning tokens (Claude extended thinking, o1)
+        - GENERATING events for partial structured output as it streams
+
+        Args:
+            params: Input parameters
+            context: Execution context (node_id, query, etc.)
+            token_batch_size: Batch N characters before emitting STREAMING event (default=10)
+            **kwargs: Additional keyword arguments
+
+        Yields:
+            StreamEvent: STARTING, RUNNING, STREAMING, GENERATING, then COMPLETED or FAILED
+
+        Example:
+            async for event in agent.astream(input_data, token_batch_size=20):
+                match event.event_type:
+                    case StreamEventType.STREAMING:
+                        print(event.token, end="")  # Raw tokens
+                    case StreamEventType.THINKING:
+                        print(f"Reasoning: {event.thinking_content}")
+                    case StreamEventType.GENERATING:
+                        print(f"Partial: {event.partial_output}")
+                    case StreamEventType.COMPLETED:
+                        print(f"Final: {event.output}")
+                    case StreamEventType.FAILED:
+                        print(f"Error: {event.error}")
+        """
+        class_name = self.__class__.__name__
+
+        # Auto-generate run_id for event correlation
+        run_context = context.copy() if context else {}
+        if "run_id" not in run_context:
+            run_context["run_id"] = uuid.uuid4().hex[:8]
+
+        yield StreamEvent(
+            event_type=StreamEventType.STARTING,
+            source=class_name,
+            message=f"Starting {class_name}",
+            context=run_context,
+        )
+
+        try:
+            # Validate input
+            params = self._validate_input(params)
+
+            # Build messages (same logic as _arun)
+            messages = [] if self.stateless else self.memory
+            if not messages:
+                messages.append(self._default_system_message())
+
+            if params:
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": params.model_dump_json(exclude={"type"}),
+                    },
+                )
+
+            # Apply trimming if enabled
+            if self.enable_trimming:
+                messages = trim_messages(
+                    messages,
+                    model=self.model_name,
+                    max_tokens=self.max_tokens,
+                    trim_ratio=self.trim_ratio,
+                )
+
+            yield StreamEvent(
+                event_type=StreamEventType.RUNNING,
+                source=class_name,
+                message=f"Running {class_name}",
+                context=run_context,
+            )
+
+            # Stream LLM response with raw tokens, thinking, and partial output
+            final_output = None
+            async for chunk in self._stream_llm_response(messages, token_batch_size=token_batch_size):
+                if chunk["type"] == "streaming":
+                    yield StreamEvent(
+                        event_type=StreamEventType.STREAMING,
+                        source=class_name,
+                        data={"token": chunk["token"]},
+                        context=run_context,
+                    )
+                elif chunk["type"] == "thinking":
+                    yield StreamEvent(
+                        event_type=StreamEventType.THINKING,
+                        source=class_name,
+                        message="Reasoning...",
+                        data={"thinking_content": chunk["content"]},
+                        context=run_context,
+                    )
+                elif chunk["type"] == "partial":
+                    yield StreamEvent(
+                        event_type=StreamEventType.GENERATING,
+                        source=class_name,
+                        message="Generating...",
+                        data={"partial_output": chunk["partial"]},
+                        context=run_context,
+                    )
+                elif chunk["type"] == "final":
+                    final_output = chunk["output"]
+
+            if final_output is None:
+                raise ValueError("No output received from LLM")
+
+            # Validate output
+            output = self._validate_output(final_output)
+
+            # Update memory if stateful
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": output.model_dump_json(exclude={"type"}),
+                },
+            )
+            if not self.stateless:
+                self._memory = messages
+
+            yield StreamEvent(
+                event_type=StreamEventType.COMPLETED,
+                source=class_name,
+                message=f"Completed {class_name}",
+                data={"output": output},
+                context=run_context,
+            )
+
+        except Exception as e:
+            yield StreamEvent(
+                event_type=StreamEventType.FAILED,
+                source=class_name,
+                message=f"Failed: {e!s}",
+                data={"error": str(e), "error_type": type(e).__name__},
+                context=run_context,
+            )
+            raise

--- a/akd/agents/search/controlled.py
+++ b/akd/agents/search/controlled.py
@@ -42,7 +42,7 @@ from akd.tools.link_relevancy_assessor import (
 from akd.tools.reranker import RerankerToolInputSchema
 from akd.tools.search import SearxNGSearchTool
 from akd.tools.search._base import QueryFocusStrategy, SearchToolInputSchema
-from akd.utils import PartialSchema
+from akd.utils import PartialModel
 
 from ._base import (
     LitBaseAgent,
@@ -1036,7 +1036,7 @@ class ControlledSearchAgent(LitBaseAgent):
                 source=class_name,
                 message="Search results available",
                 data={
-                    "partial_output": PartialSchema[LitSearchAgentOutputSchema](
+                    "partial_output": PartialModel[LitSearchAgentOutputSchema](
                         results=all_results,
                         extra={"iterations_performed": iteration},
                     ),
@@ -1077,7 +1077,7 @@ class ControlledSearchAgent(LitBaseAgent):
                 source=class_name,
                 message="Report generated",
                 data={
-                    "partial_output": PartialSchema[LitSearchAgentOutputSchema](
+                    "partial_output": PartialModel[LitSearchAgentOutputSchema](
                         results=all_results,
                         report=detailed_report,
                         extra={

--- a/akd/agents/search/controlled.py
+++ b/akd/agents/search/controlled.py
@@ -7,11 +7,14 @@ and agentic decision-making to iteratively refine search queries based on rubric
 
 from __future__ import annotations
 
+import uuid
+from collections.abc import AsyncIterator
 from typing import Any, List, Optional
 
 from loguru import logger
 from pydantic import Field
 
+from akd._base.streaming import StreamEvent, StreamEventType
 from akd.agents.query import (
     FollowUpQueryAgent,
     FollowUpQueryAgentInputSchema,
@@ -733,6 +736,46 @@ class ControlledSearchAgent(LitBaseAgent):
             },
         )
 
+    def _emit_step_event(
+        self,
+        step: str,
+        message: str,
+        run_context: dict[str, Any],
+        step_index: int | None = None,
+        total_steps: int | None = None,
+        substep: str | None = None,
+        **data_kwargs: Any,
+    ) -> StreamEvent:
+        """Create a RUNNING event for a pipeline step.
+
+        Args:
+            step: Step identifier (e.g., "iteration", "search", "evaluate")
+            message: Human-readable description
+            run_context: Execution context dict
+            step_index: Current step number (optional)
+            total_steps: Total number of steps (optional)
+            substep: Sub-step identifier (optional)
+            **data_kwargs: Additional data fields
+
+        Returns:
+            StreamEvent with RUNNING type and step metadata
+        """
+        data = {"step": step, **data_kwargs}
+        if step_index is not None:
+            data["step_index"] = step_index
+        if total_steps is not None:
+            data["total_steps"] = total_steps
+        if substep is not None:
+            data["substep"] = substep
+
+        return StreamEvent(
+            event_type=StreamEventType.RUNNING,
+            source=self.__class__.__name__,
+            message=message,
+            data=data,
+            context=run_context,
+        )
+
     async def _generate_report(
         self,
         query: str,
@@ -754,151 +797,323 @@ class ControlledSearchAgent(LitBaseAgent):
         # For now, return empty string as placeholder
         return ""
 
+    async def _astream(
+        self,
+        params: LitSearchAgentInputSchema,
+        context: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[StreamEvent]:
+        """Stream events during controlled search execution.
+
+        Yields RUNNING events throughout the iterative search loop,
+        then COMPLETED or FAILED at the end.
+
+        Args:
+            params: Input parameters (already validated by astream())
+            context: Execution context
+            **kwargs: Additional arguments
+
+        Yields:
+            StreamEvent: STARTING, RUNNING (iteration/search/evaluate), COMPLETED/FAILED
+        """
+        class_name = self.__class__.__name__
+
+        # Setup run context
+        run_context = context.copy() if context else {}
+        if "run_id" not in run_context:
+            run_context["run_id"] = uuid.uuid4().hex[:8]
+
+        # STARTING event
+        yield StreamEvent(
+            event_type=StreamEventType.STARTING,
+            source=class_name,
+            message=f"Starting {class_name}",
+            data={"query": params.query},
+            context=run_context,
+        )
+
+        try:
+            desired_max_results = params.search_mode.to_max_results()
+            queries = [params.query]
+
+            iteration = 0
+            all_results = []
+            current_results = []
+            content_so_far = ""
+
+            while not (
+                criteria := await self._should_stop(
+                    iteration=iteration,
+                    all_results=all_results,
+                    current_results=current_results,
+                    max_results=desired_max_results,
+                    query=params.query,
+                )
+            ).stop_now:
+                logger.debug(f"Stopping Criteria :: {criteria}")
+                iteration += 1
+
+                # Emit iteration start event
+                yield self._emit_step_event(
+                    step="iteration",
+                    message=f"Starting iteration {iteration}/{self.config.max_iteration}",
+                    run_context=run_context,
+                    step_index=iteration,
+                    total_steps=self.config.max_iteration,
+                    results_so_far=len(all_results),
+                    target_results=desired_max_results,
+                )
+
+                if self.debug:
+                    logger.info(f"🔄 ITERATION {iteration}")
+
+                remaining_needed = desired_max_results - len(all_results)
+                dynamic_batch_size = self._calculate_dynamic_batch_size(iteration, criteria)
+                search_limit = min(remaining_needed, dynamic_batch_size)
+
+                current_queries = queries
+                if iteration > 0:
+                    rubric_focus = None
+                    if hasattr(criteria, "recommended_query_focus") and criteria.recommended_query_focus:
+                        rubric_focus = criteria.recommended_query_focus
+
+                    logger.debug(f"Rubric focus for iteration {iteration}: {rubric_focus}")
+
+                    # Emit query generation event
+                    yield self._emit_step_event(
+                        step="iteration.queries",
+                        message=f"Generating queries for iteration {iteration}",
+                        run_context=run_context,
+                        substep="generating",
+                        rubric_focus=rubric_focus,
+                    )
+
+                    current_queries = await self._generate_queries(
+                        iteration=iteration,
+                        num_queries=3,
+                        queries=queries,
+                        results=all_results,
+                        accumulated_content=content_so_far,
+                        rubric_focus=rubric_focus,
+                    )
+
+                    # Emit queries generated event
+                    yield self._emit_step_event(
+                        step="iteration.queries",
+                        message=f"Generated {len(current_queries)} queries",
+                        run_context=run_context,
+                        substep="complete",
+                        queries=current_queries,
+                    )
+
+                logger.debug(f"Generated queries (iteration {iteration}): {current_queries}")
+
+                # Emit search event
+                yield self._emit_step_event(
+                    step="iteration.search",
+                    message=f"Searching with {len(current_queries)} queries",
+                    run_context=run_context,
+                    substep="searching",
+                    queries=current_queries,
+                    search_limit=search_limit,
+                )
+
+                search_input = SearchToolInputSchema(
+                    queries=current_queries,
+                    max_results=search_limit,
+                )
+
+                search_result = await self.search_tool.arun(
+                    self.search_tool.input_schema(**search_input.model_dump()),
+                )
+
+                current_results = self._deduplicate_results(
+                    new_results=search_result.results,
+                    existing_results=all_results,
+                )
+
+                # Fallback mechanism
+                if not current_results and iteration > 1 and current_queries != queries:
+                    if self.debug:
+                        logger.debug(
+                            f"No results from adapted queries, falling back to original queries: {queries}",
+                        )
+
+                    yield self._emit_step_event(
+                        step="iteration.search",
+                        message="Falling back to original queries",
+                        run_context=run_context,
+                        substep="fallback",
+                    )
+
+                    fallback_input = SearchToolInputSchema(
+                        queries=queries,
+                        max_results=search_limit,
+                    )
+
+                    fallback_result = await self.search_tool.arun(
+                        self.search_tool.input_schema(**fallback_input.model_dump()),
+                    )
+
+                    current_results = self._deduplicate_results(
+                        new_results=fallback_result.results,
+                        existing_results=all_results,
+                    )
+
+                    if current_results and self.debug:
+                        logger.debug(f"Fallback successful: found {len(current_results)} results")
+
+                # Emit search complete event
+                yield self._emit_step_event(
+                    step="iteration.search",
+                    message=f"Found {len(current_results)} new results",
+                    run_context=run_context,
+                    substep="complete",
+                    new_results_count=len(current_results),
+                    raw_results_count=len(search_result.results),
+                )
+
+                all_results.extend(current_results)
+
+                # Emit rerank event
+                yield self._emit_step_event(
+                    step="iteration.rerank",
+                    message=f"Reranking {len(all_results)} results",
+                    run_context=run_context,
+                    substep="reranking",
+                    total_results=len(all_results),
+                )
+
+                reranker_input = RerankerToolInputSchema(
+                    query=params.query,
+                    results=all_results,
+                )
+                reranked_results = await self.reranker.arun(reranker_input)
+                all_results = reranked_results.results
+
+                yield self._emit_step_event(
+                    step="iteration.rerank",
+                    message=f"Reranked to {len(all_results)} results",
+                    run_context=run_context,
+                    substep="complete",
+                    total_results=len(all_results),
+                )
+
+                # Update accumulated content
+                new_content = self._accumulate_content(current_results)
+                if new_content:
+                    content_so_far += "\n" + new_content if content_so_far else new_content
+
+                # Learn from iteration if rubric analysis available
+                if hasattr(criteria, "rubric_analysis") and criteria.rubric_analysis:
+                    self._learn_from_iteration(
+                        iteration,
+                        current_queries,
+                        criteria.rubric_analysis,
+                    )
+
+                    # Emit evaluate event with rubric info
+                    yield self._emit_step_event(
+                        step="iteration.evaluate",
+                        message=f"Rubric: {criteria.rubric_analysis.positive_rubric_count}/6 positive",
+                        run_context=run_context,
+                        positive_rubrics=criteria.rubric_analysis.positive_rubric_count,
+                        strong_rubrics=criteria.rubric_analysis.strong_rubrics,
+                        weak_rubrics=criteria.rubric_analysis.weak_rubrics,
+                        overall_assessment=criteria.rubric_analysis.overall_assessment,
+                    )
+
+                if self.debug:
+                    logger.debug(f"Content accumulated so far (chars): {len(content_so_far)}")
+                    logger.debug(f"Current iteration results: {len(current_results)}")
+
+            logger.debug(f"Final Stopping Criteria :: {criteria}")
+
+            # Emit synthesis events
+            yield self._emit_step_event(
+                step="synthesis.answer",
+                message="Generating answer",
+                run_context=run_context,
+                substep="generating",
+                total_results=len(all_results),
+            )
+
+            shortform_answer = await self._generate_answer(
+                query=params.query,
+                search_results=all_results,
+                additional_context=f"Final stopping criteria: {criteria}",
+            )
+
+            yield self._emit_step_event(
+                step="synthesis.answer",
+                message="Answer generated",
+                run_context=run_context,
+                substep="complete",
+                answer_preview=shortform_answer.answer[:200] if shortform_answer.answer else None,
+            )
+
+            yield self._emit_step_event(
+                step="synthesis.report",
+                message="Generating report",
+                run_context=run_context,
+                substep="generating",
+            )
+
+            detailed_report = await self._generate_report(
+                query=params.query,
+                results=all_results,
+            )
+
+            yield self._emit_step_event(
+                step="synthesis.report",
+                message="Report generated",
+                run_context=run_context,
+                substep="complete",
+                report_preview=detailed_report[:200] if detailed_report else None,
+            )
+
+            # Build output
+            output = LitSearchAgentOutputSchema(
+                answer=shortform_answer.answer,
+                report=detailed_report,
+                results=all_results,
+                extra=dict(
+                    answer_reasoning_traces=shortform_answer.reasoning_traces,
+                    iterations_performed=iteration,
+                ),
+            )
+
+            # COMPLETED event
+            yield StreamEvent(
+                event_type=StreamEventType.COMPLETED,
+                source=class_name,
+                message=f"Completed {class_name}",
+                data={"output": output},
+                context=run_context,
+            )
+
+        except Exception as e:
+            # FAILED event
+            yield StreamEvent(
+                event_type=StreamEventType.FAILED,
+                source=class_name,
+                message=f"Failed: {e!s}",
+                data={"error": str(e), "error_type": type(e).__name__},
+                context=run_context,
+            )
+            raise
+
     async def _arun(
         self,
         params: LitSearchAgentInputSchema,
         **kwargs: Any,
     ) -> LitSearchAgentOutputSchema:
-        desired_max_results = params.search_mode.to_max_results()
-        queries = [params.query]  # Convert single query to list for compatibility
+        """Run by collecting output from _astream()."""
+        output = None
+        async for event in self._astream(params, **kwargs):
+            if event.event_type == StreamEventType.COMPLETED:
+                output = event.output
 
-        iteration = 0
-        all_results = []
-        current_results = []
-        content_so_far = ""
-
-        while not (
-            criteria := await self._should_stop(
-                iteration=iteration,
-                all_results=all_results,
-                current_results=current_results,
-                max_results=desired_max_results,
-                query=params.query,
-            )
-        ).stop_now:
-            logger.debug(f"Stopping Criteria :: {criteria}")
-            iteration += 1
-
-            if self.debug:
-                logger.info(f"🔄 ITERATION {iteration}")
-
-            remaining_needed = desired_max_results - len(all_results)
-            # Dynamic batch sizing: adjust based on previous rubric performance
-            dynamic_batch_size = self._calculate_dynamic_batch_size(iteration, criteria)
-            search_limit = min(remaining_needed, dynamic_batch_size)
-
-            current_queries = queries
-            if iteration > 0:
-                # Get rubric focus from previous iteration's stopping criteria
-                rubric_focus = None
-                if hasattr(criteria, "recommended_query_focus") and criteria.recommended_query_focus:
-                    rubric_focus = criteria.recommended_query_focus
-
-                logger.debug(f"Rubric focus for iteration {iteration}: {rubric_focus}")
-
-                current_queries = await self._generate_queries(
-                    iteration=iteration,
-                    num_queries=3,
-                    queries=queries,
-                    results=all_results,
-                    accumulated_content=content_so_far,  # Pass accumulated content
-                    rubric_focus=rubric_focus,  # Pass rubric focus for adaptive queries
-                )
-
-            logger.debug(
-                f"Generated queries (iteration {iteration}): {current_queries}",
-            )
-
-            search_input = SearchToolInputSchema(
-                queries=current_queries,
-                max_results=search_limit,
-            )
-
-            search_result = await self.search_tool.arun(
-                self.search_tool.input_schema(**search_input.model_dump()),
-            )
-
-            current_results = self._deduplicate_results(
-                new_results=search_result.results,
-                existing_results=all_results,
-            )
-
-            # Fallback mechanism: If adapted queries return no results, try original queries
-            if not current_results and iteration > 1 and current_queries != queries:
-                if self.debug:
-                    logger.debug(
-                        f"No results from adapted queries, falling back to original queries: {queries}",
-                    )
-
-                fallback_input = SearchToolInputSchema(
-                    queries=queries,  # Use original queries
-                    max_results=search_limit,
-                )
-
-                fallback_result = await self.search_tool.arun(
-                    self.search_tool.input_schema(**fallback_input.model_dump()),
-                )
-
-                current_results = self._deduplicate_results(
-                    new_results=fallback_result.results,
-                    existing_results=all_results,
-                )
-
-                if current_results and self.debug:
-                    logger.debug(
-                        f"Fallback successful: found {len(current_results)} results",
-                    )
-
-            all_results.extend(current_results)
-
-            reranker_input = RerankerToolInputSchema(
-                query=params.query,
-                results=all_results,
-            )
-            reranked_results = await self.reranker.arun(reranker_input)
-            all_results = reranked_results.results
-
-            # Update accumulated content after each iteration
-            new_content = self._accumulate_content(current_results)
-            if new_content:
-                content_so_far += "\n" + new_content if content_so_far else new_content
-
-            # Learn from this iteration if we have rubric analysis
-            if hasattr(criteria, "rubric_analysis") and criteria.rubric_analysis:
-                self._learn_from_iteration(
-                    iteration,
-                    current_queries,
-                    criteria.rubric_analysis,
-                )
-
-            if self.debug:
-                logger.debug(
-                    f"Content accumulated so far (chars): {len(content_so_far)}",
-                )
-                logger.debug(
-                    f"Current iteration results: {len(current_results)}",
-                )
-
-        logger.debug(f"Final Stopping Criteria :: {criteria}")
-
-        # Generate shortform answer and report
-        shortform_answer = await self._generate_answer(
-            query=params.query,
-            search_results=all_results,
-            additional_context=f"Final stopping criteria: {criteria}",
-        )
-
-        detailed_report = await self._generate_report(
-            query=params.query,
-            results=all_results,
-        )
-
-        return LitSearchAgentOutputSchema(
-            answer=shortform_answer.answer,
-            report=detailed_report,
-            results=all_results,
-            extra=dict(
-                answer_reasoning_traces=shortform_answer.reasoning_traces,
-                iterations_performed=iteration,
-            ),
-        )
+        if output is None:
+            raise RuntimeError("No output received from _astream()")
+        return output

--- a/akd/agents/search/controlled.py
+++ b/akd/agents/search/controlled.py
@@ -42,6 +42,7 @@ from akd.tools.link_relevancy_assessor import (
 from akd.tools.reranker import RerankerToolInputSchema
 from akd.tools.search import SearxNGSearchTool
 from akd.tools.search._base import QueryFocusStrategy, SearchToolInputSchema
+from akd.utils import PartialSchema
 
 from ._base import (
     LitBaseAgent,
@@ -1029,6 +1030,20 @@ class ControlledSearchAgent(LitBaseAgent):
 
             logger.debug(f"Final Stopping Criteria :: {criteria}")
 
+            # PARTIAL event: search results available
+            yield StreamEvent(
+                event_type=StreamEventType.PARTIAL,
+                source=class_name,
+                message="Search results available",
+                data={
+                    "partial_output": PartialSchema[LitSearchAgentOutputSchema](
+                        results=all_results,
+                        extra={"iterations_performed": iteration},
+                    ),
+                },
+                context=run_context,
+            )
+
             # Emit synthesis events
             yield self._emit_step_event(
                 step="synthesis.answer",
@@ -1045,14 +1060,6 @@ class ControlledSearchAgent(LitBaseAgent):
             )
 
             yield self._emit_step_event(
-                step="synthesis.answer",
-                message="Answer generated",
-                run_context=run_context,
-                substep="complete",
-                answer_preview=shortform_answer.answer[:200] if shortform_answer.answer else None,
-            )
-
-            yield self._emit_step_event(
                 step="synthesis.report",
                 message="Generating report",
                 run_context=run_context,
@@ -1064,12 +1071,22 @@ class ControlledSearchAgent(LitBaseAgent):
                 results=all_results,
             )
 
-            yield self._emit_step_event(
-                step="synthesis.report",
+            # PARTIAL event: report available
+            yield StreamEvent(
+                event_type=StreamEventType.PARTIAL,
+                source=class_name,
                 message="Report generated",
-                run_context=run_context,
-                substep="complete",
-                report_preview=detailed_report[:200] if detailed_report else None,
+                data={
+                    "partial_output": PartialSchema[LitSearchAgentOutputSchema](
+                        results=all_results,
+                        report=detailed_report,
+                        extra={
+                            "answer_reasoning_traces": shortform_answer.reasoning_traces,
+                            "iterations_performed": iteration,
+                        },
+                    ),
+                },
+                context=run_context,
             )
 
             # Build output

--- a/akd/agents/search/deep_search.py
+++ b/akd/agents/search/deep_search.py
@@ -38,7 +38,7 @@ from akd.structures import SearchResultItem
 from akd.tools.search import SearchTool
 from akd.tools.search.pipeline import SearchPipeline
 from akd.tools.search.searxng import SearxNGSearchTool
-from akd.utils import PartialSchema
+from akd.utils import PartialModel
 
 from ._base import (
     LitBaseAgent,
@@ -884,7 +884,7 @@ class DeepLitSearchAgent(LitBaseAgent):
                 source=class_name,
                 message="Research results available",
                 data={
-                    "partial_output": PartialSchema[LitSearchAgentOutputSchema](
+                    "partial_output": PartialModel[LitSearchAgentOutputSchema](
                         results=research_output["results"],
                         extra={
                             "key_findings": research_output["key_findings"],
@@ -919,7 +919,7 @@ class DeepLitSearchAgent(LitBaseAgent):
                 source=class_name,
                 message="Report generated",
                 data={
-                    "partial_output": PartialSchema[LitSearchAgentOutputSchema](
+                    "partial_output": PartialModel[LitSearchAgentOutputSchema](
                         results=research_output["results"],
                         report=detailed_report,
                         extra={

--- a/akd/agents/search/deep_search.py
+++ b/akd/agents/search/deep_search.py
@@ -38,6 +38,7 @@ from akd.structures import SearchResultItem
 from akd.tools.search import SearchTool
 from akd.tools.search.pipeline import SearchPipeline
 from akd.tools.search.searxng import SearxNGSearchTool
+from akd.utils import PartialSchema
 
 from ._base import (
     LitBaseAgent,
@@ -877,6 +878,25 @@ class DeepLitSearchAgent(LitBaseAgent):
                 iterations_performed=research_output["iterations_performed"],
             )
 
+            # PARTIAL event: research results available
+            yield StreamEvent(
+                event_type=StreamEventType.PARTIAL,
+                source=class_name,
+                message="Research results available",
+                data={
+                    "partial_output": PartialSchema[LitSearchAgentOutputSchema](
+                        results=research_output["results"],
+                        extra={
+                            "key_findings": research_output["key_findings"],
+                            "evidence_quality_score": research_output["evidence_quality_score"],
+                            "citations": research_output["citations"],
+                            "iterations_performed": research_output["iterations_performed"],
+                        },
+                    ),
+                },
+                context=run_context,
+            )
+
             # Step 5: Generate report and answer
             yield self._emit_step_event(
                 "synthesis",
@@ -893,29 +913,39 @@ class DeepLitSearchAgent(LitBaseAgent):
                 research_report=research_output["research_report"],
             )
 
+            # PARTIAL event: report now available
+            yield StreamEvent(
+                event_type=StreamEventType.PARTIAL,
+                source=class_name,
+                message="Report generated",
+                data={
+                    "partial_output": PartialSchema[LitSearchAgentOutputSchema](
+                        results=research_output["results"],
+                        report=detailed_report,
+                        extra={
+                            "key_findings": research_output["key_findings"],
+                            "evidence_quality_score": research_output["evidence_quality_score"],
+                            "citations": research_output["citations"],
+                            "iterations_performed": research_output["iterations_performed"],
+                        },
+                    ),
+                },
+                context=run_context,
+            )
+
             yield self._emit_step_event(
                 "synthesis",
-                "Report complete, generating answer...",
+                "Generating answer...",
                 run_context,
                 step_index=5,
                 total_steps=5,
                 substep="answer",
-                report_preview=detailed_report[:200] if detailed_report else "",
             )
 
             shortform_answer = await self._generate_answer(
                 query=original_query,
                 search_results=research_output["results"],
                 additional_context=detailed_report,
-            )
-
-            yield self._emit_step_event(
-                "synthesis",
-                "Synthesis complete",
-                run_context,
-                step_index=5,
-                total_steps=5,
-                answer_preview=shortform_answer.answer[:200] if shortform_answer.answer else "",
             )
 
             # Build final output
@@ -933,7 +963,7 @@ class DeepLitSearchAgent(LitBaseAgent):
                 },
             )
 
-            # COMPLETED event
+            # COMPLETED event with full output
             yield StreamEvent(
                 event_type=StreamEventType.COMPLETED,
                 source=class_name,

--- a/akd/agents/search/deep_search.py
+++ b/akd/agents/search/deep_search.py
@@ -9,12 +9,15 @@ refer to akd/docs/deep_research_agent.md for more details.
 from __future__ import annotations
 
 import asyncio
+import uuid
+from collections.abc import AsyncIterator
 from typing import Any, Dict, List, Optional
 
 from loguru import logger
 from pydantic import Field
 
 from akd._base import exposed_param
+from akd._base.streaming import StreamEvent, StreamEventType
 from akd.agents.query import (
     FollowUpQueryAgent,
     FollowUpQueryAgentInputSchema,
@@ -162,6 +165,49 @@ class DeepLitSearchAgent(LitBaseAgent):
     def clarification_prompt(self, prompt: str) -> None:
         self.clarification_component.config.system_prompt = prompt
 
+    def _emit_step_event(
+        self,
+        step: str,
+        message: str,
+        run_context: dict[str, Any],
+        step_index: int | None = None,
+        total_steps: int | None = None,
+        substep: str | None = None,
+        **data_kwargs: Any,
+    ) -> StreamEvent:
+        """Create a RUNNING event for a pipeline step.
+
+        Args:
+            step: Step identifier (e.g., "triage", "research.search")
+            message: Human-readable progress message
+            run_context: Execution context with run_id, query, etc.
+            step_index: Current step number (1-based)
+            total_steps: Total number of main steps
+            substep: Sub-step identifier for nested progress
+            **data_kwargs: Additional data to include in event payload
+
+        Returns:
+            StreamEvent with RUNNING type and step information
+        """
+        data = {
+            "step": step,
+            **data_kwargs,
+        }
+        if step_index is not None:
+            data["step_index"] = step_index
+        if total_steps is not None:
+            data["total_steps"] = total_steps
+        if substep is not None:
+            data["substep"] = substep
+
+        return StreamEvent(
+            event_type=StreamEventType.RUNNING,
+            source=self.__class__.__name__,
+            message=message,
+            data=data,
+            context=run_context,
+        )
+
     async def _handle_triage(self, query: str) -> dict:
         """Handle query triage using embedded component."""
         if self.debug:
@@ -230,39 +276,78 @@ class DeepLitSearchAgent(LitBaseAgent):
 
         return instructions
 
-    async def _perform_deep_research(
+    async def _stream_deep_research(
         self,
         instructions: str,
         original_query: str,
         max_results: int,
-    ) -> dict:
-        """
-        Perform the actual deep research using iterative search and synthesis.
+        run_context: dict[str, Any],
+    ) -> AsyncIterator[StreamEvent | dict]:
+        """Stream the deep research loop with iteration events.
 
-        This method coordinates search tools, relevancy checking, and the
-        embedded research synthesis component to produce comprehensive results.
+        Yields StreamEvent for progress updates, and a dict with "result" key
+        containing the final research output.
+
+        Args:
+            instructions: Research instructions from instruction builder
+            original_query: Original user query
+            max_results: Maximum results per search
+            run_context: Execution context for event correlation
+
+        Yields:
+            StreamEvent: Progress events for each research step
+            dict: Final result with {"result": research_output_dict}
         """
         # Initialize research tracking
-        all_results = []
+        all_results: List[SearchResultItem] = []
         iterations = 0
-        quality_scores = []
-        research_trace = []
+        quality_scores: List[float] = []
+        research_trace: List[str] = []
 
-        # Initial search queries from instructions
+        # Generate initial queries
+        yield self._emit_step_event(
+            "research.queries",
+            "Generating initial search queries...",
+            run_context,
+            substep="initial_queries",
+        )
+
         initial_queries = await self._generate_initial_queries(instructions)
 
+        yield self._emit_step_event(
+            "research.queries",
+            f"Generated {len(initial_queries)} initial queries",
+            run_context,
+            substep="initial_queries",
+            queries=initial_queries,
+        )
+
+        # Research iteration loop
         while iterations < self.config.max_research_iterations:
             iterations += 1
             research_trace.append(
                 f"Iteration {iterations}: Searching with queries: {initial_queries}",
             )
 
-            if self.debug:
-                logger.debug(
-                    f"Research iteration {iterations}/{self.config.max_research_iterations}",
-                )
+            yield self._emit_step_event(
+                "research.iteration",
+                f"Starting research iteration {iterations}/{self.config.max_research_iterations}",
+                run_context,
+                substep=f"iteration_{iterations}",
+                iteration=iterations,
+                max_iterations=self.config.max_research_iterations,
+                current_results_count=len(all_results),
+            )
 
-            # Perform searches
+            # Search
+            yield self._emit_step_event(
+                "research.search",
+                f"Executing searches with {len(initial_queries)} queries...",
+                run_context,
+                substep=f"iteration_{iterations}.search",
+                queries=initial_queries,
+            )
+
             search_results = await self._execute_searches(
                 queries=initial_queries,
                 max_results=max_results,
@@ -272,46 +357,107 @@ class DeepLitSearchAgent(LitBaseAgent):
 
             if not search_results:
                 research_trace.append(f"Iteration {iterations}: No new results found")
+                yield self._emit_step_event(
+                    "research.search",
+                    "No results found, stopping research",
+                    run_context,
+                    substep=f"iteration_{iterations}.search",
+                    results_count=0,
+                )
                 break
 
             # Deduplicate and add to results
             new_results = self._deduplicate_results(search_results, all_results)
             all_results.extend(new_results)
-
-            # HARD Cap total results
-            # TODO: Implement reranking before capping
-            # Note: Search tool already implements reranking though. `new_results` is already reranked.
             all_results = all_results[: self.config.max_results]
+
+            yield self._emit_step_event(
+                "research.search",
+                f"Found {len(new_results)} new results (total: {len(all_results)})",
+                run_context,
+                substep=f"iteration_{iterations}.search",
+                new_results_count=len(new_results),
+                total_results_count=len(all_results),
+            )
 
             # Evaluate quality
             if new_results:
+                yield self._emit_step_event(
+                    "research.evaluate",
+                    "Evaluating research quality...",
+                    run_context,
+                    substep=f"iteration_{iterations}.evaluate",
+                )
+
                 quality_score = await self._evaluate_research_quality(
                     new_results,
                     original_query,
                 )
                 quality_scores.append(quality_score)
+                avg_quality = sum(quality_scores) / len(quality_scores)
 
                 research_trace.append(
                     f"Iteration {iterations}: Found {len(new_results)} new results, quality score: {quality_score:.2f}",
                 )
 
+                yield self._emit_step_event(
+                    "research.evaluate",
+                    f"Quality score: {quality_score:.2f} (avg: {avg_quality:.2f})",
+                    run_context,
+                    substep=f"iteration_{iterations}.evaluate",
+                    quality_score=quality_score,
+                    avg_quality=avg_quality,
+                    threshold=self.config.quality_threshold,
+                )
+
                 # Check if we've reached quality threshold
-                avg_quality = sum(quality_scores) / len(quality_scores)
                 if avg_quality >= self.config.quality_threshold and len(all_results) >= 10:
                     research_trace.append(
                         f"Stopping: Quality threshold reached ({avg_quality:.2f})",
+                    )
+                    yield self._emit_step_event(
+                        "research.iteration",
+                        f"Quality threshold reached ({avg_quality:.2f}), stopping research",
+                        run_context,
+                        substep=f"iteration_{iterations}",
+                        stopping_reason="quality_threshold",
+                        avg_quality=avg_quality,
                     )
                     break
 
             # Generate refined queries for next iteration
             if iterations < self.config.max_research_iterations:
+                yield self._emit_step_event(
+                    "research.refine",
+                    "Generating refined queries for next iteration...",
+                    run_context,
+                    substep=f"iteration_{iterations}.refine",
+                )
+
                 initial_queries = await self._generate_refined_queries(
                     initial_queries,
                     all_results,
                     instructions,
                 )
 
-        # Synthesize final research report using embedded component
+                yield self._emit_step_event(
+                    "research.refine",
+                    f"Generated {len(initial_queries)} refined queries",
+                    run_context,
+                    substep=f"iteration_{iterations}.refine",
+                    refined_queries=initial_queries,
+                )
+
+        # Synthesize final research report
+        yield self._emit_step_event(
+            "research.synthesize",
+            "Synthesizing research findings...",
+            run_context,
+            substep="synthesis",
+            total_results=len(all_results),
+            iterations_performed=iterations,
+        )
+
         research_output = await self.research_synthesis_component.synthesize(
             all_results,
             instructions,
@@ -321,14 +467,25 @@ class DeepLitSearchAgent(LitBaseAgent):
             iterations,
         )
 
-        return {
-            "research_report": research_output.research_report,
-            "key_findings": research_output.key_findings,
-            "evidence_quality_score": research_output.evidence_quality_score,
-            "citations": research_output.citations,
-            "iterations_performed": iterations,
-            "results": all_results,
-            "research_traces": research_trace,
+        yield self._emit_step_event(
+            "research.synthesize",
+            "Research synthesis complete",
+            run_context,
+            substep="synthesis",
+            key_findings_count=len(research_output.key_findings) if research_output.key_findings else 0,
+        )
+
+        # Yield final result as dict
+        yield {
+            "result": {
+                "research_report": research_output.research_report,
+                "key_findings": research_output.key_findings,
+                "evidence_quality_score": research_output.evidence_quality_score,
+                "citations": research_output.citations,
+                "iterations_performed": iterations,
+                "results": all_results,
+                "research_traces": research_trace,
+            },
         }
 
     async def _generate_initial_queries(self, instructions: str) -> List[str]:
@@ -541,96 +698,284 @@ class DeepLitSearchAgent(LitBaseAgent):
         # So we just return it from kwargs
         return kwargs.get("research_report", "")
 
+    async def _astream(
+        self,
+        params: LitSearchAgentInputSchema,
+        context: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[StreamEvent]:
+        """Stream the deep literature search with progress events.
+
+        Emits events throughout the multi-step research pipeline:
+        - STARTING at the beginning
+        - RUNNING events for each major step (triage, clarification, instructions, research, synthesis)
+        - COMPLETED with output on success
+        - FAILED with error on failure
+
+        Args:
+            params: Validated input parameters
+            context: Execution context (node_id, query, etc.)
+            **kwargs: Additional arguments (mock_answers, search_max_results, etc.)
+
+        Yields:
+            StreamEvent objects throughout execution
+
+        Example:
+            async for event in agent.astream({"query": "climate change research"}):
+                print(f"{event.event_type}: {event.data.get('step', '')} - {event.message}")
+        """
+        class_name = self.__class__.__name__
+
+        # Setup context with auto-generated run_id
+        run_context = context.copy() if context else {}
+        if "run_id" not in run_context:
+            run_context["run_id"] = uuid.uuid4().hex[:8]
+        run_context["query"] = params.query
+
+        # STARTING event
+        yield StreamEvent(
+            event_type=StreamEventType.STARTING,
+            source=class_name,
+            message=f"Starting deep literature search: {params.query[:100]}...",
+            data={"query": params.query},
+            context=run_context,
+        )
+
+        try:
+            original_query = params.query
+            max_results = kwargs.get("search_max_results", params.search_mode.to_max_results())
+            logger.info(f"DeepLitSearchAgent with params: {params}")
+            logger.debug(f"DeepLitSearchAgent | max_results = {max_results}")
+
+            # Step 1: Triage
+            yield self._emit_step_event(
+                "triage",
+                "Analyzing query to determine research approach...",
+                run_context,
+                step_index=1,
+                total_steps=5,
+            )
+
+            triage_result = await self._handle_triage(original_query)
+
+            yield self._emit_step_event(
+                "triage",
+                f"Query triage complete: {triage_result['routing_decision']}",
+                run_context,
+                step_index=1,
+                total_steps=5,
+                needs_clarification=triage_result["needs_clarification"],
+                routing_decision=triage_result["routing_decision"],
+            )
+
+            # Step 2: Clarification (if needed)
+            enriched_query = original_query
+            clarifications: List[str] = []
+
+            if triage_result["needs_clarification"] and self.config.auto_clarify:
+                yield self._emit_step_event(
+                    "clarification",
+                    "Query requires clarification, starting clarification process...",
+                    run_context,
+                    step_index=2,
+                    total_steps=5,
+                )
+
+                max_rounds = max(1, getattr(self.config, "max_clarifying_rounds", 1))
+                for round_num in range(max_rounds):
+                    yield self._emit_step_event(
+                        "clarification",
+                        f"Clarification round {round_num + 1}/{max_rounds}...",
+                        run_context,
+                        step_index=2,
+                        total_steps=5,
+                        substep=f"round_{round_num + 1}",
+                        round=round_num + 1,
+                    )
+
+                    enriched_query, new_clarifications = await self._handle_clarification(
+                        enriched_query,
+                        kwargs.get("mock_answers"),
+                    )
+                    if new_clarifications:
+                        clarifications.extend(new_clarifications)
+
+                    yield self._emit_step_event(
+                        "clarification",
+                        f"Clarification round {round_num + 1} complete",
+                        run_context,
+                        step_index=2,
+                        total_steps=5,
+                        substep=f"round_{round_num + 1}",
+                        clarifications_count=len(clarifications),
+                    )
+
+                    # Re-triage to check if more clarification is needed
+                    try:
+                        triage_result = await self._handle_triage(enriched_query)
+                    except Exception:
+                        break
+
+                    if not triage_result.get("needs_clarification"):
+                        break
+
+            # Step 3: Build research instructions
+            yield self._emit_step_event(
+                "instructions",
+                "Building detailed research instructions...",
+                run_context,
+                step_index=3,
+                total_steps=5,
+            )
+
+            instructions = await self._build_research_instructions(
+                enriched_query,
+                clarifications or None,
+            )
+
+            yield self._emit_step_event(
+                "instructions",
+                "Research instructions ready",
+                run_context,
+                step_index=3,
+                total_steps=5,
+                instructions_preview=instructions[:200] if instructions else "",
+            )
+
+            # Step 4: Deep research loop (streaming)
+            yield self._emit_step_event(
+                "research",
+                f"Starting iterative deep research (max {self.config.max_research_iterations} iterations)...",
+                run_context,
+                step_index=4,
+                total_steps=5,
+                max_iterations=self.config.max_research_iterations,
+            )
+
+            research_output = None
+            async for item in self._stream_deep_research(
+                instructions,
+                original_query,
+                max_results,
+                run_context,
+            ):
+                if isinstance(item, StreamEvent):
+                    yield item
+                elif isinstance(item, dict) and "result" in item:
+                    research_output = item["result"]
+
+            if research_output is None:
+                raise RuntimeError("No research output received from _stream_deep_research")
+
+            yield self._emit_step_event(
+                "research",
+                f"Deep research complete: {len(research_output['results'])} results in {research_output['iterations_performed']} iterations",
+                run_context,
+                step_index=4,
+                total_steps=5,
+                total_results=len(research_output["results"]),
+                iterations_performed=research_output["iterations_performed"],
+            )
+
+            # Step 5: Generate report and answer
+            yield self._emit_step_event(
+                "synthesis",
+                "Generating detailed report...",
+                run_context,
+                step_index=5,
+                total_steps=5,
+                substep="report",
+            )
+
+            detailed_report = await self._generate_report(
+                query=original_query,
+                results=research_output["results"],
+                research_report=research_output["research_report"],
+            )
+
+            yield self._emit_step_event(
+                "synthesis",
+                "Report complete, generating answer...",
+                run_context,
+                step_index=5,
+                total_steps=5,
+                substep="answer",
+                report_preview=detailed_report[:200] if detailed_report else "",
+            )
+
+            shortform_answer = await self._generate_answer(
+                query=original_query,
+                search_results=research_output["results"],
+                additional_context=detailed_report,
+            )
+
+            yield self._emit_step_event(
+                "synthesis",
+                "Synthesis complete",
+                run_context,
+                step_index=5,
+                total_steps=5,
+                answer_preview=shortform_answer.answer[:200] if shortform_answer.answer else "",
+            )
+
+            # Build final output
+            output = LitSearchAgentOutputSchema(
+                answer=shortform_answer.answer,
+                report=detailed_report,
+                results=research_output["results"],
+                extra={
+                    "key_findings": research_output["key_findings"],
+                    "evidence_quality_score": research_output["evidence_quality_score"],
+                    "citations": research_output["citations"],
+                    "answer_reasoning_traces": shortform_answer.reasoning_traces,
+                    "research_traces": research_output.get("research_traces", []),
+                    "iterations_performed": research_output["iterations_performed"],
+                },
+            )
+
+            # COMPLETED event
+            yield StreamEvent(
+                event_type=StreamEventType.COMPLETED,
+                source=class_name,
+                message="Deep literature search completed",
+                data={"output": output},
+                context=run_context,
+            )
+
+        except Exception as e:
+            # FAILED event
+            yield StreamEvent(
+                event_type=StreamEventType.FAILED,
+                source=class_name,
+                message=f"Deep literature search failed: {e!s}",
+                data={"error": str(e), "error_type": type(e).__name__},
+                context=run_context,
+            )
+            raise
+
     async def _arun(
         self,
         params: LitSearchAgentInputSchema,
         **kwargs: Any,
     ) -> LitSearchAgentOutputSchema:
+        """Run the DeepLitSearchAgent by collecting output from _astream().
+
+        This method delegates to _astream() and collects the final output from
+        the COMPLETED event. Use astream() directly if you want real-time progress.
+
+        Args:
+            params: Input parameters for the search
+            **kwargs: Additional arguments (mock_answers, search_max_results, etc.)
+
+        Returns:
+            LitSearchAgentOutputSchema with answer, report, results, and metadata
         """
-        Run the DeepLitSearchAgent with multi-agent orchestration using embedded components.
+        output = None
+        async for event in self._astream(params, **kwargs):
+            if event.event_type == StreamEventType.COMPLETED:
+                output = event.output
 
-        This implements the full deep research pipeline:
-        1. Triage the query
-        2. Clarify if needed
-        3. Build research instructions
-        4. Perform deep research
-        5. Return structured results
+        if output is None:
+            raise RuntimeError("No output received from _astream()")
 
-        Note 1: The maximum number of results to retrieve while running the DeepLitSearchAgent.search_tool is controlled  either:
-        - By `SearchMode` from `params.search_mode` (if kwargs does not specify `search_max_results`). This is the user-facing paramter to control search.
-        - By passing `search_max_results` in `kwargs` (overrides SearchMode). This is useful for dev-mode
-
-        Note 2:
-        - The `DeepLitSearchAgentConfig.max_results` parameter is a hard cap on the total number of results the agent will keep track of during research to control the research iteration. (TODO: Implement reranking at before capping.)
-        """
-        original_query = params.query
-        max_results = kwargs.get("search_max_results", params.search_mode.to_max_results())
-        logger.info(f"DeepLitSearchAgent with params: {params}")
-        logger.debug(f"DeepLitSearchAgent | max_results = {max_results}")
-
-        # Step 1: Triage the query using embedded component
-        triage_result = await self._handle_triage(original_query)
-
-        # Step 2: Clarification loop (LLM-driven) if needed
-        enriched_query = original_query
-        clarifications: List[str] | None = []
-
-        if triage_result["needs_clarification"] and self.config.auto_clarify:
-            max_rounds = max(1, getattr(self.config, "max_clarifying_rounds", 1))
-            for _ in range(max_rounds):
-                enriched_query, new_clarifications = await self._handle_clarification(
-                    enriched_query,
-                    kwargs.get("mock_answers"),
-                )
-                if new_clarifications:
-                    clarifications.extend(new_clarifications)
-
-                # Re-triage to see if more clarification is needed
-                try:
-                    triage_result = await self._handle_triage(enriched_query)
-                except Exception:
-                    break
-
-                if not triage_result.get("needs_clarification"):
-                    break
-
-        # Step 3: Build research instructions using embedded component
-        instructions = await self._build_research_instructions(
-            enriched_query,
-            clarifications or None,
-        )
-
-        # Step 4: Perform deep research using embedded components
-        research_output = await self._perform_deep_research(
-            instructions,
-            original_query,
-            max_results=max_results,
-        )
-
-        # Step 5: Generate shortform answer and report
-        detailed_report = await self._generate_report(
-            query=original_query,
-            results=research_output["results"],
-            research_report=research_output["research_report"],
-        )
-
-        shortform_answer = await self._generate_answer(
-            query=original_query,
-            search_results=research_output["results"],
-            additional_context=detailed_report,
-        )
-
-        # Step 6: Return research output with SearchResultItem objects directly
-        return LitSearchAgentOutputSchema(
-            answer=shortform_answer.answer,
-            report=detailed_report,
-            results=research_output["results"],
-            extra={
-                "key_findings": research_output["key_findings"],
-                "evidence_quality_score": research_output["evidence_quality_score"],
-                "citations": research_output["citations"],
-                "answer_reasoning_traces": shortform_answer.reasoning_traces,
-                "research_traces": research_output.get("research_traces", []),
-                "iterations_performed": research_output["iterations_performed"],
-            },
-        )
+        return output

--- a/akd/utils.py
+++ b/akd/utils.py
@@ -263,22 +263,22 @@ def to_snake_case(name: str) -> str:
     return result.lower()
 
 
-class PartialSchema[T: BaseModel]:
+class PartialModel[T: BaseModel]:
     """Partial schema generator - all fields become Optional.
 
     Creates a Pydantic model where all fields are Optional, useful for
     streaming PARTIAL events where output builds progressively.
 
     Usage:
-        PartialSchema[MySchema]           # Returns the partial model class
-        PartialSchema[MySchema](field=v)  # Creates instance
+        PartialModel[MySchema]           # Returns the partial model class
+        PartialModel[MySchema](field=v)  # Creates instance
 
     Example:
-        from akd.utils import PartialSchema
+        from akd.utils import PartialModel
         from akd.agents.search._base import LitSearchAgentOutputSchema
 
         # Create partial with only some fields
-        partial = PartialSchema[LitSearchAgentOutputSchema](
+        partial = PartialModel[LitSearchAgentOutputSchema](
             results=[...],
             extra={"key_findings": [...]},
         )

--- a/akd/utils.py
+++ b/akd/utils.py
@@ -10,7 +10,7 @@ import dateparser
 import gdown
 import requests
 from loguru import logger
-from pydantic import BaseModel, HttpUrl
+from pydantic import BaseModel, HttpUrl, create_model
 
 if TYPE_CHECKING:
     pass
@@ -261,3 +261,42 @@ def to_snake_case(name: str) -> str:
     # Insert _ between acronym and next word: CMRAgent -> CMR_Agent
     result = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", result)
     return result.lower()
+
+
+class PartialSchema[T: BaseModel]:
+    """Partial schema generator - all fields become Optional.
+
+    Creates a Pydantic model where all fields are Optional, useful for
+    streaming PARTIAL events where output builds progressively.
+
+    Usage:
+        PartialSchema[MySchema]           # Returns the partial model class
+        PartialSchema[MySchema](field=v)  # Creates instance
+
+    Example:
+        from akd.utils import PartialSchema
+        from akd.agents.search._base import LitSearchAgentOutputSchema
+
+        # Create partial with only some fields
+        partial = PartialSchema[LitSearchAgentOutputSchema](
+            results=[...],
+            extra={"key_findings": [...]},
+        )
+
+        # Serialize for frontend
+        partial.model_dump()  # {'answer': None, 'report': None, 'results': [...], 'extra': {...}}
+    """
+
+    _cache: dict[type[BaseModel], type[BaseModel]] = {}
+
+    def __class_getitem__(cls, model: type[T]) -> type[T]:
+        """Generate partial version of model with all fields Optional."""
+        if model not in cls._cache:
+            fields = {}
+            for name, field_info in model.model_fields.items():
+                fields[name] = (field_info.annotation | None, None)
+            cls._cache[model] = create_model(
+                f"Partial{model.__name__}",
+                **fields,
+            )
+        return cls._cache[model]

--- a/docs/specs/STREAMING.md
+++ b/docs/specs/STREAMING.md
@@ -1,0 +1,624 @@
+# Streaming Architecture
+
+Real-time progress and partial output streaming for AKD agents.
+
+## Overview
+
+The streaming system enables agents to emit events during execution, providing:
+
+- **Progress visibility**: Track multi-step pipelines in real-time
+- **Partial outputs**: Access structured results as they build progressively
+- **Reasoning transparency**: Observe LLM thinking tokens (Claude extended thinking, o1)
+- **Error handling**: Immediate failure notification with context
+
+Streaming follows a simple pattern: call `agent.astream()` instead of `agent.arun()` and iterate over events.
+
+```python
+async for event in agent.astream(input_data):
+    match event.event_type:
+        case StreamEventType.RUNNING:
+            print(f"Step: {event.data.get('step')}")
+        case StreamEventType.PARTIAL:
+            print(f"Partial: {event.partial_output}")
+        case StreamEventType.COMPLETED:
+            result = event.output
+```
+
+---
+
+## Core Infrastructure
+
+### StreamEventType
+
+Enum defining all event types (`akd/_base/streaming.py`):
+
+| Event Type | Purpose | When Emitted |
+|------------|---------|--------------|
+| `STARTING` | Lifecycle | Beginning of execution |
+| `RUNNING` | Progress | Each pipeline step or substep |
+| `STREAMING` | Raw tokens | LLM token-by-token output |
+| `THINKING` | Reasoning | Claude extended thinking, o1 reasoning tokens |
+| `PARTIAL` | Structured | Validated partial model as JSON builds |
+| `COMPLETED` | Lifecycle | Successful completion with output |
+| `FAILED` | Lifecycle | Error with details |
+| `TOOL_CALLING` | Tools | Tool invocation (Stage 2) |
+| `TOOL_RESULT` | Tools | Tool completion (Stage 2) |
+
+### StreamEvent
+
+CloudEvents-inspired envelope for all streaming events:
+
+```python
+class StreamEvent(BaseModel):
+    # Core envelope
+    event_type: StreamEventType
+    timestamp: datetime
+    event_id: str           # Unique ID (auto-generated)
+    source: str | None      # Class name that generated event
+    message: str | None     # Human-readable description
+
+    # Flexible payload
+    data: dict[str, Any]    # Event-specific data
+
+    # Execution context
+    context: dict[str, Any] # node_id, query, run_id, etc.
+```
+
+**Convenience properties** provide typed access to common data fields:
+
+```python
+event.output           # COMPLETED: final output
+event.error            # FAILED: error message
+event.token            # STREAMING: raw token string
+event.thinking_content # THINKING: reasoning content
+event.partial_output   # PARTIAL: partial model instance
+event.tool_name        # TOOL_CALLING/TOOL_RESULT: tool name
+event.tool_input       # TOOL_CALLING: tool parameters
+event.tool_output      # TOOL_RESULT: tool return value
+```
+
+### StreamingMixin
+
+Base mixin that adds `astream()` to any agent (`akd/_base/streaming.py`):
+
+```python
+class StreamingMixin:
+    async def astream(
+        self,
+        params: Any,
+        context: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[StreamEvent]:
+        """Public streaming API with input/output validation."""
+        params = self._validate_input(params)
+
+        async for event in self._astream(params, context, **kwargs):
+            if event.event_type == StreamEventType.COMPLETED:
+                output = self._validate_output(event.data.get("output"))
+                yield StreamEvent(..., data={"output": output})
+            else:
+                yield event
+
+    async def _astream(self, params, context, **kwargs):
+        """Override this for custom streaming logic."""
+        # Default: STARTING -> RUNNING -> _arun() -> COMPLETED/FAILED
+        ...
+```
+
+Key design:
+- `astream()` handles validation, `_astream()` contains streaming logic
+- Input validation happens before any events are yielded
+- Output validation happens on COMPLETED event before yielding
+- Default `_astream()` wraps `_arun()` for backward compatibility
+
+---
+
+## Event Types in Detail
+
+### STARTING
+
+Emitted once at execution start:
+
+```python
+StreamEvent(
+    event_type=StreamEventType.STARTING,
+    source="DeepLitSearchAgent",
+    message="Starting deep literature search: climate change...",
+    data={"query": "climate change research"},
+    context={"run_id": "abc123", "query": "climate change research"},
+)
+```
+
+### RUNNING
+
+Emitted for pipeline progress. Use `data["step"]` for step tracking:
+
+```python
+StreamEvent(
+    event_type=StreamEventType.RUNNING,
+    source="DeepLitSearchAgent",
+    message="Starting research iteration 2/5",
+    data={
+        "step": "research.iteration",
+        "substep": "iteration_2",
+        "step_index": 4,
+        "total_steps": 5,
+        "iteration": 2,
+        "max_iterations": 5,
+        "current_results_count": 15,
+    },
+    context={"run_id": "abc123"},
+)
+```
+
+Common step patterns:
+- `step="triage"` - Query analysis
+- `step="research.queries"` - Query generation
+- `step="research.iteration"` - Main iteration loop
+- `step="research.search"` - Search execution
+- `step="research.evaluate"` - Quality evaluation
+- `step="synthesis"` - Report/answer generation
+
+### STREAMING
+
+Raw LLM tokens as they arrive (batched for efficiency):
+
+```python
+StreamEvent(
+    event_type=StreamEventType.STREAMING,
+    source="LiteLLMInstructorBaseAgent",
+    data={"token": "The research shows"},
+    context={"run_id": "abc123"},
+)
+```
+
+Access via `event.token`.
+
+### THINKING
+
+Reasoning tokens from Claude extended thinking or o1:
+
+```python
+StreamEvent(
+    event_type=StreamEventType.THINKING,
+    source="LiteLLMInstructorBaseAgent",
+    message="Reasoning...",
+    data={"thinking_content": "Let me analyze the query structure..."},
+    context={"run_id": "abc123"},
+)
+```
+
+Access via `event.thinking_content`.
+
+### PARTIAL
+
+Validated partial output as JSON builds:
+
+```python
+StreamEvent(
+    event_type=StreamEventType.PARTIAL,
+    source="DeepLitSearchAgent",
+    message="Research results available",
+    data={
+        "partial_output": PartialModel[LitSearchAgentOutputSchema](
+            results=[...],
+            extra={"key_findings": [...]},
+        )
+    },
+    context={"run_id": "abc123"},
+)
+```
+
+Access via `event.partial_output`. The partial model has all fields Optional.
+
+### COMPLETED
+
+Successful completion with validated output:
+
+```python
+StreamEvent(
+    event_type=StreamEventType.COMPLETED,
+    source="DeepLitSearchAgent",
+    message="Deep literature search completed",
+    data={"output": LitSearchAgentOutputSchema(...)},
+    context={"run_id": "abc123"},
+)
+```
+
+Access via `event.output`.
+
+### FAILED
+
+Error with details:
+
+```python
+StreamEvent(
+    event_type=StreamEventType.FAILED,
+    source="DeepLitSearchAgent",
+    message="Failed: Connection timeout",
+    data={"error": "Connection timeout", "error_type": "TimeoutError"},
+    context={"run_id": "abc123"},
+)
+```
+
+Access via `event.error`. The original exception is re-raised after this event.
+
+---
+
+## Adding Streaming to New Agents
+
+### Step 1: Override `_astream()`
+
+```python
+from akd._base.streaming import StreamEvent, StreamEventType
+
+class MyAgent(LiteLLMInstructorBaseAgent):
+
+    async def _astream(
+        self,
+        params: MyInputSchema,
+        context: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[StreamEvent]:
+        """Stream execution with progress events."""
+        class_name = self.__class__.__name__
+
+        # Setup context with auto-generated run_id
+        run_context = context.copy() if context else {}
+        if "run_id" not in run_context:
+            run_context["run_id"] = uuid.uuid4().hex[:8]
+
+        # STARTING event
+        yield StreamEvent(
+            event_type=StreamEventType.STARTING,
+            source=class_name,
+            message=f"Starting {class_name}",
+            context=run_context,
+        )
+
+        try:
+            # Your pipeline steps here...
+            yield StreamEvent(
+                event_type=StreamEventType.RUNNING,
+                source=class_name,
+                message="Processing step 1",
+                data={"step": "step1"},
+                context=run_context,
+            )
+
+            result = await self._do_work(params)
+
+            # COMPLETED event
+            yield StreamEvent(
+                event_type=StreamEventType.COMPLETED,
+                source=class_name,
+                message=f"Completed {class_name}",
+                data={"output": result},
+                context=run_context,
+            )
+
+        except Exception as e:
+            # FAILED event
+            yield StreamEvent(
+                event_type=StreamEventType.FAILED,
+                source=class_name,
+                message=f"Failed: {e!s}",
+                data={"error": str(e), "error_type": type(e).__name__},
+                context=run_context,
+            )
+            raise  # Re-raise after yielding FAILED
+```
+
+### Step 2: Implement `_arun()` via `_astream()`
+
+For consistency, delegate `_arun()` to `_astream()`:
+
+```python
+async def _arun(
+    self,
+    params: MyInputSchema,
+    **kwargs: Any,
+) -> MyOutputSchema:
+    """Run by collecting output from _astream()."""
+    output = None
+    async for event in self._astream(params, **kwargs):
+        if event.event_type == StreamEventType.COMPLETED:
+            output = event.output
+
+    if output is None:
+        raise RuntimeError("No output received from _astream()")
+    return output
+```
+
+### Step 3: Helper for RUNNING Events
+
+Create a helper method for consistent step events:
+
+```python
+def _emit_step_event(
+    self,
+    step: str,
+    message: str,
+    run_context: dict[str, Any],
+    step_index: int | None = None,
+    total_steps: int | None = None,
+    substep: str | None = None,
+    **data_kwargs: Any,
+) -> StreamEvent:
+    """Create a RUNNING event for a pipeline step."""
+    data = {"step": step, **data_kwargs}
+    if step_index is not None:
+        data["step_index"] = step_index
+    if total_steps is not None:
+        data["total_steps"] = total_steps
+    if substep is not None:
+        data["substep"] = substep
+
+    return StreamEvent(
+        event_type=StreamEventType.RUNNING,
+        source=self.__class__.__name__,
+        message=message,
+        data=data,
+        context=run_context,
+    )
+```
+
+---
+
+## PartialModel for Progressive Output
+
+`PartialModel[T]` creates a version of any Pydantic model where all fields are Optional (`akd/utils.py`):
+
+```python
+from akd.utils import PartialModel
+from akd.agents.search._base import LitSearchAgentOutputSchema
+
+# Create partial with only some fields populated
+partial = PartialModel[LitSearchAgentOutputSchema](
+    results=[...],           # Available
+    extra={"key_findings": [...]},
+    # answer=None (implicit)
+    # report=None (implicit)
+)
+
+# Serialize for frontend
+partial.model_dump()
+# {'answer': None, 'report': None, 'results': [...], 'extra': {...}}
+```
+
+### Using PartialModel in Streaming
+
+Emit PARTIAL events as pipeline produces partial results:
+
+```python
+# After search completes but before synthesis
+yield StreamEvent(
+    event_type=StreamEventType.PARTIAL,
+    source=class_name,
+    message="Search results available",
+    data={
+        "partial_output": PartialModel[LitSearchAgentOutputSchema](
+            results=all_results,
+            extra={"iterations_performed": iteration},
+        ),
+    },
+    context=run_context,
+)
+
+# After report generation
+yield StreamEvent(
+    event_type=StreamEventType.PARTIAL,
+    source=class_name,
+    message="Report generated",
+    data={
+        "partial_output": PartialModel[LitSearchAgentOutputSchema](
+            results=all_results,
+            report=detailed_report,
+            extra={"iterations_performed": iteration},
+        ),
+    },
+    context=run_context,
+)
+```
+
+### LLM Streaming with PartialModel
+
+`LiteLLMInstructorBaseAgent._stream_llm_response()` validates partial JSON as it streams:
+
+```python
+async def _stream_llm_response(self, messages, response_model, token_batch_size=10):
+    PartialResponseModel = PartialModel[response_model]
+    accumulated = ""
+
+    async for chunk in response:
+        accumulated += delta.content
+
+        # Try to validate as partial
+        parsed = self._try_parse_json(accumulated)
+        if parsed:
+            try:
+                partial = PartialResponseModel.model_validate(parsed)
+                yield {"type": StreamEventType.PARTIAL, "partial": partial}
+            except Exception:
+                pass  # Skip invalid partials
+```
+
+---
+
+## Usage Examples
+
+### DeepLitSearchAgent - Multi-Step Pipeline
+
+```python
+from akd.agents.search.deep_search import DeepLitSearchAgent, LitSearchAgentInputSchema
+
+agent = DeepLitSearchAgent()
+input_data = LitSearchAgentInputSchema(query="climate change mitigation strategies")
+
+async for event in agent.astream(input_data):
+    match event.event_type:
+        case StreamEventType.STARTING:
+            print(f"Starting: {event.message}")
+
+        case StreamEventType.RUNNING:
+            step = event.data.get("step", "")
+            if step.startswith("research.iteration"):
+                iteration = event.data.get("iteration", 0)
+                print(f"Iteration {iteration}: {event.message}")
+            else:
+                print(f"  {event.message}")
+
+        case StreamEventType.PARTIAL:
+            partial = event.partial_output
+            if partial.results:
+                print(f"  Results so far: {len(partial.results)}")
+
+        case StreamEventType.COMPLETED:
+            result = event.output
+            print(f"Complete: {len(result.results)} results")
+            print(f"Answer: {result.answer[:200]}...")
+
+        case StreamEventType.FAILED:
+            print(f"Error: {event.error}")
+```
+
+### ControlledSearchAgent - Iteration-Based
+
+```python
+from akd.agents.search.controlled import ControlledSearchAgent
+
+agent = ControlledSearchAgent()
+
+async for event in agent.astream({"query": "machine learning optimization"}):
+    match event.event_type:
+        case StreamEventType.RUNNING:
+            step = event.data.get("step", "")
+
+            if step == "iteration":
+                step_index = event.data.get("step_index", 0)
+                total = event.data.get("total_steps", 5)
+                results = event.data.get("results_so_far", 0)
+                print(f"[{step_index}/{total}] Results: {results}")
+
+            elif step == "iteration.evaluate":
+                positive = event.data.get("positive_rubrics", 0)
+                strong = event.data.get("strong_rubrics", [])
+                print(f"  Quality: {positive}/6 - Strong: {strong}")
+```
+
+### Base Agent LLM Streaming
+
+```python
+from akd.agents._base import LiteLLMInstructorBaseAgent
+
+class MyAgent(LiteLLMInstructorBaseAgent):
+    ...
+
+async for event in agent.astream(input_data, token_batch_size=20):
+    match event.event_type:
+        case StreamEventType.STREAMING:
+            print(event.token, end="", flush=True)
+
+        case StreamEventType.THINKING:
+            print(f"\n[Thinking] {event.thinking_content}")
+
+        case StreamEventType.PARTIAL:
+            # Partial structured output
+            partial = event.partial_output
+            if partial and hasattr(partial, 'answer') and partial.answer:
+                print(f"\nPartial answer: {partial.answer[:100]}...")
+```
+
+---
+
+## Testing Streaming
+
+### Basic Event Collection
+
+```python
+import pytest
+
+@pytest.mark.asyncio
+async def test_agent_streaming():
+    agent = DeepLitSearchAgent()
+    events = []
+
+    async for event in agent.astream({"query": "test query"}):
+        events.append(event)
+
+    # Verify event sequence
+    assert events[0].event_type == StreamEventType.STARTING
+    assert events[-1].event_type == StreamEventType.COMPLETED
+
+    # Check for expected steps
+    running_steps = [e.data.get("step") for e in events if e.event_type == StreamEventType.RUNNING]
+    assert "triage" in running_steps
+    assert "research.iteration" in running_steps
+```
+
+### Event Type Assertions
+
+```python
+def assert_streaming_contract(events: list[StreamEvent]):
+    """Verify streaming contract is followed."""
+    event_types = [e.event_type for e in events]
+
+    # Must start with STARTING
+    assert event_types[0] == StreamEventType.STARTING
+
+    # Must end with COMPLETED or FAILED
+    assert event_types[-1] in (StreamEventType.COMPLETED, StreamEventType.FAILED)
+
+    # COMPLETED must have output
+    if event_types[-1] == StreamEventType.COMPLETED:
+        assert events[-1].output is not None
+
+    # FAILED must have error
+    if event_types[-1] == StreamEventType.FAILED:
+        assert events[-1].error is not None
+```
+
+### Mock Event Consumer
+
+```python
+class StreamEventCollector:
+    """Collect and categorize stream events for testing."""
+
+    def __init__(self):
+        self.events = []
+        self.by_type = {}
+
+    async def collect(self, stream: AsyncIterator[StreamEvent]):
+        async for event in stream:
+            self.events.append(event)
+            self.by_type.setdefault(event.event_type, []).append(event)
+        return self
+
+    @property
+    def output(self):
+        completed = self.by_type.get(StreamEventType.COMPLETED, [])
+        return completed[0].output if completed else None
+
+    @property
+    def partials(self):
+        return [e.partial_output for e in self.by_type.get(StreamEventType.PARTIAL, [])]
+
+# Usage
+collector = StreamEventCollector()
+await collector.collect(agent.astream(input_data))
+assert collector.output is not None
+assert len(collector.partials) >= 1
+```
+
+---
+
+## Best Practices
+
+1. **Always yield STARTING first** - Consumers expect it for initialization
+2. **Always yield COMPLETED or FAILED last** - Never leave streams hanging
+3. **Re-raise after FAILED** - Allow error propagation after event emission
+4. **Use consistent step naming** - `parent.child` pattern (e.g., `research.search`)
+5. **Include context in all events** - Enables filtering and correlation
+6. **Batch tokens for efficiency** - Default `token_batch_size=10` balances latency/overhead
+7. **Emit PARTIAL progressively** - Let consumers see results as they become available
+8. **Delegate `_arun()` to `_astream()`** - Single source of truth for execution logic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ python_files = ["test_*.py", "*_test.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = [
+    "-v",
     "-n",
     "auto",
     "--dist=loadfile",

--- a/tests/agents/base/test_streaming.py
+++ b/tests/agents/base/test_streaming.py
@@ -1,61 +1,113 @@
 """Tests for streaming support."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from .conftest import LiteLLMTestInputSchema, LiteLLMTestOutputSchema, TestLiteLLMAgent
+from akd._base.streaming import StreamEvent, StreamEventType
+
+from .conftest import LiteLLMTestInputSchema, TestLiteLLMAgent
 
 
-@pytest.fixture
-def mock_litellm():
-    """Mock LiteLLM instructor."""
-    with patch("instructor.from_litellm") as mock:
-        client = AsyncMock()
-        mock.return_value = client
-        client.chat.completions.create = AsyncMock(
-            return_value=LiteLLMTestOutputSchema(response="Test", confidence=0.9),
-        )
-        yield client
+def make_chunk(content: str = "", reasoning: str | None = None):
+    """Create a mock streaming chunk."""
+    chunk = MagicMock()
+    chunk.choices = [MagicMock()]
+    chunk.choices[0].delta = MagicMock()
+    chunk.choices[0].delta.content = content
+    chunk.choices[0].delta.reasoning_content = reasoning
+    chunk.choices[0].delta.thinking = None
+    return chunk
 
 
-@pytest.fixture
-def agent(mock_litellm, litellm_config):
-    """Create agent with mock."""
-    return TestLiteLLMAgent(config=litellm_config)
+async def make_stream(*chunks):
+    """Create async generator from chunks."""
+    for chunk in chunks:
+        yield chunk
 
 
 class TestStreaming:
     """Streaming tests."""
 
     @pytest.mark.asyncio
-    async def test_astream_emits_events(self, agent, mock_litellm):
+    async def test_astream_emits_lifecycle_events(self, litellm_config):
         """Test astream emits STARTING, RUNNING, COMPLETED."""
-        events = [e async for e in agent.astream(LiteLLMTestInputSchema(query="test"))]
+        json_output = '{"response": "Test", "confidence": 0.9}'
 
-        assert [e.event_type for e in events] == ["starting", "running", "completed"]
+        with patch("akd.agents._base.acompletion") as mock_acompletion:
+            mock_acompletion.return_value = make_stream(make_chunk(json_output))
+
+            agent = TestLiteLLMAgent(config=litellm_config)
+            events = [e async for e in agent.astream(LiteLLMTestInputSchema(query="test"))]
+
+        event_types = [e.event_type for e in events]
+        assert event_types[0] == "starting"
+        assert "running" in event_types
+        assert event_types[-1] == "completed"
 
     @pytest.mark.asyncio
-    async def test_astream_sets_source(self, agent, mock_litellm):
+    async def test_astream_sets_source(self, litellm_config):
         """Test source is set on all events."""
-        events = [e async for e in agent.astream(LiteLLMTestInputSchema(query="test"))]
+        json_output = '{"response": "Test", "confidence": 0.9}'
+
+        with patch("akd.agents._base.acompletion") as mock_acompletion:
+            mock_acompletion.return_value = make_stream(make_chunk(json_output))
+
+            agent = TestLiteLLMAgent(config=litellm_config)
+            events = [e async for e in agent.astream(LiteLLMTestInputSchema(query="test"))]
 
         assert all(e.source == "TestLiteLLMAgent" for e in events)
 
     @pytest.mark.asyncio
-    async def test_astream_completed_has_output(self, agent, mock_litellm):
+    async def test_astream_completed_has_output(self, litellm_config):
         """Test COMPLETED event has output."""
-        events = [e async for e in agent.astream(LiteLLMTestInputSchema(query="test"))]
+        json_output = '{"response": "Test", "confidence": 0.9}'
+
+        with patch("akd.agents._base.acompletion") as mock_acompletion:
+            mock_acompletion.return_value = make_stream(make_chunk(json_output))
+
+            agent = TestLiteLLMAgent(config=litellm_config)
+            events = [e async for e in agent.astream(LiteLLMTestInputSchema(query="test"))]
 
         assert events[-1].output.response == "Test"
+        assert events[-1].output.confidence == 0.9
+
+    @pytest.mark.asyncio
+    async def test_astream_emits_thinking_events(self, litellm_config):
+        """Test THINKING events for reasoning tokens."""
+        with patch("akd.agents._base.acompletion") as mock_acompletion:
+            mock_acompletion.return_value = make_stream(
+                make_chunk(reasoning="Let me think..."),
+                make_chunk('{"response": "Test", "confidence": 0.9}'),
+            )
+
+            agent = TestLiteLLMAgent(config=litellm_config)
+            events = [e async for e in agent.astream(LiteLLMTestInputSchema(query="test"))]
+
+        thinking_events = [e for e in events if e.event_type == "thinking"]
+        assert len(thinking_events) == 1
+        assert thinking_events[0].thinking_content == "Let me think..."
+
+    @pytest.mark.asyncio
+    async def test_astream_emits_generating_events(self, litellm_config):
+        """Test GENERATING events for partial output."""
+        with patch("akd.agents._base.acompletion") as mock_acompletion:
+            # Stream JSON in chunks - only complete JSON will emit GENERATING
+            mock_acompletion.return_value = make_stream(
+                make_chunk('{"response": "Test", "confidence": 0.9}'),
+            )
+
+            agent = TestLiteLLMAgent(config=litellm_config)
+            events = [e async for e in agent.astream(LiteLLMTestInputSchema(query="test"))]
+
+        generating_events = [e for e in events if e.event_type == "generating"]
+        assert len(generating_events) >= 1
 
     @pytest.mark.asyncio
     async def test_astream_error_yields_failed(self, litellm_config):
         """Test error yields FAILED event."""
-        with patch("instructor.from_litellm") as mock:
-            client = AsyncMock()
-            mock.return_value = client
-            client.chat.completions.create = AsyncMock(side_effect=ValueError("Error!"))
+        with patch("akd.agents._base.acompletion") as mock_acompletion:
+            mock_acompletion.side_effect = ValueError("API Error!")
 
             agent = TestLiteLLMAgent(config=litellm_config)
             events = []
@@ -64,5 +116,38 @@ class TestStreaming:
                 async for e in agent.astream(LiteLLMTestInputSchema(query="test")):
                     events.append(e)
 
-            assert events[-1].event_type == "failed"
-            assert events[-1].error == "Error!"
+        assert events[-1].event_type == "failed"
+        assert events[-1].error == "API Error!"
+
+
+class TestStreamEventProperties:
+    """Tests for StreamEvent convenience properties."""
+
+    def test_thinking_content_property(self):
+        """Test thinking_content property returns data value."""
+        event = StreamEvent(
+            event_type=StreamEventType.THINKING,
+            source="TestAgent",
+            data={"thinking_content": "Let me think..."},
+        )
+        assert event.thinking_content == "Let me think..."
+
+    def test_partial_output_property(self):
+        """Test partial_output property returns data value."""
+        event = StreamEvent(
+            event_type=StreamEventType.GENERATING,
+            source="TestAgent",
+            data={"partial_output": {"response": "partial"}},
+        )
+        assert event.partial_output == {"response": "partial"}
+
+    def test_properties_return_none_when_missing(self):
+        """Test properties return None when data keys are missing."""
+        event = StreamEvent(
+            event_type=StreamEventType.THINKING,
+            source="TestAgent",
+        )
+        assert event.thinking_content is None
+        assert event.partial_output is None
+        assert event.output is None
+        assert event.error is None

--- a/tests/agents/base/test_streaming.py
+++ b/tests/agents/base/test_streaming.py
@@ -89,10 +89,10 @@ class TestStreaming:
         assert thinking_events[0].thinking_content == "Let me think..."
 
     @pytest.mark.asyncio
-    async def test_astream_emits_generating_events(self, litellm_config):
-        """Test GENERATING events for partial output."""
+    async def test_astream_emits_partial_events(self, litellm_config):
+        """Test PARTIAL events for partial output."""
         with patch("akd.agents._base.acompletion") as mock_acompletion:
-            # Stream JSON in chunks - only complete JSON will emit GENERATING
+            # Stream JSON in chunks - only complete JSON will emit PARTIAL
             mock_acompletion.return_value = make_stream(
                 make_chunk('{"response": "Test", "confidence": 0.9}'),
             )
@@ -100,8 +100,8 @@ class TestStreaming:
             agent = TestLiteLLMAgent(config=litellm_config)
             events = [e async for e in agent.astream(LiteLLMTestInputSchema(query="test"))]
 
-        generating_events = [e for e in events if e.event_type == "generating"]
-        assert len(generating_events) >= 1
+        partial_events = [e for e in events if e.event_type == "partial"]
+        assert len(partial_events) >= 1
 
     @pytest.mark.asyncio
     async def test_astream_error_yields_failed(self, litellm_config):
@@ -135,7 +135,7 @@ class TestStreamEventProperties:
     def test_partial_output_property(self):
         """Test partial_output property returns data value."""
         event = StreamEvent(
-            event_type=StreamEventType.GENERATING,
+            event_type=StreamEventType.PARTIAL,
             source="TestAgent",
             data={"partial_output": {"response": "partial"}},
         )


### PR DESCRIPTION
> This is a follow up the previous pr #303 

---

### Summary :memo:

Add real-time streaming support for AKD agents, enabling progress visibility, partial outputs, and reasoning transparency during execution. Agents now expose `astream()` API alongside `arun()` for observing execution in real-time.

### Details

1. **Core streaming infrastructure** (`akd/_base/streaming.py`)
   - `StreamEventType` enum: STARTING, RUNNING, STREAMING, THINKING, PARTIAL, COMPLETED, FAILED, TOOL_CALLING, TOOL_RESULT
   - `StreamEvent` CloudEvents-inspired envelope with convenience properties
   - `StreamingMixin` adds `astream()` with input/output validation

2. **PartialModel generic** (`akd/utils.py`)
   - Dynamically converts any Pydantic model to partial (all fields Optional)
   - Enables progressive output as JSON builds during LLM streaming

3. **LiteLLMInstructorBaseAgent streaming** (`akd/agents/_base.py`)
   - `_stream_llm_response()` for token-by-token streaming with batching
   - STREAMING events for raw tokens, THINKING for reasoning tokens
   - PARTIAL events with validated partial model instances

4. **DeepLitSearchAgent streaming** (`akd/agents/search/deep_search.py`)
   - Multi-step pipeline progress events (triage, research iterations, synthesis)
   - PARTIAL events with accumulated search results during research

5. **ControlledSearchAgent streaming** (`akd/agents/search/controlled.py`)
   - Iteration-based progress events with quality metrics
   - Inherited by CodeSearchAgent for code search streaming

6. **Documentation** (`docs/specs/STREAMING.md`)
   - Comprehensive guide for event types, usage patterns, and implementation

---

## Usage

### DeepLitSearchAgent

```python
from akd.agents.search.deep_search import DeepLitSearchAgent, LitSearchAgentInputSchema
from akd._base.streaming import StreamEventType

agent = DeepLitSearchAgent()
input_data = LitSearchAgentInputSchema(query="climate change mitigation strategies")

async for event in agent.astream(input_data):
    match event.event_type:
        case StreamEventType.STARTING:
            print(f"Starting: {event.message}")

        case StreamEventType.RUNNING:
            step = event.data.get("step", "")
            if step.startswith("research.iteration"):
                iteration = event.data.get("iteration", 0)
                print(f"Iteration {iteration}: {event.message}")
            else:
                print(f"  {event.message}")

        case StreamEventType.PARTIAL:
            partial = event.partial_output
            if partial and partial.results:
                print(f"  Results so far: {len(partial.results)}")

        case StreamEventType.COMPLETED:
            result = event.output
            print(f"Complete: {len(result.results)} results")
            print(f"Answer: {result.answer[:200]}...")

        case StreamEventType.FAILED:
            print(f"Error: {event.error}")
```

### CodeSearchAgent

```python
from akd.agents.search.code_search import CodeSearchAgent, CodeSearchAgentConfig
from akd._base.streaming import StreamEventType

agent = CodeSearchAgent(config=CodeSearchAgentConfig(debug=True))

async for event in agent.astream({"query": "NASA earth observation data processing"}):
    match event.event_type:
        case StreamEventType.RUNNING:
            step = event.data.get("step", "")
            if step == "iteration":
                step_index = event.data.get("step_index", 0)
                total = event.data.get("total_steps", 5)
                results = event.data.get("results_so_far", 0)
                print(f"[{step_index}/{total}] Results: {results}")
            elif step == "iteration.evaluate":
                positive = event.data.get("positive_rubrics", 0)
                print(f"  Quality: {positive}/6 rubrics positive")

        case StreamEventType.COMPLETED:
            result = event.output
            print(f"Found {len(result.results)} code results")
```

### QueryAgent (simple agent)

```python
from akd.agents.query import QueryAgent, QueryAgentInputSchema
from akd._base.streaming import StreamEventType

agent = QueryAgent()
input_data = QueryAgentInputSchema(query="machine learning optimization techniques", num_queries=5)

# Option 1: Basic streaming with lifecycle events
async for event in agent.astream(input_data):
    match event.event_type:
        case StreamEventType.STARTING:
            print("Generating queries...")
        case StreamEventType.COMPLETED:
            result = event.output
            print(f"Generated {len(result.queries)} queries:")
            for q in result.queries:
                print(f"  - {q}")

# Option 2: With token streaming (for observing LLM output)
async for event in agent.astream(input_data, token_batch_size=10):
    match event.event_type:
        case StreamEventType.STREAMING:
            print(event.token, end="", flush=True)  # Raw tokens
        case StreamEventType.THINKING:
            print(f"\n[Reasoning] {event.thinking_content}")  # For o1/Claude thinking
        case StreamEventType.PARTIAL:
            partial = event.partial_output
            if partial and partial.queries:
                print(f"\nPartial queries: {partial.queries}")
        case StreamEventType.COMPLETED:
            result = event.output
            print(f"\nFinal: {result.queries}")
```

### Key Concepts

| Method | Returns | Use Case |
|--------|---------|----------|
| `agent.arun(input)` | Output directly | Simple execution, no progress tracking |
| `agent.astream(input)` | `AsyncIterator[StreamEvent]` | Real-time progress, partial outputs, token streaming |

Event flow: `STARTING → RUNNING* → (STREAMING|THINKING|PARTIAL)* → COMPLETED|FAILED`
