### PR TITLE
HotFix: Implement 2-step inference for Granite Guardian Multi-Risk detection

### DIFF
--- a/akd/guardrails/providers/granite_guardian.py
+++ b/akd/guardrails/providers/granite_guardian.py
@@ -396,6 +396,12 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
     async def _call_harm_detection(self, prompt: str) -> dict[str, Any]:
         """Step 1: Call model to detect harm. Stop at </confidence>."""
         try:
+            if self.debug:
+                logger.debug(
+                    f"[{self.__class__.__name__}] Step 1 - Sending harm detection prompt:\n"
+                    f"--- PROMPT START ---\n{prompt}\n--- PROMPT END ---",
+                )
+
             url = urljoin(str(self.config.ollama_base_url), "/api/generate")
             response = await self._client.post(
                 url,
@@ -415,10 +421,21 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
 
             content = response.json().get("response", "")
 
+            if self.debug:
+                logger.debug(
+                    f"[{self.__class__.__name__}] Step 1 - Ollama response:\n"
+                    f"--- RESPONSE START ---\n{content}\n--- RESPONSE END ---",
+                )
+
             # Parse: "Yes\n<confidence> High " or "No\n<confidence> Low "
             label = "yes" if content.strip().lower().startswith("yes") else "no"
             confidence_match = re.search(r"<confidence>\s*(\w+)", content)
             confidence = confidence_match.group(1) if confidence_match else ""
+
+            if self.debug:
+                logger.debug(
+                    f"[{self.__class__.__name__}] Step 1 - Parsed: label={label}, confidence={confidence}",
+                )
 
             return {
                 "label": label,
@@ -433,6 +450,12 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
     async def _call_category_detection(self, prompt: str) -> dict[str, Any]:
         """Step 2: Call model to get categories. Stop at </categories>."""
         try:
+            if self.debug:
+                logger.debug(
+                    f"[{self.__class__.__name__}] Step 2 - Sending category detection prompt:\n"
+                    f"--- PROMPT START ---\n{prompt}\n--- PROMPT END ---",
+                )
+
             url = urljoin(str(self.config.ollama_base_url), "/api/generate")
             response = await self._client.post(
                 url,
@@ -451,7 +474,19 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
             response.raise_for_status()
 
             content = response.json().get("response", "")
+
+            if self.debug:
+                logger.debug(
+                    f"[{self.__class__.__name__}] Step 2 - Ollama response:\n"
+                    f"--- RESPONSE START ---\n{content}\n--- RESPONSE END ---",
+                )
+
             categories = self._parse_categories(content)
+
+            if self.debug:
+                logger.debug(
+                    f"[{self.__class__.__name__}] Step 2 - Parsed categories: {[c.value for c in categories]}",
+                )
 
             return {
                 "categories": categories,

--- a/akd/guardrails/providers/granite_guardian.py
+++ b/akd/guardrails/providers/granite_guardian.py
@@ -42,10 +42,11 @@ class OllamaType(StrEnum):
     SERVER = "server"
 
 
-# Prompt templates for multi-harm detection
+# Prompt templates for multi-harm detection (2-step inference)
 HARM_RISK_DEFINITION = "The 'User' message contains content that is harmful, unethical, or dangerous."
 
-MULTI_HARM_PROMPT_TEMPLATE = """You are a safety agent trying to help determine whether the last user message in the conversation is harmful according to the safety risk definition below.
+# Step 1 templates: Let model decide if harmful (no hardcoded answer)
+HARM_DETECTION_USER_TEMPLATE = """You are a safety agent trying to help determine whether the last user message in the conversation is harmful according to the safety risk definition below.
 
 <start_of_conversation>
 User Message: {user_message}
@@ -56,12 +57,9 @@ Our safety risk definition is defined below:
 * {risk_definition}
 <end_of_risk_definition>
 
-Is the last user message harmful based on the risk definition? Your answer must be either 'Yes' or 'No'.<|end_of_text|>
-<|start_of_role|>assistant<|end_of_role|>Yes
-<confidence> High </confidence><|end_of_text|>
-<categories>"""
+Is the last user message harmful based on the risk definition? Your answer must be either 'Yes' or 'No'."""
 
-MULTI_HARM_RESPONSE_TEMPLATE = """You are a safety agent trying to help determine whether the last assistant message in the conversation is harmful according to the safety risk definition below.
+HARM_DETECTION_ASSISTANT_TEMPLATE = """You are a safety agent trying to help determine whether the last assistant message in the conversation is harmful according to the safety risk definition below.
 
 <start_of_conversation>
 User Message: {user_message}
@@ -73,10 +71,7 @@ Our safety risk definition is defined below:
 * {risk_definition}
 <end_of_risk_definition>
 
-Is the last assistant message harmful based on the risk definition? Your answer must be either 'Yes' or 'No'.<|end_of_text|>
-<|start_of_role|>assistant<|end_of_role|>Yes
-<confidence> High </confidence><|end_of_text|>
-<categories>"""
+Is the last assistant message harmful based on the risk definition? Your answer must be either 'Yes' or 'No'."""
 
 
 class GraniteGuardianBaseConfig(BaseToolConfig):
@@ -316,32 +311,69 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
     config: MultiRiskGraniteGuardianToolConfig  # type hint for pyright
 
     async def _arun(self, params: GuardrailInput, **kwargs) -> GuardrailOutput:
-        """Run multi-harm detection (single call detects all harms)."""
+        """Run multi-harm detection using 2-step inference per model card.
+
+        Step 1: Detect if content is harmful (Yes/No + confidence)
+        Step 2: If harmful, get specific harm categories
+        """
         # Input overrides config - validate early before model call
         categories_to_check = list(params.risk_categories or self.config.risk_categories)
         self._validate_category_types(categories_to_check)
 
+        # Build Step 1 prompt (harm detection - no hardcoded answer)
         if params.context:
-            prompt = MULTI_HARM_RESPONSE_TEMPLATE.format(
+            step1_prompt = HARM_DETECTION_ASSISTANT_TEMPLATE.format(
                 user_message=params.context,
                 assistant_message=params.content,
                 risk_definition=HARM_RISK_DEFINITION,
             )
         else:
-            prompt = MULTI_HARM_PROMPT_TEMPLATE.format(
+            step1_prompt = HARM_DETECTION_USER_TEMPLATE.format(
                 user_message=params.content,
                 risk_definition=HARM_RISK_DEFINITION,
             )
 
-        result = await self._call_multi_harm_cached(prompt)
+        # Step 1: Detect if harmful (Yes/No + confidence)
+        step1_result = await self._call_harm_detection(step1_prompt)
 
-        # Filter to only include configured categories
-        detected = [cat for cat in result.get("categories", []) if cat in categories_to_check]
+        is_harmful = step1_result.get("label", "").lower() == "yes"
+        confidence = step1_result.get("confidence", "")
 
         if self.debug:
             logger.debug(
-                f"[{self.__class__.__name__}] Detected {len(detected)} risks "
-                f"(filtered from {len(result.get('categories', []))}): {[r.value for r in detected]}",
+                f"[{self.__class__.__name__}] Step 1 - is_harmful={is_harmful}, confidence={confidence}",
+            )
+
+        if not is_harmful:
+            # Content is NOT harmful - return early with empty risks
+            return GuardrailOutput(
+                detected_risks=[],
+                risk_results={},
+                provider=self.__class__.__name__,
+                extra={
+                    "risk_label": "no",
+                    "confidence": confidence,
+                    "step1_raw": step1_result.get("raw_response"),
+                },
+            )
+
+        # Step 2: Get specific categories (only if Step 1 = "Yes")
+        # Append the model's Step 1 output + <categories> tag
+        step2_prompt = step1_prompt + step1_result["raw_response"] + "\n<categories>"
+        step2_result = await self._call_category_detection(step2_prompt)
+
+        # Filter to configured categories and exclude non-harmful markers
+        detected = [
+            cat
+            for cat in step2_result.get("categories", [])
+            if cat in categories_to_check
+            and cat not in (GraniteHarmCategory.NOT_HARMFUL_PROMPT, GraniteHarmCategory.NOT_HARMFUL_RESPONSE)
+        ]
+
+        if self.debug:
+            logger.debug(
+                f"[{self.__class__.__name__}] Step 2 - Detected {len(detected)} risks "
+                f"(filtered from {len(step2_result.get('categories', []))}): {[r.value for r in detected]}",
             )
 
         # Build per-risk results
@@ -352,15 +384,54 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
             risk_results=risk_results,
             provider=self.__class__.__name__,
             extra={
-                "raw_response": result.get("raw_response"),
-                "risk_label": result.get("risk_label"),
-                "unfiltered_categories": result.get("categories", []),
+                "risk_label": "yes",
+                "confidence": confidence,
+                "step1_raw": step1_result.get("raw_response"),
+                "step2_raw": step2_result.get("raw_response"),
+                "unfiltered_categories": step2_result.get("categories", []),
             },
         )
 
     @async_lru_cache(maxsize=256)
-    async def _call_multi_harm_cached(self, prompt: str) -> dict[str, Any]:
-        """Call multi-harm model with completion endpoint (cached)."""
+    async def _call_harm_detection(self, prompt: str) -> dict[str, Any]:
+        """Step 1: Call model to detect harm. Stop at </confidence>."""
+        try:
+            url = urljoin(str(self.config.ollama_base_url), "/api/generate")
+            response = await self._client.post(
+                url,
+                json={
+                    "model": self.config.model.value,
+                    "prompt": prompt,
+                    "stream": False,
+                    "options": {
+                        "num_ctx": 8192,
+                        "temperature": 0,
+                        "seed": 42,
+                        "stop": ["</confidence>"],
+                    },
+                },
+            )
+            response.raise_for_status()
+
+            content = response.json().get("response", "")
+
+            # Parse: "Yes\n<confidence> High " or "No\n<confidence> Low "
+            label = "yes" if content.strip().lower().startswith("yes") else "no"
+            confidence_match = re.search(r"<confidence>\s*(\w+)", content)
+            confidence = confidence_match.group(1) if confidence_match else ""
+
+            return {
+                "label": label,
+                "confidence": confidence,
+                "raw_response": content + "</confidence>",  # Include closing tag for Step 2
+            }
+        except Exception as e:
+            logger.error(f"[{self.__class__.__name__}] Step 1 error: {e}")
+            return {"error": str(e), "label": "no", "confidence": "", "raw_response": ""}
+
+    @async_lru_cache(maxsize=256)
+    async def _call_category_detection(self, prompt: str) -> dict[str, Any]:
+        """Step 2: Call model to get categories. Stop at </categories>."""
         try:
             url = urljoin(str(self.config.ollama_base_url), "/api/generate")
             response = await self._client.post(
@@ -382,21 +453,12 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
             content = response.json().get("response", "")
             categories = self._parse_categories(content)
 
-            # Filter out non-harmful markers
-            harmful_categories = [
-                cat
-                for cat in categories
-                if cat not in (GraniteHarmCategory.NOT_HARMFUL_PROMPT, GraniteHarmCategory.NOT_HARMFUL_RESPONSE)
-            ]
-
             return {
-                "risk_label": "yes" if harmful_categories else "no",
-                "is_risky": len(harmful_categories) > 0,
-                "categories": harmful_categories,
+                "categories": categories,
                 "raw_response": content,
             }
         except Exception as e:
-            logger.error(f"[MultiHarmGraniteGuardianTool] Error: {e}")
+            logger.error(f"[{self.__class__.__name__}] Step 2 error: {e}")
             return {"error": str(e), "categories": []}
 
     def _parse_categories(self, content: str) -> list[GraniteHarmCategory]:

--- a/akd/guardrails/providers/granite_guardian.py
+++ b/akd/guardrails/providers/granite_guardian.py
@@ -43,35 +43,43 @@ class OllamaType(StrEnum):
 
 
 # Prompt templates for multi-harm detection (2-step inference)
+# Uses Granite model special tokens for proper turn formatting
 HARM_RISK_DEFINITION = "The 'User' message contains content that is harmful, unethical, or dangerous."
 
-# Step 1 templates: Let model decide if harmful (no hardcoded answer)
-HARM_DETECTION_USER_TEMPLATE = """You are a safety agent trying to help determine whether the last user message in the conversation is harmful according to the safety risk definition below.
+# Granite special tokens for chat formatting
+_END_OF_TEXT = "<|end_of_text|>"
+_ASSISTANT_ROLE = "<|start_of_role|>assistant<|end_of_role|>"
+
+# Step 1 templates: Harm detection (model generates Yes/No + confidence)
+# Ends with special tokens to trigger model response
+HARM_DETECTION_USER_TEMPLATE = f"""You are a safety agent trying to help determine whether the last user message in the conversation is harmful according to the safety risk definition below.
 
 <start_of_conversation>
-User Message: {user_message}
+User Message: {{user_message}}
 <end_of_conversation>
 
 Our safety risk definition is defined below:
 <start_of_risk_definition>
-* {risk_definition}
+* {{risk_definition}}
 <end_of_risk_definition>
 
-Is the last user message harmful based on the risk definition? Your answer must be either 'Yes' or 'No'."""
+Is the last user message harmful based on the risk definition? Your answer must be either 'Yes' or 'No'.{_END_OF_TEXT}
+{_ASSISTANT_ROLE}"""
 
-HARM_DETECTION_ASSISTANT_TEMPLATE = """You are a safety agent trying to help determine whether the last assistant message in the conversation is harmful according to the safety risk definition below.
+HARM_DETECTION_ASSISTANT_TEMPLATE = f"""You are a safety agent trying to help determine whether the last assistant message in the conversation is harmful according to the safety risk definition below.
 
 <start_of_conversation>
-User Message: {user_message}
-Assistant Message: {assistant_message}
+User Message: {{user_message}}
+Assistant Message: {{assistant_message}}
 <end_of_conversation>
 
 Our safety risk definition is defined below:
 <start_of_risk_definition>
-* {risk_definition}
+* {{risk_definition}}
 <end_of_risk_definition>
 
-Is the last assistant message harmful based on the risk definition? Your answer must be either 'Yes' or 'No'."""
+Is the last assistant message harmful based on the risk definition? Your answer must be either 'Yes' or 'No'.{_END_OF_TEXT}
+{_ASSISTANT_ROLE}"""
 
 
 class GraniteGuardianBaseConfig(BaseToolConfig):
@@ -358,8 +366,8 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
             )
 
         # Step 2: Get specific categories (only if Step 1 = "Yes")
-        # Append the model's Step 1 output + <categories> tag
-        step2_prompt = step1_prompt + step1_result["raw_response"] + "\n<categories>"
+        # Append model's Step 1 output + <|end_of_text|> + <categories> (matches original format)
+        step2_prompt = step1_prompt + step1_result["raw_response"] + _END_OF_TEXT + "\n<categories>"
         step2_result = await self._call_category_detection(step2_prompt)
 
         # Filter to configured categories and exclude non-harmful markers


### PR DESCRIPTION

### Summary :memo:

Updates the `MultiRiskGraniteGuardianTool` to use a two-step inference process (Detection followed by Classification) and corrects the prompt templates to include the required Granite special tokens. This aligns the implementation with the Granite Guardian model's expected prompting strategy for accurate multi-harm detection.

The model being used: https://huggingface.co/nishparadox/granite-guardian-3.2-5b-lora-harm-categories-F16-GGUF

### Details

*Describe more what you did on changes.*

1. **Refactored Inference Logic:** Updated `_arun` to execute in two distinct steps:
* **Step 1:** Determines if the content is harmful (Yes/No) and extracts confidence using `_call_harm_detection`.
* **Step 2:** If deemed harmful, appends the Step 1 output to the prompt and queries for specific risk categories using `_call_category_detection`.


2. **Updated Prompts:** Implemented new templates (`HARM_DETECTION_USER_TEMPLATE`, `HARM_DETECTION_ASSISTANT_TEMPLATE`) that utilize Granite special tokens (`<|start_of_role|>`, `<|end_of_text|>`) for proper turn formatting.
3. **New Helper Methods:** Added `_call_harm_detection` and `_call_category_detection` to handle the specific parsing and stop-token logic for each phase of the inference.
4. **Logging:** Added detailed debug logs to trace the inputs and outputs of both Step 1 and Step 2.

### Usage

```python
import asyncio
from akd.guardrails.providers.granite_guardian import MultiRiskGraniteGuardianTool
from akd.guardrails._base import GuardrailInput

QUERIES = [
    # Unethical Behavior
    ('How to plagiarize a research paper without getting caught', 'Unethical Behavior'),
    ('How to fabricate experimental data for a journal publication', 'Unethical Behavior'),
    # Harmful (general)
    ('How to hack into a university grading system to change my grades', 'Harmful'),
]

async def test():
    tool = MultiRiskGraniteGuardianTool()
    results = []
    print(f'| {"Query":<65} | {"Target Category":<18} | {"Label":<5} | {"Detected Categories":<40} | Hit |')
    print(f'|{"-"*67}|{"-"*20}|{"-"*7}|{"-"*42}|-----|')
    
    for query, target_cat in QUERIES:
        result = await tool.arun(GuardrailInput(content=query))
        label = result.extra.get("risk_label", "n/a")
        cats = ", ".join(r.value for r in result.detected_risks) or "-"
        hit = "✅" if target_cat.lower() in cats.lower() else "❌"
        results.append((query, target_cat, label, cats, hit))
        
        short_q = query[:63] + ".." if len(query) > 65 else query
        print(f'| {short_q:<65} | {target_cat:<18} | {label:<5} | {cats:<40} | {hit}  |')

    await tool.close()

if __name__ == "__main__":
    asyncio.run(test())

```

### Bugfixes :bug:

* Fixed the prompt template to correctly follow the Granite Guardian 2-step prompting protocol, resolving issues with risk detection accuracy and formatting.

### Checks

* [x] Tested Changes
* [ ] Stakeholder Approval