### PR TITLE
Fix build_risk_category_from_yaml dropping severity into extra dict

### DIFF
--- a/akd/guardrails/categories/atlas.py
+++ b/akd/guardrails/categories/atlas.py
@@ -45,13 +45,15 @@ def build_risk_category_from_yaml(
         # Core fields
         description = risk.get("description", "")
         name = risk.get("name")
+        severity = risk.get("severity", "normal")
 
         # Put everything else in extra
-        extra = {k: v for k, v in risk.items() if k not in ("id", "description", "name") and v}
+        extra = {k: v for k, v in risk.items() if k not in ("id", "description", "name", "severity") and v}
 
         metadata = RiskMetadata(
             description=description,
             name=name,
+            severity=severity,
             extra=extra,
         )
 


### PR DESCRIPTION
   severity from YAML was not extracted as a core field, so it ended up in
   RiskMetadata.extra while RiskMetadata.severity always defaulted to
   normal.
