### PR TITLE
fix: Added unique node IDs, validator for worflow_plan, and unified planner model config

### DIFF
--- a/akd/configs/project.py
+++ b/akd/configs/project.py
@@ -35,6 +35,7 @@ class ApiKeys(BaseModel):
 class ModelConfigSettings(BaseSettings):
     provider: ModelProvider = ModelProvider.OPENAI
     model_name: str = "gpt-4o-mini"
+    planner_model_name: str = "gpt-5.2"
     temperature: float = 0.0
     max_tokens: int = 120_000
     api_keys: ApiKeys = ApiKeys()

--- a/akd/mapping/agent_registry.json
+++ b/akd/mapping/agent_registry.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "created_at": "2025-10-02T07:25:35.166590+00:00",
-  "updated_at": "2025-10-02T07:25:35.166645+00:00",
+  "created_at": "2026-02-10T16:11:27.465651+00:00",
+  "updated_at": "2026-02-10T16:11:27.465749+00:00",
   "agents": {
     "deep_search": {
       "agent_id": "deep_search",
@@ -12,34 +12,26 @@
       "input_schema": {
         "fields": [
           {
-            "name": "queries",
+            "name": "query",
             "type": "string",
-            "description": "List of additional queries to refine search",
-            "required": false,
+            "description": "Query to search for. Can be question or subject/topic of interest.",
+            "required": true,
             "default": null,
             "items_type": null
           },
           {
-            "name": "category",
+            "name": "search_mode",
             "type": "string",
-            "description": "Search category",
+            "description": "Search mode determining depth and breadth of search",
             "required": false,
-            "default": "science",
+            "default": "medium",
             "items_type": null
           },
           {
-            "name": "max_results",
-            "type": "integer",
-            "description": "Maximum number of results to return",
-            "required": false,
-            "default": 20,
-            "items_type": null
-          },
-          {
-            "name": "query",
+            "name": "additional_context",
             "type": "string",
-            "description": "Research query to search for",
-            "required": true,
+            "description": "Additional context for the search agent",
+            "required": false,
             "default": null,
             "items_type": null
           }
@@ -48,27 +40,11 @@
       "output_schema": {
         "fields": [
           {
-            "name": "results",
-            "type": "array",
-            "description": "List of search results",
-            "required": true,
-            "default": null,
-            "items_type": "string"
-          },
-          {
-            "name": "category",
+            "name": "answer",
             "type": "string",
-            "description": "Search category",
+            "description": "Concise shortform answer to the research query in few sentences.",
             "required": true,
             "default": null,
-            "items_type": null
-          },
-          {
-            "name": "iterations_performed",
-            "type": "integer",
-            "description": "Number of search iterations performed",
-            "required": false,
-            "default": 1,
             "items_type": null
           },
           {
@@ -76,8 +52,16 @@
             "type": "string",
             "description": "Synthesized research report from the literature search",
             "required": false,
-            "default": "",
+            "default": null,
             "items_type": null
+          },
+          {
+            "name": "results",
+            "type": "array",
+            "description": "List of search results",
+            "required": true,
+            "default": null,
+            "items_type": "string"
           },
           {
             "name": "extra",
@@ -143,9 +127,9 @@
           },
           {
             "name": "graph",
-            "type": "object",
+            "type": "string",
             "description": "Graph created from the ingested papers.",
-            "required": true,
+            "required": false,
             "default": null,
             "items_type": null
           }
@@ -168,34 +152,26 @@
       "input_schema": {
         "fields": [
           {
-            "name": "queries",
+            "name": "query",
             "type": "string",
-            "description": "List of additional queries to refine search",
-            "required": false,
+            "description": "Query to search for. Can be question or subject/topic of interest.",
+            "required": true,
             "default": null,
             "items_type": null
           },
           {
-            "name": "category",
+            "name": "search_mode",
             "type": "string",
-            "description": "Search category",
+            "description": "Search mode determining depth and breadth of search",
             "required": false,
-            "default": "science",
+            "default": "medium",
             "items_type": null
           },
           {
-            "name": "max_results",
-            "type": "integer",
-            "description": "Maximum number of results to return",
-            "required": false,
-            "default": 20,
-            "items_type": null
-          },
-          {
-            "name": "query",
+            "name": "additional_context",
             "type": "string",
-            "description": "Research query to search for",
-            "required": true,
+            "description": "Additional context for the search agent",
+            "required": false,
             "default": null,
             "items_type": null
           }
@@ -203,6 +179,22 @@
       },
       "output_schema": {
         "fields": [
+          {
+            "name": "answer",
+            "type": "string",
+            "description": "Concise shortform answer to the research query in few sentences.",
+            "required": true,
+            "default": null,
+            "items_type": null
+          },
+          {
+            "name": "report",
+            "type": "string",
+            "description": "Detailed report pertaining to the research query.",
+            "required": false,
+            "default": null,
+            "items_type": null
+          },
           {
             "name": "results",
             "type": "array",
@@ -212,19 +204,11 @@
             "items_type": "string"
           },
           {
-            "name": "category",
-            "type": "string",
-            "description": "Search category",
-            "required": true,
-            "default": null,
-            "items_type": null
-          },
-          {
-            "name": "iterations_performed",
-            "type": "integer",
-            "description": "Number of search iterations performed",
+            "name": "extra",
+            "type": "object",
+            "description": "Extra metadata and synthesis information",
             "required": false,
-            "default": 1,
+            "default": null,
             "items_type": null
           }
         ]

--- a/akd/planner/field_mapping_generator.py
+++ b/akd/planner/field_mapping_generator.py
@@ -46,7 +46,7 @@ class FieldMappingGenerator:
             temperature: Generation temperature (0.0 for deterministic)
             api_key: API key (defaults to CONFIG setting)
         """
-        self.model = model or CONFIG.model_config_settings.model_name
+        self.model = model or CONFIG.model_config_settings.planner_model_name
         self.temperature = temperature
         self.api_key = api_key or CONFIG.model_config_settings.api_keys.openai
 

--- a/akd/planner/field_mapping_generator.py
+++ b/akd/planner/field_mapping_generator.py
@@ -5,7 +5,7 @@ Generates semantic field mappings when explicit mappings don't exist,
 with confidence scoring and detailed reasoning.
 """
 
-from typing import Optional
+from __future__ import annotations
 
 from loguru import logger
 
@@ -37,7 +37,7 @@ class FieldMappingGenerator:
     field names don't match exactly between agents.
     """
 
-    def __init__(self, model: Optional[str] = None, temperature: float = 0.0, api_key: Optional[str] = None):
+    def __init__(self, model: str | None = None, temperature: float = 0.0, api_key: str | None = None):
         """
         Initialize field mapping generator.
 

--- a/akd/planner/field_mapping_registry.py
+++ b/akd/planner/field_mapping_registry.py
@@ -7,10 +7,12 @@ Provides three-tier mapping strategy:
 3. LLM-generated mappings (intelligent fallback)
 """
 
+from __future__ import annotations
+
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from loguru import logger
 from pydantic import BaseModel, Field
@@ -46,8 +48,8 @@ class FieldMappingRegistry:
 
     def __init__(
         self,
-        explicit_path: Optional[str] = None,
-        llm_path: Optional[str] = None,
+        explicit_path: str | None = None,
+        llm_path: str | None = None,
     ):
         """
         Initialize field mapping registry.
@@ -120,7 +122,7 @@ class FieldMappingRegistry:
         self,
         source_agent_id: str,
         target_agent_id: str,
-    ) -> Optional[dict[str, str]]:
+    ) -> dict[str, str] | None:
         """
         Get field mapping for source->target agent pair.
 
@@ -300,7 +302,7 @@ class FieldMappingRegistry:
         self,
         source_agent_id: str,
         target_agent_id: str,
-    ) -> Optional[dict[str, Any]]:
+    ) -> dict[str, Any] | None:
         """
         Get detailed information about a mapping including metadata.
 

--- a/akd/planner/format_builder.py
+++ b/akd/planner/format_builder.py
@@ -60,12 +60,13 @@ class WorkflowNodeIO(BaseModel):
 class WorkflowNode(BaseModel):
     """Individual node in a workflow definition."""
 
-    type: str = Field(..., description="Node type corresponding to agent type")
+    id: str = Field(..., description="Unique node identifier (e.g., code_search_0, gap_analysis_0)")
+    type: str = Field(..., description="Node type corresponding to agent type for registry lookup")
     input: WorkflowNodeIO = Field(default_factory=WorkflowNodeIO)
     output: WorkflowNodeIO | None = Field(default=None)
     io_map: dict[str, str] | None = Field(
         default=None,
-        description="JSONPath mappings for cross-node data access (target_field: jsonpath_expr)",
+        description="JSONPath mappings for cross-node data access (target_field: jsonpath_expr using node id)",
     )
 
 
@@ -119,7 +120,7 @@ class WorkflowFormat(BaseModel):
 
         Checks that:
         1. JSONPath expressions are well-formed (start with $.)
-        2. Referenced nodes exist in the workflow
+        2. Referenced node IDs exist in the workflow
         3. No circular dependencies exist
 
         Args:
@@ -132,7 +133,7 @@ class WorkflowFormat(BaseModel):
             ValueError: If strict=True and validation errors found
         """
         issues = []
-        node_types = {node.type for node in self.nodes}
+        node_ids = {node.id for node in self.nodes}
 
         for node in self.nodes:
             if not node.io_map:
@@ -141,22 +142,22 @@ class WorkflowFormat(BaseModel):
             for target_field, jsonpath in node.io_map.items():
                 # Check JSONPath format
                 if not jsonpath.startswith("$."):
-                    issue = f"Node '{node.type}', field '{target_field}': Invalid JSONPath '{jsonpath}' (must start with '$.')"
+                    issue = f"Node '{node.id}', field '{target_field}': Invalid JSONPath '{jsonpath}' (must start with '$.')"
                     issues.append(issue)
                     continue
 
                 # Extract referenced node from JSONPath (format: $.node_id.outputs.field)
                 parts = jsonpath.split(".")
                 if len(parts) < 4:
-                    issue = f"Node '{node.type}', field '{target_field}': Invalid JSONPath format '{jsonpath}' (expected $.node_id.outputs.field)"
+                    issue = f"Node '{node.id}', field '{target_field}': Invalid JSONPath format '{jsonpath}' (expected $.node_id.outputs.field)"
                     issues.append(issue)
                     continue
 
                 referenced_node = parts[1]
 
                 # Check referenced node exists
-                if referenced_node not in node_types:
-                    issue = f"Node '{node.type}', field '{target_field}': Referenced node '{referenced_node}' not found in workflow"
+                if referenced_node not in node_ids:
+                    issue = f"Node '{node.id}', field '{target_field}': Referenced node '{referenced_node}' not found in workflow"
                     issues.append(issue)
 
         if strict and issues:
@@ -169,7 +170,7 @@ class WorkflowFormat(BaseModel):
         Validate workflow edges.
 
         Checks that:
-        1. All edges reference existing nodes (or START/END)
+        1. All edges reference existing node IDs (or START/END)
         2. Workflow has a valid flow from START to END
         3. No orphaned nodes exist
 
@@ -183,8 +184,8 @@ class WorkflowFormat(BaseModel):
             ValueError: If strict=True and validation errors found
         """
         issues = []
-        node_types = {node.type for node in self.nodes}
-        valid_nodes = node_types | {"START", "END"}
+        node_ids = {node.id for node in self.nodes}
+        valid_nodes = node_ids | {"START", "END"}
 
         # Check all edge references are valid
         for edge in self.edges:
@@ -210,7 +211,7 @@ class WorkflowFormat(BaseModel):
             if edge.to_node != "END":
                 nodes_in_edges.add(edge.to_node)
 
-        orphaned = node_types - nodes_in_edges
+        orphaned = node_ids - nodes_in_edges
         if orphaned:
             issues.append(f"Orphaned nodes (not connected to any edge): {orphaned}")
 
@@ -285,6 +286,7 @@ class WorkflowFormat(BaseModel):
             "total_edges": len(self.edges),
             "nodes_with_io_map": len(nodes_with_io_map),
             "total_io_map_entries": io_map_count,
+            "node_ids": [node.id for node in self.nodes],
             "node_types": [node.type for node in self.nodes],
             "version": self.version,
             "workflow_type": self.workflow_type,

--- a/akd/planner/format_builder.py
+++ b/akd/planner/format_builder.py
@@ -8,14 +8,14 @@ that can be executed by the AKD framework.
 from __future__ import annotations
 
 import json
-from typing import Any, Union
+from typing import Any
 
 from loguru import logger
 from pydantic import BaseModel, Field
 
 # Type for workflow field values (supports common JSON-serializable types)
 # Note: list and dict items are not recursively typed to avoid complexity
-FieldValue = Union[str, int, float, bool, list[Any], dict[str, Any], None]
+FieldValue = str | int | float | bool | list[Any] | dict[str, Any] | None
 
 # Workflow format metadata
 WORKFLOW_TYPE = "AKDResearchWorkflow"
@@ -61,13 +61,18 @@ class WorkflowNode(BaseModel):
     """Individual node in a workflow definition."""
 
     id: str = Field(..., description="Unique node identifier (e.g., code_search_0, gap_analysis_0)")
-    type: str = Field(..., description="Node type corresponding to agent type for registry lookup")
+    type_: str = Field(..., alias="type", description="Node type corresponding to agent type for registry lookup")
     input: WorkflowNodeIO = Field(default_factory=WorkflowNodeIO)
     output: WorkflowNodeIO | None = Field(default=None)
     io_map: dict[str, str] | None = Field(
         default=None,
         description="JSONPath mappings for cross-node data access (target_field: jsonpath_expr using node id)",
     )
+
+    model_config = {
+        "populate_by_name": True,
+        "serialize_by_alias": True,
+    }
 
 
 class WorkflowEdge(BaseModel):
@@ -78,6 +83,7 @@ class WorkflowEdge(BaseModel):
 
     model_config = {
         "populate_by_name": True,
+        "serialize_by_alias": True,
     }
 
 
@@ -287,7 +293,7 @@ class WorkflowFormat(BaseModel):
             "nodes_with_io_map": len(nodes_with_io_map),
             "total_io_map_entries": io_map_count,
             "node_ids": [node.id for node in self.nodes],
-            "node_types": [node.type for node in self.nodes],
+            "node_types": [node.type_ for node in self.nodes],
             "version": self.version,
             "workflow_type": self.workflow_type,
         }

--- a/akd/planner/llm_planner.py
+++ b/akd/planner/llm_planner.py
@@ -75,7 +75,7 @@ class PlannerResponse(OutputSchema):
 
     message: str = Field(..., description="Response message to the user")
     phase: ConversationPhase = Field(..., description="Current conversation phase")
-    question: Optional[PlannerQuestion] = Field(default=None, description="Follow-up question if needed")
+    question: PlannerQuestion | None = Field(default=None, description="Follow-up question if needed")
     workflow_plan: Optional[WorkflowPlan] = Field(default=None, description="Generated workflow plan")
     ready_to_generate: bool = Field(default=False, description="Whether ready to generate final workflow")
 
@@ -157,8 +157,7 @@ class LLMWorkflowPlanner(LiteLLMInstructorBaseAgent[PlannerInput, PlannerRespons
 
     def __init__(
         self,
-        config: Optional[BaseAgentConfig] = None,
-        planner_config: Optional[PlannerConfig] = None,
+        config: PlannerConfig | None = None,
         registry: Optional[AgentRegistry] = None,
         mapping_registry: Optional[FieldMappingRegistry] = None,
         mapping_generator: Optional[FieldMappingGenerator] = None,
@@ -168,8 +167,7 @@ class LLMWorkflowPlanner(LiteLLMInstructorBaseAgent[PlannerInput, PlannerRespons
         Initialize the planner.
 
         Args:
-            config: Agent-level configuration (model, API keys, etc.)
-            planner_config: Planner-specific configuration (thresholds, temperatures, etc.)
+            config: Planner configuration (model, temperature, thresholds, etc.)
             registry: Agent registry
             mapping_registry: Field mapping registry
             mapping_generator: Field mapping generator
@@ -180,17 +178,14 @@ class LLMWorkflowPlanner(LiteLLMInstructorBaseAgent[PlannerInput, PlannerRespons
         self.mapping_generator = mapping_generator or FieldMappingGenerator()
         self.builder = WorkflowBuilder(self.registry, self.mapping_registry, debug=debug)
         self.conversation_state: dict[str, Any] = {}
-        self.planner_config = planner_config or PlannerConfig()
+        self.planner_config = config or PlannerConfig()
         self.debug = debug
 
-        # Set up system prompt for workflow planning (uses self.registry)
-        agent_config = config or BaseAgentConfig()
-        agent_config.system_prompt = self._get_planner_system_prompt()
-        # Use planner config model_name and temperature if not explicitly set
-        if not agent_config.model_name or agent_config.model_name == "gpt-4o-mini":
-            agent_config.model_name = self.planner_config.model_name
-        if not agent_config.temperature:
-            agent_config.temperature = self.planner_config.temperature
+        agent_config = BaseAgentConfig(
+            model_name=self.planner_config.model_name,
+            temperature=self.planner_config.temperature,
+            system_prompt=self._get_planner_system_prompt(),
+        )
 
         super().__init__(config=agent_config, debug=debug)
 
@@ -727,14 +722,14 @@ These fields should be OMITTED from your output entirely."""
 
 # Convenience functions
 async def create_planner(
-    config: Optional[BaseAgentConfig] = None,
+    config: Optional[PlannerConfig] = None,
     registry: Optional[AgentRegistry] = None,
 ) -> LLMWorkflowPlanner:
     """Create a new workflow planner instance."""
     return LLMWorkflowPlanner(config=config, registry=registry)
 
 
-async def quick_plan(research_goal: str, config: Optional[BaseAgentConfig] = None) -> InteractivePlannerSession:
+async def quick_plan(research_goal: str, config: Optional[PlannerConfig] = None) -> InteractivePlannerSession:
     """Create a quick planning session for a research goal."""
     planner = await create_planner(config=config)
     return await planner.init_planner_session(research_goal)

--- a/akd/planner/llm_planner.py
+++ b/akd/planner/llm_planner.py
@@ -54,9 +54,9 @@ class PlannerQuestion(OutputSchema):
 
     question: str = Field(..., description="The question to ask the user")
     question_type: PlannerQuestionType = Field(..., description="Type of question")
-    options: Optional[list[str]] = Field(default=None, description="Options for multiple choice questions")
+    options: list[str] | None = Field(default=None, description="Options for multiple choice questions")
     context: str = Field(..., description="Context explaining why this question is important")
-    suggested_answer: Optional[str] = Field(default=None, description="Suggested answer if applicable")
+    suggested_answer: str | None = Field(default=None, description="Suggested answer if applicable")
 
     @field_validator("question_type", mode="before")
     @classmethod
@@ -76,7 +76,7 @@ class PlannerResponse(OutputSchema):
     message: str = Field(..., description="Response message to the user")
     phase: ConversationPhase = Field(..., description="Current conversation phase")
     question: PlannerQuestion | None = Field(default=None, description="Follow-up question if needed")
-    workflow_plan: Optional[WorkflowPlan] = Field(default=None, description="Generated workflow plan")
+    workflow_plan: WorkflowPlan | None = Field(default=None, description="Generated workflow plan")
     ready_to_generate: bool = Field(default=False, description="Whether ready to generate final workflow")
 
     @field_validator("phase", mode="before")
@@ -158,9 +158,9 @@ class LLMWorkflowPlanner(LiteLLMInstructorBaseAgent[PlannerInput, PlannerRespons
     def __init__(
         self,
         config: PlannerConfig | None = None,
-        registry: Optional[AgentRegistry] = None,
-        mapping_registry: Optional[FieldMappingRegistry] = None,
-        mapping_generator: Optional[FieldMappingGenerator] = None,
+        registry: AgentRegistry | None = None,
+        mapping_registry: FieldMappingRegistry | None = None,
+        mapping_generator: FieldMappingGenerator | None = None,
         debug: bool = False,
     ):
         """
@@ -306,8 +306,8 @@ class InteractivePlannerSession:
         self.initial_request = initial_request
         self.conversation_history = conversation_history or []
         self.current_phase = ConversationPhase.INITIAL_REQUIREMENTS
-        self.workflow_plan: Optional[WorkflowPlan] = None
-        self.final_workflow: Optional[WorkflowFormat] = None
+        self.workflow_plan: WorkflowPlan | None = None
+        self.final_workflow: WorkflowFormat | None = None
 
     async def start(self) -> PlannerResponse:
         """Start the planning conversation."""
@@ -399,7 +399,7 @@ class InteractivePlannerSession:
     async def _handle_unmapped_fields(
         self,
         unmapped: list[dict[str, Any]],
-        confidence_threshold: Optional[float] = None,
+        confidence_threshold: float | None = None,
     ) -> None:
         """
         Generate LLM mappings for unmapped fields and handle user approval.
@@ -513,7 +513,7 @@ class InteractivePlannerSession:
         agent: Any,
         agent_id: str,
         agent_suggestion: AgentSuggestion,
-        workflow_plan: Optional[WorkflowPlan] = None,
+        workflow_plan: WorkflowPlan | None = None,
     ) -> dict[str, Any]:
         """
         Use Instructor LLM to extract structured input values from full conversation context.
@@ -722,14 +722,14 @@ These fields should be OMITTED from your output entirely."""
 
 # Convenience functions
 async def create_planner(
-    config: Optional[PlannerConfig] = None,
-    registry: Optional[AgentRegistry] = None,
+    config: PlannerConfig | None = None,
+    registry: AgentRegistry | None = None,
 ) -> LLMWorkflowPlanner:
     """Create a new workflow planner instance."""
     return LLMWorkflowPlanner(config=config, registry=registry)
 
 
-async def quick_plan(research_goal: str, config: Optional[PlannerConfig] = None) -> InteractivePlannerSession:
+async def quick_plan(research_goal: str, config: PlannerConfig | None = None) -> InteractivePlannerSession:
     """Create a quick planning session for a research goal."""
     planner = await create_planner(config=config)
     return await planner.init_planner_session(research_goal)

--- a/akd/planner/llm_planner.py
+++ b/akd/planner/llm_planner.py
@@ -91,11 +91,12 @@ class PlannerResponse(OutputSchema):
     @classmethod
     def auto_set_ready_when_plan_exists(cls, v: bool, info) -> bool:
         """
-        Automatically set ready_to_generate=True if workflow_plan exists AND no question is asked.
+        Bidirectional auto-correction for ready_to_generate flag.
 
-        This prevents infinite loops when the LLM says "workflow is ready" but forgets
-        to set the flag, while still allowing the LLM to present a plan and ask for
-        confirmation or clarification.
+        SAFETY CORRECTION (ready=True but plan missing/empty):
+        - If ready_to_generate=True but workflow_plan=None, then correct to False
+        - If ready_to_generate=True but workflow_plan has no agents, then correct to False
+        This prevents "Workflow complete!" followed by "No workflow plan available" error.
 
         Auto-correction only happens when:
         - workflow_plan exists (plan is complete)
@@ -110,13 +111,22 @@ class PlannerResponse(OutputSchema):
         question = info.data.get("question")
         message = info.data.get("message", "")
 
-        # Only auto-correct if:
-        # 1. Plan exists
-        # 2. No question being asked
-        # 3. Message indicates finality (ready/generate keywords)
-        # 4. But flag is False
+        # SAFETY: Cannot be ready without a complete plan
+        if v:  # ready_to_generate is True
+            if workflow_plan is None:
+                logger.warning(
+                    "SAFETY: ready_to_generate=True but workflow_plan=None. Auto-correcting to False.",
+                )
+                return False
+
+            if not workflow_plan.suggested_agents:
+                logger.warning(
+                    "SAFETY: ready_to_generate=True but workflow_plan has no agents. Auto-correcting to False.",
+                )
+                return False
+
+        # CONVENIENCE: Auto-set True if plan exists, no question, and message indicates ready
         if workflow_plan is not None and not v and question is None:
-            # Check if message indicates the workflow is actually ready
             ready_keywords = ["ready", "will be generated", "workflow is complete", "finalized"]
             message_lower = message.lower()
 
@@ -176,7 +186,9 @@ class LLMWorkflowPlanner(LiteLLMInstructorBaseAgent[PlannerInput, PlannerRespons
         # Set up system prompt for workflow planning (uses self.registry)
         agent_config = config or BaseAgentConfig()
         agent_config.system_prompt = self._get_planner_system_prompt()
-        # Use planner config temperature
+        # Use planner config model_name and temperature if not explicitly set
+        if not agent_config.model_name or agent_config.model_name == "gpt-4o-mini":
+            agent_config.model_name = self.planner_config.model_name
         if not agent_config.temperature:
             agent_config.temperature = self.planner_config.temperature
 

--- a/akd/planner/registry.py
+++ b/akd/planner/registry.py
@@ -4,11 +4,13 @@ Agent Registry for the AKD Planner module.
 This module provides agent registration and discovery capabilities for the AKD framework.
 """
 
+from __future__ import annotations
+
 import importlib
 import json
 import os
 from datetime import datetime, timezone
-from typing import Any, Optional, Type
+from typing import Any
 
 from loguru import logger
 from pydantic import BaseModel, Field
@@ -28,7 +30,7 @@ class FieldDefinition(BaseModel):
     description: str = Field(..., description="Field description")
     required: bool = Field(default=True, description="Whether field is required")
     default: str | int | float | bool | list[Any] | None = Field(default=None, description="Default value if any")
-    items_type: Optional[str] = Field(default=None, description="Array item type")
+    items_type: str | None = Field(default=None, description="Array item type")
 
 
 class AgentSchemaDefinition(BaseModel):
@@ -92,13 +94,13 @@ class AgentRegistry:
         "code_search": ("akd.agents.search.code_search", "CodeSearchAgent"),
     }
 
-    def __new__(cls, config: Optional[AgentRegistryConfig] = None):
+    def __new__(cls, config: AgentRegistryConfig | None = None):
         """Create or return the singleton instance."""
         if cls._instance is None:
             cls._instance = super().__new__(cls)
         return cls._instance
 
-    def __init__(self, config: Optional[AgentRegistryConfig] = None):
+    def __init__(self, config: AgentRegistryConfig | None = None):
         """Initialize the agent registry (only once due to singleton pattern)."""
         if not self._initialized:
             self.config = config or AgentRegistryConfig()
@@ -251,7 +253,7 @@ class AgentRegistry:
         self.registry_data = AgentRegistryData(agents=discovered)
         logger.info(f"Auto-discovered {len(discovered)} agents")
 
-    def _extract_schema(self, schema_class: Optional[Type[IOSchema]]) -> AgentSchemaDefinition:
+    def _extract_schema(self, schema_class: type[IOSchema] | None) -> AgentSchemaDefinition:
         """Extract schema from an agent IOSchema class (InputSchema/OutputSchema)."""
         if not schema_class:
             return AgentSchemaDefinition()
@@ -309,7 +311,7 @@ class AgentRegistry:
         except Exception as e:
             logger.error(f"Failed to save registry: {e}")
 
-    def get_agent(self, agent_id: str) -> Optional[AgentEntry]:
+    def get_agent(self, agent_id: str) -> AgentEntry | None:
         """Get a specific agent by ID."""
         return self.registry_data.agents.get(agent_id)
 
@@ -452,6 +454,6 @@ class AgentRegistry:
         cls._initialized = False
 
 
-def get_agent_registry(config: Optional[AgentRegistryConfig] = None) -> AgentRegistry:
+def get_agent_registry(config: AgentRegistryConfig | None = None) -> AgentRegistry:
     """Get the singleton agent registry instance."""
     return AgentRegistry(config)

--- a/akd/planner/structures.py
+++ b/akd/planner/structures.py
@@ -93,7 +93,7 @@ class FieldMappingResult(OutputSchema):
 class PlannerConfig(BaseModel):
     """Configuration for workflow planners."""
 
-    model_name: str = Field(default="gpt-4", description="LLM model to use for planning")
+    model_name: str = Field(default="gpt-5.2", description="LLM model to use for planning")
     temperature: float = Field(default=0.3, description="Temperature for LLM generation (deterministic planning)")
     max_conversation_turns: int = Field(default=25, description="Maximum conversation turns before forcing completion")
     field_mapping_confidence_threshold: float = Field(

--- a/akd/planner/structures.py
+++ b/akd/planner/structures.py
@@ -11,6 +11,8 @@ from pydantic import BaseModel, Field, field_validator
 
 from akd._base import OutputSchema
 
+from akd.configs.project import CONFIG
+
 
 class AgentSuggestion(OutputSchema):
     """Agent suggestion for workflow planning."""
@@ -93,7 +95,10 @@ class FieldMappingResult(OutputSchema):
 class PlannerConfig(BaseModel):
     """Configuration for workflow planners."""
 
-    model_name: str = Field(default="gpt-5.2", description="LLM model to use for planning")
+    model_name: str = Field(
+        default_factory=lambda: CONFIG.model_config_settings.planner_model_name,
+        description="LLM model to use for planning",
+    )
     temperature: float = Field(default=0.3, description="Temperature for LLM generation (deterministic planning)")
     max_conversation_turns: int = Field(default=25, description="Maximum conversation turns before forcing completion")
     field_mapping_confidence_threshold: float = Field(

--- a/akd/planner/structures.py
+++ b/akd/planner/structures.py
@@ -4,7 +4,7 @@ Data structures for AKD planner.
 This module contains workflow planning data models.
 """
 
-from typing import Optional
+from __future__ import annotations
 
 from loguru import logger
 from pydantic import BaseModel, Field, field_validator
@@ -23,7 +23,7 @@ class AgentSuggestion(OutputSchema):
     confidence: float = Field(..., ge=0.0, le=1.0, description="Confidence in this suggestion (0.0-1.0)")
     required_inputs: list[str] = Field(default_factory=list, description="Required input fields")
     expected_outputs: list[str] = Field(default_factory=list, description="Expected output fields")
-    depends_on: Optional[list[str]] = Field(default=None, description="Agent IDs this agent depends on for input data")
+    depends_on: list[str] | None = Field(default=None, description="Agent IDs this agent depends on for input data")
 
 
 class WorkflowPlan(OutputSchema):
@@ -89,7 +89,7 @@ class FieldMappingResult(OutputSchema):
 
     mappings: list[FieldMappingEntry] = Field(..., description="List of field mappings with confidence scores")
     overall_confidence: float = Field(..., ge=0.0, le=1.0, description="Overall confidence in the entire mapping set")
-    notes: Optional[str] = Field(None, description="Additional notes or warnings about the mapping")
+    notes: str | None = Field(None, description="Additional notes or warnings about the mapping")
 
 
 class PlannerConfig(BaseModel):

--- a/akd/planner/workflow_builder.py
+++ b/akd/planner/workflow_builder.py
@@ -60,27 +60,26 @@ class WorkflowBuilder:
         self.mapping_registry = mapping_registry or FieldMappingRegistry()
         self.debug = debug
 
-    def _build_and_validate_jsonpath(self, agent_id: str, field_name: str) -> str:
+    def _build_and_validate_jsonpath(self, node_id: str, field_name: str) -> str:
         """
         Build and validate JSONPath expression for field mapping.
 
         Args:
-            agent_id: Agent identifier to reference in JSONPath
+            node_id: Unique node identifier to reference in JSONPath (e.g., code_search_0)
             field_name: Field name to reference in JSONPath
 
         Returns:
-            Validated JSONPath expression (e.g., "$.agent_id.outputs.field_name")
+            Validated JSONPath expression (e.g., "$.node_id.outputs.field_name")
 
         Raises:
-            ValueError: If agent_id or field_name contains invalid characters
+            ValueError: If node_id or field_name contains invalid characters
                        or if the resulting JSONPath expression is malformed
         """
         # Sanitize identifiers - only allow alphanumeric and underscore
         # This prevents JSONPath injection and ensures valid syntax
-        if not re.match(r"^[a-zA-Z0-9_]+$", agent_id):
+        if not re.match(r"^[a-zA-Z0-9_]+$", node_id):
             raise ValueError(
-                f"Invalid agent_id for JSONPath: '{agent_id}'. "
-                f"Only alphanumeric characters and underscores are allowed.",
+                f"Invalid node_id for JSONPath: '{node_id}'. Only alphanumeric characters and underscores are allowed.",
             )
 
         if not re.match(r"^[a-zA-Z0-9_]+$", field_name):
@@ -90,7 +89,7 @@ class WorkflowBuilder:
             )
 
         # Build JSONPath expression
-        path_str = f"$.{agent_id}.outputs.{field_name}"
+        path_str = f"$.{node_id}.outputs.{field_name}"
 
         # Validate JSONPath syntax using jsonpath_ng
         try:
@@ -107,6 +106,8 @@ class WorkflowBuilder:
         filled_inputs: dict[str, AgentInputs],
         agent_id: str,
         prev_agent_id: str,
+        node_id: str,
+        prev_node_id: str,
     ) -> dict[str, str]:
         """
         Build io_map for runtime data flow from previous agent to current agent.
@@ -120,12 +121,14 @@ class WorkflowBuilder:
             agent: Current agent instance
             prev_agent: Previous agent instance
             filled_inputs: Pre-filled inputs for all agents
-            agent_id: Current agent ID
-            prev_agent_id: Previous agent ID
+            agent_id: Current agent type ID (for registry lookup)
+            prev_agent_id: Previous agent type ID (for registry lookup)
+            node_id: Current node unique ID (for JSONPath)
+            prev_node_id: Previous node unique ID (for JSONPath)
 
         Returns:
             Dictionary mapping current agent field names to JSONPath expressions
-            (e.g., {"field_name": "$.prev_agent_id.outputs.source_field"})
+            (e.g., {"field_name": "$.prev_node_id.outputs.source_field"})
         """
         io_map = {}
         inputs = filled_inputs.get(agent_id, {})
@@ -136,7 +139,7 @@ class WorkflowBuilder:
         # Map each required input using three-tier strategy
         for field in agent.input_schema.fields:
             if field.required and field.name not in inputs:
-                # Get field mapping from registry
+                # Get field mapping from registry (uses agent types, not node IDs)
                 mapping = self.mapping_registry.get_mapping(
                     prev_agent_id,
                     agent_id,
@@ -149,8 +152,8 @@ class WorkflowBuilder:
                     # VALIDATION: Check source field exists in prev_agent outputs
                     if source_field not in source_field_names:
                         logger.error(
-                            f"Invalid mapping: {agent_id}.{field.name} <- "
-                            f"{prev_agent_id}.{source_field} "
+                            f"Invalid mapping: {node_id}.{field.name} <- "
+                            f"{prev_node_id}.{source_field} "
                             f"(source field '{source_field}' does not exist in {prev_agent_id} output schema)",
                         )
                         if self.debug:
@@ -160,27 +163,27 @@ class WorkflowBuilder:
                                 f"Available fields: {source_field_names}",
                             )
                         # Skip invalid mapping in production mode
-                        logger.warning(f"Skipping invalid mapping for {agent_id}.{field.name}")
+                        logger.warning(f"Skipping invalid mapping for {node_id}.{field.name}")
                         continue
 
-                    # Build and validate JSONPath expression
-                    io_map[field.name] = self._build_and_validate_jsonpath(prev_agent_id, source_field)
+                    # Build and validate JSONPath expression using node ID
+                    io_map[field.name] = self._build_and_validate_jsonpath(prev_node_id, source_field)
                     logger.debug(
-                        f"Mapped {agent_id}.{field.name} <- {prev_agent_id}.{source_field} (from registry, validated)",
+                        f"Mapped {node_id}.{field.name} <- {prev_node_id}.{source_field} (from registry, validated)",
                     )
                 else:
                     # Priority 3: Exact name match fallback
                     if field.name in source_field_names:
-                        # Build and validate JSONPath expression
-                        io_map[field.name] = self._build_and_validate_jsonpath(prev_agent_id, field.name)
+                        # Build and validate JSONPath expression using node ID
+                        io_map[field.name] = self._build_and_validate_jsonpath(prev_node_id, field.name)
                         logger.debug(
-                            f"Mapped {agent_id}.{field.name} <- {prev_agent_id}.{field.name} (exact match, validated)",
+                            f"Mapped {node_id}.{field.name} <- {prev_node_id}.{field.name} (exact match, validated)",
                         )
                     else:
                         # No mapping available - will need LLM generation
                         logger.warning(
-                            f"No mapping found for {agent_id}.{field.name} from "
-                            f"{prev_agent_id}. Field will be missing unless LLM mapping "
+                            f"No mapping found for {node_id}.{field.name} from "
+                            f"{prev_node_id}. Field will be missing unless LLM mapping "
                             f"is generated.",
                         )
 
@@ -210,6 +213,11 @@ class WorkflowBuilder:
                 edges=[],
             )
 
+        # Track agent type counts for generating unique node IDs
+        agent_counts: dict[str, int] = {}
+        # Map from index to node_id for edge creation
+        node_ids: list[str] = []
+
         # Build nodes with io_map for sequential data flow
         for i, agent_suggestion in enumerate(agents):
             agent_id = agent_suggestion.agent_id
@@ -219,6 +227,12 @@ class WorkflowBuilder:
                 logger.warning(f"Agent {agent_id} not in registry, skipping")
                 continue
 
+            # Generate unique node ID: {agent_id}_{count} (starting from 1)
+            count = agent_counts.get(agent_id, 1)
+            node_id = f"{agent_id}_{count}"
+            agent_counts[agent_id] = count + 1
+            node_ids.append(node_id)
+
             # Get filled inputs for this agent
             inputs = filled_inputs.get(agent_id, {})
 
@@ -227,6 +241,7 @@ class WorkflowBuilder:
             if i > 0:
                 prev_agent_id = agents[i - 1].agent_id
                 prev_agent = self.registry.get_agent(prev_agent_id)
+                prev_node_id = node_ids[i - 1]
 
                 if not prev_agent:
                     logger.warning(f"Previous agent {prev_agent_id} not in registry")
@@ -237,10 +252,13 @@ class WorkflowBuilder:
                         filled_inputs,
                         agent_id,
                         prev_agent_id,
+                        node_id,
+                        prev_node_id,
                     )
 
-            # Create node
+            # Create node with unique id and type
             node = WorkflowNode(
+                id=node_id,
                 type=agent_id,
                 input=WorkflowNodeIO(fields=[{k: v} for k, v in inputs.items()]),
                 output=WorkflowNodeIO(fields=[]),  # Runtime fills this
@@ -248,12 +266,12 @@ class WorkflowBuilder:
             )
             nodes.append(node)
 
-        # Build sequential edges
+        # Build sequential edges using node IDs
         if nodes:
-            edges.append(WorkflowEdge(from_node="START", to_node=nodes[0].type))
+            edges.append(WorkflowEdge(from_node="START", to_node=nodes[0].id))
             for i in range(len(nodes) - 1):
-                edges.append(WorkflowEdge(from_node=nodes[i].type, to_node=nodes[i + 1].type))
-            edges.append(WorkflowEdge(from_node=nodes[-1].type, to_node="END"))
+                edges.append(WorkflowEdge(from_node=nodes[i].id, to_node=nodes[i + 1].id))
+            edges.append(WorkflowEdge(from_node=nodes[-1].id, to_node="END"))
 
         return WorkflowFormat(
             workflow_type=WORKFLOW_TYPE,

--- a/akd/planner/workflow_builder.py
+++ b/akd/planner/workflow_builder.py
@@ -259,7 +259,7 @@ class WorkflowBuilder:
             # Create node with unique id and type
             node = WorkflowNode(
                 id=node_id,
-                type=agent_id,
+                type_=agent_id,
                 input=WorkflowNodeIO(fields=[{k: v} for k, v in inputs.items()]),
                 output=WorkflowNodeIO(fields=[]),  # Runtime fills this
                 io_map=io_map if io_map else None,
@@ -307,7 +307,7 @@ class WorkflowBuilder:
             {
                 "source_agent_id": str,
                 "target_agent_id": str,
-                "unmapped_fields": List[str]  # Target field names
+                "unmapped_fields": list[str]  # Target field names
             }
         ]
         """

--- a/scripts/demo_planner.py
+++ b/scripts/demo_planner.py
@@ -166,7 +166,7 @@ async def interactive_planning_session():
 
                     for node in nodes_with_io_map:
                         for field, jsonpath in node.io_map.items():
-                            table.add_row(node.type, field, jsonpath)
+                            table.add_row(node.type_, field, jsonpath)
 
                     console.print(table)
 
@@ -308,7 +308,7 @@ async def automated_planning_session(
 
                     for node in nodes_with_io_map:
                         for field, jsonpath in node.io_map.items():
-                            table.add_row(node.type, field, jsonpath)
+                            table.add_row(node.type_, field, jsonpath)
 
                     console.print(table)
 
@@ -367,7 +367,7 @@ async def demo_workflow_display():
         # Show nodes with io_map
         console.print("\n[bold]Runtime Data Flow (io_map):[/bold]")
         for node in workflow.nodes:
-            console.print(f"\nNode: [cyan]{node.type}[/cyan]")
+            console.print(f"\nNode: [cyan]{node.type_}[/cyan]")
             if node.io_map:
                 for field, jsonpath in node.io_map.items():
                     console.print(f"  {field} ← [yellow]{jsonpath}[/yellow]")

--- a/tests/planner/test_field_mapping.py
+++ b/tests/planner/test_field_mapping.py
@@ -118,7 +118,7 @@ class TestFieldMappingGenerator:
         assert query_mapping is not None
 
         # Validate LLM chose a reasonable source field
-        sensible_sources = ["report", "category", "results"]
+        sensible_sources = ["report", "category", "results", "answer"]
         assert query_mapping.source_field in sensible_sources
 
     @pytest.mark.asyncio
@@ -211,7 +211,7 @@ class TestWorkflowBuilderMapping:
         assert gap_node is not None
         assert gap_node.io_map is not None
         assert "search_results" in gap_node.io_map
-        assert gap_node.io_map["search_results"] == "$.deep_search.outputs.results"
+        assert gap_node.io_map["search_results"] == "$.deep_search_1.outputs.results"
 
     def test_unmapped_field_detection(self, workflow_builder):
         """Test detection of unmapped fields."""
@@ -282,6 +282,7 @@ class TestWorkflowBuilderMapping:
         assert gap_node is not None
         assert gap_node.io_map is not None
         assert "search_results" in gap_node.io_map
+        assert gap_node.io_map["search_results"] == "$.deep_search_1.outputs.results"
         # Check that gap is NOT in io_map (it's filled directly)
         assert "gap" not in gap_node.io_map
 
@@ -368,7 +369,7 @@ class TestSpecificAgentWorkflows:
 
         assert code_node is not None
         assert code_node.io_map is not None
-        assert code_node.io_map.get("query") == "$.deep_search.outputs.report"
+        assert code_node.io_map.get("query") == "$.deep_search_1.outputs.report"
 
     def test_code_search_to_gap_analysis(self, workflow_builder):
         """Test code_search -> gap_analysis mapping."""
@@ -409,7 +410,7 @@ class TestSpecificAgentWorkflows:
 
         assert gap_node is not None
         assert gap_node.io_map is not None
-        assert gap_node.io_map.get("search_results") == "$.code_search.outputs.results"
+        assert gap_node.io_map.get("search_results") == "$.code_search_1.outputs.results"
 
 
 if __name__ == "__main__":

--- a/tests/planner/test_field_mapping.py
+++ b/tests/planner/test_field_mapping.py
@@ -206,7 +206,7 @@ class TestWorkflowBuilderMapping:
         assert len(workflow.nodes) == 2
 
         # Check io_map in gap_analysis node
-        gap_node = next((n for n in workflow.nodes if n.type == "gap_analysis"), None)
+        gap_node = next((n for n in workflow.nodes if n.type_ == "gap_analysis"), None)
 
         assert gap_node is not None
         assert gap_node.io_map is not None
@@ -277,7 +277,7 @@ class TestWorkflowBuilderMapping:
         }
 
         workflow = workflow_builder.build(plan, filled_inputs)
-        gap_node = next((n for n in workflow.nodes if n.type == "gap_analysis"), None)
+        gap_node = next((n for n in workflow.nodes if n.type_ == "gap_analysis"), None)
 
         assert gap_node is not None
         assert gap_node.io_map is not None
@@ -365,7 +365,7 @@ class TestSpecificAgentWorkflows:
         assert len(workflow.nodes) == 2
 
         # Check io_map in code_search node
-        code_node = next((n for n in workflow.nodes if n.type == "code_search"), None)
+        code_node = next((n for n in workflow.nodes if n.type_ == "code_search"), None)
 
         assert code_node is not None
         assert code_node.io_map is not None
@@ -406,7 +406,7 @@ class TestSpecificAgentWorkflows:
         assert len(workflow.nodes) == 2
 
         # Check io_map in gap_analysis node
-        gap_node = next((n for n in workflow.nodes if n.type == "gap_analysis"), None)
+        gap_node = next((n for n in workflow.nodes if n.type_ == "gap_analysis"), None)
 
         assert gap_node is not None
         assert gap_node.io_map is not None

--- a/tests/planner/test_llm_planner.py
+++ b/tests/planner/test_llm_planner.py
@@ -123,7 +123,15 @@ class TestInteractivePlannerSession:
 
         workflow_plan = WorkflowPlan(
             workflow_description="Test workflow",
-            research_goal="Test goal"
+            research_goal="Test goal",
+            suggested_agents=[
+                AgentSuggestion(
+                    agent_id="deep_search",
+                    agent_name="Deep Search",
+                    reason="Testing",
+                    confidence=1.0,
+                )
+            ],
         )
 
         response = PlannerResponse(
@@ -307,6 +315,114 @@ class TestPlannerErrorHandling:
 
         with pytest.raises(ValueError, match="not found in registry"):
             await session.generate_workflow()
+
+
+class TestPlannerResponseValidator:
+    """Test PlannerResponse ready_to_generate validator."""
+
+    def test_safety_correction_ready_but_no_plan(self):
+        """Test that ready_to_generate is corrected to False when plan is None."""
+        response = PlannerResponse(
+            message="Workflow is ready",
+            phase=ConversationPhase.FINALIZATION,
+            workflow_plan=None,
+            ready_to_generate=True,
+        )
+        # Safety validator should correct to False
+        assert response.ready_to_generate is False
+
+    def test_safety_correction_ready_but_no_agents(self):
+        """Test that ready_to_generate is corrected to False when plan has no agents."""
+        plan = WorkflowPlan(
+            workflow_description="Empty plan",
+            research_goal="Test",
+            suggested_agents=[],
+        )
+        response = PlannerResponse(
+            message="Workflow is ready",
+            phase=ConversationPhase.FINALIZATION,
+            workflow_plan=plan,
+            ready_to_generate=True,
+        )
+        # Safety validator should correct to False
+        assert response.ready_to_generate is False
+
+    def test_convenience_correction_plan_exists_message_says_ready(self):
+        """Test that ready_to_generate is corrected to True when plan exists and message says ready."""
+        plan = WorkflowPlan(
+            workflow_description="Test",
+            research_goal="Test",
+            suggested_agents=[
+                AgentSuggestion(
+                    agent_id="deep_search",
+                    agent_name="Deep Search",
+                    reason="Testing",
+                    confidence=1.0,
+                )
+            ],
+        )
+        response = PlannerResponse(
+            message="Workflow is ready and will be generated",
+            phase=ConversationPhase.FINALIZATION,
+            workflow_plan=plan,
+            question=None,
+            ready_to_generate=False,
+        )
+        # Convenience validator should correct to True
+        assert response.ready_to_generate is True
+
+    def test_no_correction_when_question_asked(self):
+        """Test that ready_to_generate stays False when a question is asked."""
+        from akd.planner.llm_planner import PlannerQuestion, PlannerQuestionType
+
+        plan = WorkflowPlan(
+            workflow_description="Test",
+            research_goal="Test",
+            suggested_agents=[
+                AgentSuggestion(
+                    agent_id="deep_search",
+                    agent_name="Deep Search",
+                    reason="Testing",
+                    confidence=1.0,
+                )
+            ],
+        )
+        response = PlannerResponse(
+            message="Workflow is ready but does this look good?",
+            phase=ConversationPhase.FINALIZATION,
+            workflow_plan=plan,
+            question=PlannerQuestion(
+                question="Does this look good?",
+                question_type=PlannerQuestionType.CONFIRMATION,
+                context="Confirming plan",
+            ),
+            ready_to_generate=False,
+        )
+        # Should stay False because a question is being asked
+        assert response.ready_to_generate is False
+
+    def test_valid_ready_with_plan_and_agents(self):
+        """Test that ready_to_generate stays True when plan has agents."""
+        plan = WorkflowPlan(
+            workflow_description="Test",
+            research_goal="Test",
+            suggested_agents=[
+                AgentSuggestion(
+                    agent_id="deep_search",
+                    agent_name="Deep Search",
+                    reason="Testing",
+                    confidence=1.0,
+                )
+            ],
+        )
+        response = PlannerResponse(
+            message="All good",
+            phase=ConversationPhase.FINALIZATION,
+            workflow_plan=plan,
+            ready_to_generate=True,
+        )
+        # Should stay True - valid state
+        assert response.ready_to_generate is True
 
 
 class TestConversationPhases:

--- a/tests/planner/test_workflow_builder.py
+++ b/tests/planner/test_workflow_builder.py
@@ -129,7 +129,7 @@ class TestWorkflowGeneration:
 
         workflow = workflow_builder.build(simple_workflow_plan, filled_inputs)
 
-        node_types = [node.type for node in workflow.nodes]
+        node_types = [node.type_ for node in workflow.nodes]
         node_ids = [node.id for node in workflow.nodes]
 
         assert "deep_search" in node_types
@@ -147,7 +147,7 @@ class TestWorkflowGeneration:
         workflow = workflow_builder.build(simple_workflow_plan, filled_inputs)
 
         # gap_analysis should have io_map
-        gap_node = next((n for n in workflow.nodes if n.type == "gap_analysis"), None)
+        gap_node = next((n for n in workflow.nodes if n.type_ == "gap_analysis"), None)
 
         assert gap_node is not None
         assert gap_node.id == "gap_analysis_1"
@@ -202,8 +202,8 @@ class TestWorkflowGeneration:
         assert len(workflow.nodes) == 2
         assert workflow.nodes[0].id == "deep_search_1"
         assert workflow.nodes[1].id == "deep_search_2"
-        assert workflow.nodes[0].type == "deep_search"
-        assert workflow.nodes[1].type == "deep_search"
+        assert workflow.nodes[0].type_ == "deep_search"
+        assert workflow.nodes[1].type_ == "deep_search"
 
         # Edges should use unique IDs
         assert workflow.edges[0].to_node == "deep_search_1"
@@ -302,7 +302,7 @@ class TestWorkflowInputHandling:
         assert len(workflow.nodes) == 2
 
         # deep_search node should have input
-        deep_node = next((n for n in workflow.nodes if n.type == "deep_search"), None)
+        deep_node = next((n for n in workflow.nodes if n.type_ == "deep_search"), None)
         assert deep_node is not None
         assert deep_node.id == "deep_search_1"
         assert len(deep_node.input.fields) > 0
@@ -318,7 +318,7 @@ class TestWorkflowInputHandling:
 
         workflow = workflow_builder.build(simple_workflow_plan, filled_inputs)
 
-        deep_node = next((n for n in workflow.nodes if n.type == "deep_search"), None)
+        deep_node = next((n for n in workflow.nodes if n.type_ == "deep_search"), None)
         assert deep_node is not None
 
         # Check that input fields contain the values
@@ -368,7 +368,7 @@ class TestWorkflowValidation:
         workflow = workflow_builder.build(plan, filled_inputs)
 
         assert len(workflow.nodes) == 1
-        assert workflow.nodes[0].type == "deep_search"
+        assert workflow.nodes[0].type_ == "deep_search"
         assert workflow.nodes[0].id == "deep_search_1"
 
 
@@ -506,7 +506,7 @@ class TestJSONPathValidation:
         assert len(workflow.nodes) == 2
 
         # Check that io_map was built with validated JSONPath using node IDs
-        gap_node = next(node for node in workflow.nodes if node.type == "gap_analysis")
+        gap_node = next(node for node in workflow.nodes if node.type_ == "gap_analysis")
         assert gap_node.id == "gap_analysis_1"
         assert gap_node.io_map is not None
         # JSONPath should reference the node ID, not the type

--- a/tests/planner/test_workflow_builder.py
+++ b/tests/planner/test_workflow_builder.py
@@ -118,10 +118,10 @@ class TestWorkflowGeneration:
 
         assert isinstance(workflow, WorkflowFormat)
         assert len(workflow.nodes) == 2
-        assert len(workflow.edges) == 3  # START->deep_search, deep_search->gap_analysis, gap_analysis->END
+        assert len(workflow.edges) == 3  # START->deep_search_1, deep_search_1->gap_analysis_1, gap_analysis_1->END
 
     def test_workflow_has_correct_nodes(self, workflow_builder, simple_workflow_plan):
-        """Test that workflow contains correct agent nodes."""
+        """Test that workflow contains correct agent nodes with unique IDs."""
         filled_inputs = {
             "deep_search": {"query": "test"},
             "gap_analysis": {},
@@ -130,9 +130,12 @@ class TestWorkflowGeneration:
         workflow = workflow_builder.build(simple_workflow_plan, filled_inputs)
 
         node_types = [node.type for node in workflow.nodes]
+        node_ids = [node.id for node in workflow.nodes]
 
         assert "deep_search" in node_types
         assert "gap_analysis" in node_types
+        assert "deep_search_1" in node_ids
+        assert "gap_analysis_1" in node_ids
 
     def test_workflow_has_io_map(self, workflow_builder, simple_workflow_plan):
         """Test that workflow generates io_map for data routing."""
@@ -147,11 +150,12 @@ class TestWorkflowGeneration:
         gap_node = next((n for n in workflow.nodes if n.type == "gap_analysis"), None)
 
         assert gap_node is not None
+        assert gap_node.id == "gap_analysis_1"
         assert gap_node.io_map is not None
         assert len(gap_node.io_map) > 0
 
     def test_workflow_edges(self, workflow_builder, simple_workflow_plan):
-        """Test that workflow generates correct edges."""
+        """Test that workflow generates correct edges using node IDs."""
         filled_inputs = {
             "deep_search": {"query": "test"},
             "gap_analysis": {},
@@ -165,8 +169,47 @@ class TestWorkflowGeneration:
 
         assert len(start_edges) == 1
         assert len(end_edges) == 1
-        assert start_edges[0].to_node == "deep_search"
-        assert end_edges[0].from_node == "gap_analysis"
+        assert start_edges[0].to_node == "deep_search_1"
+        assert end_edges[0].from_node == "gap_analysis_1"
+
+    def test_duplicate_agent_types_get_unique_ids(self, workflow_builder):
+        """Test that duplicate agent types get unique IDs."""
+        plan = WorkflowPlan(
+            workflow_description="Dual search workflow",
+            research_goal="Search twice",
+            suggested_agents=[
+                AgentSuggestion(
+                    agent_id="deep_search",
+                    agent_name="Deep Search",
+                    reason="First search",
+                    confidence=1.0,
+                ),
+                AgentSuggestion(
+                    agent_id="deep_search",
+                    agent_name="Deep Search",
+                    reason="Second search",
+                    confidence=1.0,
+                ),
+            ],
+        )
+
+        filled_inputs = {
+            "deep_search": {"query": "test"},
+        }
+
+        workflow = workflow_builder.build(plan, filled_inputs)
+
+        assert len(workflow.nodes) == 2
+        assert workflow.nodes[0].id == "deep_search_1"
+        assert workflow.nodes[1].id == "deep_search_2"
+        assert workflow.nodes[0].type == "deep_search"
+        assert workflow.nodes[1].type == "deep_search"
+
+        # Edges should use unique IDs
+        assert workflow.edges[0].to_node == "deep_search_1"
+        assert workflow.edges[1].from_node == "deep_search_1"
+        assert workflow.edges[1].to_node == "deep_search_2"
+        assert workflow.edges[2].from_node == "deep_search_2"
 
 
 class TestWorkflowSerialization:
@@ -190,6 +233,11 @@ class TestWorkflowSerialization:
         assert "nodes" in data
         assert "edges" in data
         assert data["workflow_type"] == "AKDResearchWorkflow"
+
+        # Verify nodes have both id and type
+        for node in data["nodes"]:
+            assert "id" in node
+            assert "type" in node
 
     def test_workflow_model_dump(self, workflow_builder, simple_workflow_plan):
         """Test that workflow can be dumped to dict."""
@@ -256,6 +304,7 @@ class TestWorkflowInputHandling:
         # deep_search node should have input
         deep_node = next((n for n in workflow.nodes if n.type == "deep_search"), None)
         assert deep_node is not None
+        assert deep_node.id == "deep_search_1"
         assert len(deep_node.input.fields) > 0
 
     def test_input_fields_preserved(self, workflow_builder, simple_workflow_plan):
@@ -320,6 +369,7 @@ class TestWorkflowValidation:
 
         assert len(workflow.nodes) == 1
         assert workflow.nodes[0].type == "deep_search"
+        assert workflow.nodes[0].id == "deep_search_1"
 
 
 class TestJSONPathValidation:
@@ -328,12 +378,12 @@ class TestJSONPathValidation:
     def test_validate_jsonpath_with_valid_identifiers(self, workflow_builder):
         """Test that valid identifiers (alphanumeric + underscore) pass validation."""
         # Test with simple alphanumeric
-        result = workflow_builder._build_and_validate_jsonpath("agent_a", "field1")
-        assert result == "$.agent_a.outputs.field1"
+        result = workflow_builder._build_and_validate_jsonpath("agent_a_1", "field1")
+        assert result == "$.agent_a_1.outputs.field1"
 
         # Test with underscores
-        result = workflow_builder._build_and_validate_jsonpath("deep_search_agent", "research_results")
-        assert result == "$.deep_search_agent.outputs.research_results"
+        result = workflow_builder._build_and_validate_jsonpath("deep_search_agent_1", "research_results")
+        assert result == "$.deep_search_agent_1.outputs.research_results"
 
         # Test with numbers
         result = workflow_builder._build_and_validate_jsonpath("agent123", "field456")
@@ -343,19 +393,19 @@ class TestJSONPathValidation:
         result = workflow_builder._build_and_validate_jsonpath("AgentA", "FieldB")
         assert result == "$.AgentA.outputs.FieldB"
 
-    def test_validate_jsonpath_with_hyphenated_agent_id(self, workflow_builder):
-        """Test that agent IDs with hyphens are rejected."""
-        with pytest.raises(ValueError, match="Invalid agent_id for JSONPath"):
+    def test_validate_jsonpath_with_hyphenated_node_id(self, workflow_builder):
+        """Test that node IDs with hyphens are rejected."""
+        with pytest.raises(ValueError, match="Invalid node_id for JSONPath"):
             workflow_builder._build_and_validate_jsonpath("test-agent", "field")
 
     def test_validate_jsonpath_with_hyphenated_field_name(self, workflow_builder):
         """Test that field names with hyphens are rejected."""
         with pytest.raises(ValueError, match="Invalid field_name for JSONPath"):
-            workflow_builder._build_and_validate_jsonpath("agent", "test-field")
+            workflow_builder._build_and_validate_jsonpath("agent_1", "test-field")
 
-    def test_validate_jsonpath_with_special_characters_in_agent_id(self, workflow_builder):
-        """Test that agent IDs with special characters are rejected."""
-        invalid_agent_ids = [
+    def test_validate_jsonpath_with_special_characters_in_node_id(self, workflow_builder):
+        """Test that node IDs with special characters are rejected."""
+        invalid_node_ids = [
             "agent@123",  # @ symbol
             "agent.name",  # period
             "agent$id",  # dollar sign
@@ -366,9 +416,9 @@ class TestJSONPathValidation:
             "agent\nagent",  # newline
         ]
 
-        for agent_id in invalid_agent_ids:
-            with pytest.raises(ValueError, match="Invalid agent_id for JSONPath"):
-                workflow_builder._build_and_validate_jsonpath(agent_id, "field")
+        for node_id in invalid_node_ids:
+            with pytest.raises(ValueError, match="Invalid node_id for JSONPath"):
+                workflow_builder._build_and_validate_jsonpath(node_id, "field")
 
     def test_validate_jsonpath_with_special_characters_in_field_name(self, workflow_builder):
         """Test that field names with special characters are rejected."""
@@ -383,17 +433,17 @@ class TestJSONPathValidation:
 
         for field_name in invalid_field_names:
             with pytest.raises(ValueError, match="Invalid field_name for JSONPath"):
-                workflow_builder._build_and_validate_jsonpath("agent", field_name)
+                workflow_builder._build_and_validate_jsonpath("agent_1", field_name)
 
-    def test_validate_jsonpath_with_empty_agent_id(self, workflow_builder):
-        """Test that empty agent IDs are rejected."""
-        with pytest.raises(ValueError, match="Invalid agent_id for JSONPath"):
+    def test_validate_jsonpath_with_empty_node_id(self, workflow_builder):
+        """Test that empty node IDs are rejected."""
+        with pytest.raises(ValueError, match="Invalid node_id for JSONPath"):
             workflow_builder._build_and_validate_jsonpath("", "field")
 
     def test_validate_jsonpath_with_empty_field_name(self, workflow_builder):
         """Test that empty field names are rejected."""
         with pytest.raises(ValueError, match="Invalid field_name for JSONPath"):
-            workflow_builder._build_and_validate_jsonpath("agent", "")
+            workflow_builder._build_and_validate_jsonpath("agent_1", "")
 
     def test_validate_jsonpath_prevents_path_injection(self, workflow_builder):
         """Test that path traversal attempts are blocked."""
@@ -406,21 +456,21 @@ class TestJSONPathValidation:
         ]
 
         for malicious_input in malicious_inputs:
-            # Test in agent_id
-            with pytest.raises(ValueError, match="Invalid agent_id for JSONPath"):
+            # Test in node_id
+            with pytest.raises(ValueError, match="Invalid node_id for JSONPath"):
                 workflow_builder._build_and_validate_jsonpath(malicious_input, "field")
 
             # Test in field_name
             with pytest.raises(ValueError, match="Invalid field_name for JSONPath"):
-                workflow_builder._build_and_validate_jsonpath("agent", malicious_input)
+                workflow_builder._build_and_validate_jsonpath("agent_1", malicious_input)
 
     def test_validate_jsonpath_with_very_long_identifiers(self, workflow_builder):
         """Test that very long but valid identifiers work."""
-        long_agent_id = "a" * 100
+        long_node_id = "a" * 100
         long_field_name = "f" * 100
 
-        result = workflow_builder._build_and_validate_jsonpath(long_agent_id, long_field_name)
-        assert result == f"$.{long_agent_id}.outputs.{long_field_name}"
+        result = workflow_builder._build_and_validate_jsonpath(long_node_id, long_field_name)
+        assert result == f"$.{long_node_id}.outputs.{long_field_name}"
 
     def test_validate_jsonpath_integration_with_build(self, workflow_builder, agent_registry):
         """Test that JSONPath validation is applied during workflow building."""
@@ -455,12 +505,13 @@ class TestJSONPathValidation:
         workflow = workflow_builder.build(plan, filled_inputs)
         assert len(workflow.nodes) == 2
 
-        # Check that io_map was built with validated JSONPath
+        # Check that io_map was built with validated JSONPath using node IDs
         gap_node = next(node for node in workflow.nodes if node.type == "gap_analysis")
+        assert gap_node.id == "gap_analysis_1"
         assert gap_node.io_map is not None
-        # JSONPath should be validated and well-formed
+        # JSONPath should reference the node ID, not the type
         for jsonpath in gap_node.io_map.values():
-            assert jsonpath.startswith("$.deep_search.outputs.")
+            assert jsonpath.startswith("$.deep_search_1.outputs.")
 
 
 if __name__ == "__main__":

--- a/tests/planner/test_workflow_format.py
+++ b/tests/planner/test_workflow_format.py
@@ -14,17 +14,18 @@ class TestWorkflowFormatValidation:
         """Test that validation detects invalid node references in io_map."""
         workflow = WorkflowFormat(
             nodes=[
-                WorkflowNode(type="agent_a", input=WorkflowNodeIO()),
+                WorkflowNode(id="agent_a_1", type="agent_a", input=WorkflowNodeIO()),
                 WorkflowNode(
+                    id="agent_b_1",
                     type="agent_b",
                     input=WorkflowNodeIO(),
                     io_map={"field1": "$.non_existent_agent.outputs.field"},
                 ),
             ],
             edges=[
-                WorkflowEdge(from_node="START", to_node="agent_a"),
-                WorkflowEdge(from_node="agent_a", to_node="agent_b"),
-                WorkflowEdge(from_node="agent_b", to_node="END"),
+                WorkflowEdge(from_node="START", to_node="agent_a_1"),
+                WorkflowEdge(from_node="agent_a_1", to_node="agent_b_1"),
+                WorkflowEdge(from_node="agent_b_1", to_node="END"),
             ],
         )
 
@@ -36,17 +37,18 @@ class TestWorkflowFormatValidation:
         """Test that validation detects invalid JSONPath format."""
         workflow = WorkflowFormat(
             nodes=[
-                WorkflowNode(type="agent_a", input=WorkflowNodeIO()),
+                WorkflowNode(id="agent_a_1", type="agent_a", input=WorkflowNodeIO()),
                 WorkflowNode(
+                    id="agent_b_1",
                     type="agent_b",
                     input=WorkflowNodeIO(),
                     io_map={"field1": "invalid_path"},
                 ),
             ],
             edges=[
-                WorkflowEdge(from_node="START", to_node="agent_a"),
-                WorkflowEdge(from_node="agent_a", to_node="agent_b"),
-                WorkflowEdge(from_node="agent_b", to_node="END"),
+                WorkflowEdge(from_node="START", to_node="agent_a_1"),
+                WorkflowEdge(from_node="agent_a_1", to_node="agent_b_1"),
+                WorkflowEdge(from_node="agent_b_1", to_node="END"),
             ],
         )
 
@@ -58,17 +60,18 @@ class TestWorkflowFormatValidation:
         """Test that validation passes for valid io_map."""
         workflow = WorkflowFormat(
             nodes=[
-                WorkflowNode(type="agent_a", input=WorkflowNodeIO()),
+                WorkflowNode(id="agent_a_1", type="agent_a", input=WorkflowNodeIO()),
                 WorkflowNode(
+                    id="agent_b_1",
                     type="agent_b",
                     input=WorkflowNodeIO(),
-                    io_map={"field1": "$.agent_a.outputs.result"},
+                    io_map={"field1": "$.agent_a_1.outputs.result"},
                 ),
             ],
             edges=[
-                WorkflowEdge(from_node="START", to_node="agent_a"),
-                WorkflowEdge(from_node="agent_a", to_node="agent_b"),
-                WorkflowEdge(from_node="agent_b", to_node="END"),
+                WorkflowEdge(from_node="START", to_node="agent_a_1"),
+                WorkflowEdge(from_node="agent_a_1", to_node="agent_b_1"),
+                WorkflowEdge(from_node="agent_b_1", to_node="END"),
             ],
         )
 
@@ -79,14 +82,14 @@ class TestWorkflowFormatValidation:
         """Test that validation detects orphaned nodes."""
         workflow = WorkflowFormat(
             nodes=[
-                WorkflowNode(type="agent_a", input=WorkflowNodeIO()),
-                WorkflowNode(type="agent_b", input=WorkflowNodeIO()),
-                WorkflowNode(type="orphaned_agent", input=WorkflowNodeIO()),
+                WorkflowNode(id="agent_a_1", type="agent_a", input=WorkflowNodeIO()),
+                WorkflowNode(id="agent_b_1", type="agent_b", input=WorkflowNodeIO()),
+                WorkflowNode(id="orphaned_agent_1", type="orphaned_agent", input=WorkflowNodeIO()),
             ],
             edges=[
-                WorkflowEdge(from_node="START", to_node="agent_a"),
-                WorkflowEdge(from_node="agent_a", to_node="agent_b"),
-                WorkflowEdge(from_node="agent_b", to_node="END"),
+                WorkflowEdge(from_node="START", to_node="agent_a_1"),
+                WorkflowEdge(from_node="agent_a_1", to_node="agent_b_1"),
+                WorkflowEdge(from_node="agent_b_1", to_node="END"),
             ],
         )
 
@@ -97,8 +100,8 @@ class TestWorkflowFormatValidation:
     def test_validate_edges_missing_start(self):
         """Test that validation detects missing START edge."""
         workflow = WorkflowFormat(
-            nodes=[WorkflowNode(type="agent_a", input=WorkflowNodeIO())],
-            edges=[WorkflowEdge(from_node="agent_a", to_node="END")],
+            nodes=[WorkflowNode(id="agent_a_1", type="agent_a", input=WorkflowNodeIO())],
+            edges=[WorkflowEdge(from_node="agent_a_1", to_node="END")],
         )
 
         issues = workflow.validate_edges(strict=False)
@@ -108,8 +111,8 @@ class TestWorkflowFormatValidation:
     def test_validate_edges_missing_end(self):
         """Test that validation detects missing END edge."""
         workflow = WorkflowFormat(
-            nodes=[WorkflowNode(type="agent_a", input=WorkflowNodeIO())],
-            edges=[WorkflowEdge(from_node="START", to_node="agent_a")],
+            nodes=[WorkflowNode(id="agent_a_1", type="agent_a", input=WorkflowNodeIO())],
+            edges=[WorkflowEdge(from_node="START", to_node="agent_a_1")],
         )
 
         issues = workflow.validate_edges(strict=False)
@@ -120,13 +123,13 @@ class TestWorkflowFormatValidation:
         """Test that validation passes for valid edges."""
         workflow = WorkflowFormat(
             nodes=[
-                WorkflowNode(type="agent_a", input=WorkflowNodeIO()),
-                WorkflowNode(type="agent_b", input=WorkflowNodeIO()),
+                WorkflowNode(id="agent_a_1", type="agent_a", input=WorkflowNodeIO()),
+                WorkflowNode(id="agent_b_1", type="agent_b", input=WorkflowNodeIO()),
             ],
             edges=[
-                WorkflowEdge(from_node="START", to_node="agent_a"),
-                WorkflowEdge(from_node="agent_a", to_node="agent_b"),
-                WorkflowEdge(from_node="agent_b", to_node="END"),
+                WorkflowEdge(from_node="START", to_node="agent_a_1"),
+                WorkflowEdge(from_node="agent_a_1", to_node="agent_b_1"),
+                WorkflowEdge(from_node="agent_b_1", to_node="END"),
             ],
         )
 
@@ -146,8 +149,9 @@ class TestWorkflowFormatValidation:
         """Test comprehensive validation with multiple issues."""
         workflow = WorkflowFormat(
             nodes=[
-                WorkflowNode(type="agent_a", input=WorkflowNodeIO()),
+                WorkflowNode(id="agent_a_1", type="agent_a", input=WorkflowNodeIO()),
                 WorkflowNode(
+                    id="agent_b_1",
                     type="agent_b",
                     input=WorkflowNodeIO(),
                     io_map={"field1": "invalid"},  # Invalid JSONPath
@@ -155,8 +159,8 @@ class TestWorkflowFormatValidation:
             ],
             edges=[
                 # Missing START edge
-                WorkflowEdge(from_node="agent_a", to_node="agent_b"),
-                WorkflowEdge(from_node="agent_b", to_node="END"),
+                WorkflowEdge(from_node="agent_a_1", to_node="agent_b_1"),
+                WorkflowEdge(from_node="agent_b_1", to_node="END"),
             ],
         )
 
@@ -175,17 +179,18 @@ class TestWorkflowFormatValidation:
         """Test workflow summary generation."""
         workflow = WorkflowFormat(
             nodes=[
-                WorkflowNode(type="agent_a", input=WorkflowNodeIO()),
+                WorkflowNode(id="agent_a_1", type="agent_a", input=WorkflowNodeIO()),
                 WorkflowNode(
+                    id="agent_b_1",
                     type="agent_b",
                     input=WorkflowNodeIO(),
-                    io_map={"field1": "$.agent_a.outputs.result"},
+                    io_map={"field1": "$.agent_a_1.outputs.result"},
                 ),
             ],
             edges=[
-                WorkflowEdge(from_node="START", to_node="agent_a"),
-                WorkflowEdge(from_node="agent_a", to_node="agent_b"),
-                WorkflowEdge(from_node="agent_b", to_node="END"),
+                WorkflowEdge(from_node="START", to_node="agent_a_1"),
+                WorkflowEdge(from_node="agent_a_1", to_node="agent_b_1"),
+                WorkflowEdge(from_node="agent_b_1", to_node="END"),
             ],
         )
 
@@ -195,6 +200,7 @@ class TestWorkflowFormatValidation:
         assert summary["total_edges"] == 3
         assert summary["nodes_with_io_map"] == 1
         assert summary["total_io_map_entries"] == 1
+        assert summary["node_ids"] == ["agent_a_1", "agent_b_1"]
         assert summary["node_types"] == ["agent_a", "agent_b"]
         assert summary["version"] == "1.0.0"
         assert summary["workflow_type"] == "AKDResearchWorkflow"


### PR DESCRIPTION
## Summary
Added unique node IDs to handle duplicate agents, added validator to ensure workflow_plan exists when ready_to_generate is true, and moved planner model config to single source in CONFIG for the planner.

## Changes

### 1. Unique Node IDs (Duplicate Agents)
- Added `id` field to `WorkflowNode` (e.g., `code_search_1`, `code_search_2`)
- Edges now reference node `id` instead of `type`
- io_map JSONPath uses node `id` (e.g., `$.code_search_1.outputs.results`)
- Updated validation methods for node IDs

### 2. Model Config - Planner
- Added `planner_model_name` to `ModelConfigSettings` as single source of truth
- `PlannerConfig` now uses `CONFIG.planner_model_name`
- `FieldMappingGenerator` now uses `CONFIG.planner_model_name`
- Removed hardcoded model names from planner module

### 3. Validators
- Added validator: `ready_to_generate=True` requires `workflow_plan` to exist
- Prevents crash when LLM says "ready" but forgets to provide plan

## How to Test

**Unit tests:**
```bash
uv run pytest tests/planner/
```

**Manual test:**
```bash
python scripts/demo_planner.py automated "Find weather repos, find climate repos, and do gap analysis"
```