### PR TITLE
Feat: Implement RunUsage token tracking and refactor Base Agent

### DIFF
--- a/akd/_base/_base.py
+++ b/akd/_base/_base.py
@@ -5,12 +5,20 @@ from abc import ABC, ABCMeta, abstractmethod
 from typing import Any, Type, cast
 
 from loguru import logger
-from pydantic import BaseModel, Field, ValidationError, computed_field, create_model
+from pydantic import (
+    BaseModel,
+    Field,
+    PrivateAttr,
+    ValidationError,
+    computed_field,
+    create_model,
+)
 
 from akd.utils import get_model_fields, to_snake_case
 
 from .errors import HumanInputRequired, SchemaValidationError
 from .streaming import StreamingMixin
+from .structures import RunContext
 from .utils import AsyncRunMixin
 
 
@@ -76,6 +84,8 @@ class OutputSchema(IOSchema):
 
     __response_field__: str | None = None
 
+    _run_context: RunContext | None = PrivateAttr(default=None)
+
     @computed_field
     def _response(self) -> str:
         """
@@ -90,6 +100,11 @@ class OutputSchema(IOSchema):
         if self.__response_field__ is not None:
             return getattr(self, self.__response_field__, "")
         return ""
+
+    @property
+    def run_context(self) -> RunContext | None:
+        """Get the run context associated with this output."""
+        return self._run_context
 
 
 class TextInput(InputSchema):

--- a/akd/_base/memory.py
+++ b/akd/_base/memory.py
@@ -96,6 +96,10 @@ class Memory[T](BaseModel):
         if run_context and run_context.messages:
             self.sync(run_context.messages)
 
+        # Share live reference so run_context.messages updates in real-time
+        if run_context is not None:
+            run_context.messages = self.messages
+
         if enable_trimming and model_name and max_tokens:
             trimmed = trim_messages(
                 self.messages,
@@ -109,7 +113,7 @@ class Memory[T](BaseModel):
             yield self.messages
         finally:
             if run_context is not None:
-                # prevent references to prevent self.clear() affecting run_context
+                # Snapshot before stateless clear to preserve messages
                 run_context.messages = list(self.messages)
             if stateless:
                 self.clear()

--- a/akd/_base/memory.py
+++ b/akd/_base/memory.py
@@ -108,6 +108,9 @@ class Memory[T](BaseModel):
         try:
             yield self.messages
         finally:
+            if run_context is not None:
+                # prevent references to prevent self.clear() affecting run_context
+                run_context.messages = list(self.messages)
             if stateless:
                 self.clear()
 

--- a/akd/_base/streaming.py
+++ b/akd/_base/streaming.py
@@ -410,7 +410,7 @@ class StreamingMixin:
     async def _astream(
         self,
         params: Any,
-        run_context: RunContext | None = None,
+        run_context: RunContext,
         **kwargs: Any,
     ) -> AsyncIterator[StreamEvent]:
         """Internal streaming implementation. Override for custom streaming.
@@ -435,10 +435,6 @@ class StreamingMixin:
             StreamEvent: STARTING, RUNNING, then COMPLETED or FAILED
         """
         class_name = self.__class__.__name__
-
-        # Auto-generate run_id for event correlation
-        run_context = (run_context or RunContext()).model_copy()
-        run_context.run_id = run_context.run_id or uuid.uuid4().hex[:8]
 
         yield StartingEvent(
             source=class_name,

--- a/akd/_base/structures.py
+++ b/akd/_base/structures.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from .tool_calling import ToolResult
 
@@ -37,6 +37,51 @@ class HumanResponse(ToolResult):
     tool_name: str = Field(default="ask_human", description="Tool name (defaults to ask_human)")
 
 
+class RunUsage(BaseModel):
+    """Token usage statistics for an agent run.
+
+    Accumulates across tool loop iterations via ``incr()``.
+    Inspired by pydantic-ai's RunUsage pattern.
+
+    Example:
+        usage = RunUsage()
+        usage.incr(RunUsage(input_tokens=100, output_tokens=50, requests=1))
+        usage.incr(RunUsage(input_tokens=200, output_tokens=80, requests=1))
+        print(usage)  # RunUsage(input_tokens=300, output_tokens=130, requests=2, total_tokens=430)
+    """
+
+    input_tokens: int = Field(default=0, description="Total input/prompt tokens")
+    output_tokens: int = Field(default=0, description="Total output/completion tokens")
+    requests: int = Field(default=0, description="Number of LLM API requests")
+    details: dict[str, int] = Field(
+        default_factory=dict,
+        description="Provider-specific extra usage details",
+    )
+
+    @computed_field
+    @property
+    def total_tokens(self) -> int:
+        """Sum of input_tokens + output_tokens."""
+        return self.input_tokens + self.output_tokens
+
+    def incr(self, other: RunUsage) -> None:
+        """Increment usage in place.
+
+        Args:
+            other: The usage to add.
+        """
+        self.input_tokens += other.input_tokens
+        self.output_tokens += other.output_tokens
+        self.requests += other.requests
+        for k, v in other.details.items():
+            self.details[k] = self.details.get(k, 0) + v
+
+    def __iadd__(self, other: RunUsage) -> RunUsage:
+        """Support ``usage += other_usage`` syntax."""
+        self.incr(other)
+        return self
+
+
 class RunContext(BaseModel):
     """Execution context for streaming and tool calling.
 
@@ -66,6 +111,10 @@ class RunContext(BaseModel):
         default=None,
         description="Unique identifier for this execution run",
     )
+    usage: RunUsage = Field(
+        default_factory=RunUsage,
+        description="Accumulated token usage for this run",
+    )
 
 
-__all__ = ["HumanResponse", "RunContext"]
+__all__ = ["HumanResponse", "RunContext", "RunUsage"]

--- a/akd/agents/__init__.py
+++ b/akd/agents/__init__.py
@@ -1,13 +1,8 @@
-from ._base import (
-    BaseAgent,
-    BaseAgentConfig,
-    InstructorBaseAgent,
-    LiteLLMInstructorBaseAgent,
-)
+from ._base import Agent, BaseAgent, BaseAgentConfig, LiteLLMInstructorBaseAgent
 
 __all__ = [
+    "Agent",
     "BaseAgent",
     "BaseAgentConfig",
-    "InstructorBaseAgent",
     "LiteLLMInstructorBaseAgent",
 ]

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -201,6 +201,20 @@ class BaseAgentConfig(BaseConfig):
 
         return self
 
+    @model_validator(mode="after")
+    def openai_responses_model_name(self):
+        if not self.model_name or not (self.reasoning_effort or self.reasoning_summary):
+            return self
+
+        try:
+            if supports_reasoning(model=self.model_name) and self.model_name.startswith("gpt-5"):
+                self.model_name = f"openai/responses/{self.model_name}"
+                logger.info(f"Converting to {self.model_name}")
+        except Exception:
+            pass
+
+        return self
+
 
 class BaseAgent[
     InSchema: InputSchema,

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -383,6 +383,14 @@ class InstructorBaseAgent[
         memory: Memory | None = None,
         debug: bool = False,
     ) -> None:
+        import warnings
+
+        if not isinstance(self, LiteLLMInstructorBaseAgent):
+            warnings.warn(
+                "InstructorBaseAgent is deprecated. Use LiteLLMInstructorBaseAgent instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         super().__init__(config=config, memory=memory, debug=debug)
 
         # Create the OpenAI client
@@ -1339,3 +1347,6 @@ class LiteLLMInstructorBaseAgent[
                 run_context=run_context,
             )
             raise
+
+
+Agent = LiteLLMInstructorBaseAgent

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -309,6 +309,7 @@ class BaseAgent[
         self,
         params: Any,
         run_context: RunContext | None = None,
+        **kwargs: Any,
     ) -> TextOutput:
         """Convenience method for simple text-based conversations.
 
@@ -338,7 +339,11 @@ class BaseAgent[
             response = await agent.achat("What's my name?")  # response.content == "Alice"
         """
         text_input = params if isinstance(params, TextInput) else TextInput(content=str(params))
-        result = await self._arun(text_input, run_context=run_context)
+        # only reference, no copy
+        run_context = run_context or RunContext()
+        run_context.run_id = run_context.run_id or uuid.uuid4().hex[:8]
+        result = await self._arun(text_input, run_context=run_context, **kwargs)
+        object.__setattr__(result, "run_context", run_context)
         if isinstance(result, TextOutput):
             return result
         return TextOutput(content=result._response or str(result))

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -337,8 +337,8 @@ class BaseAgent[
             response = await agent.achat("What's my name?")  # response.content == "Alice"
         """
         text_input = params if isinstance(params, TextInput) else TextInput(content=str(params))
-        # only reference, no copy
-        run_context = run_context or RunContext()
+
+        run_context = (run_context or RunContext()).model_copy()
         run_context.run_id = run_context.run_id or uuid.uuid4().hex[:8]
         result = await self._arun(text_input, run_context=run_context, **kwargs)
         result._run_context = run_context

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -280,8 +280,7 @@ class BaseAgent[
         Returns:
             Output matching the agent's output_schema.
         """
-        # only reference, no copy
-        run_context = run_context or RunContext()
+        run_context = (run_context or RunContext()).model_copy()
         run_context.run_id = run_context.run_id or uuid.uuid4().hex[:8]
         output = await super().arun(params, run_context=run_context, **kwargs)
         # attach run_context (with accumulated usage) to final output
@@ -299,8 +298,7 @@ class BaseAgent[
         Centralizes run_context creation and run_id assignment,
         then delegates to parent astream().
         """
-        # only reference, no copy
-        run_context = run_context or RunContext()
+        run_context = (run_context or RunContext()).model_copy()
         run_context.run_id = run_context.run_id or uuid.uuid4().hex[:8]
         async for event in super().astream(params, run_context=run_context, **kwargs):
             yield event

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -675,6 +675,22 @@ class LiteLLMInstructorBaseAgent[
             run_usage.input_tokens = getattr(usage, "prompt_tokens", 0) or 0
             run_usage.output_tokens = getattr(usage, "completion_tokens", 0) or 0
             run_usage.requests = 1
+
+            # Capture provider-specific details (reasoning tokens, cached tokens, etc.)
+            for details_attr in ("completion_tokens_details", "prompt_tokens_details"):
+                details_obj = getattr(usage, details_attr, None)
+                if details_obj is None:
+                    continue
+                # details_obj can be a dict or a Pydantic model
+                items = (
+                    details_obj.items()
+                    if isinstance(details_obj, dict)
+                    else ((k, v) for k, v in vars(details_obj).items() if isinstance(v, int) and v > 0)
+                )
+                for k, v in items:
+                    if isinstance(v, int) and v > 0:
+                        run_usage.details[f"{details_attr}.{k}"] = v
+
         return run_usage
 
     async def _arun(

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -809,10 +809,13 @@ class LiteLLMInstructorBaseAgent[
                     "schema": self._build_response_format_schema(response_model),
                 },
             },
+            "stream_options": {"include_usage": True},
         }
 
         if self.reasoning_effort:
             completion_kwargs["reasoning_effort"] = self.reasoning_effort
+        if self.reasoning_summary:
+            completion_kwargs["reasoning"] = {"summary": self.reasoning_summary}
 
         class_name = self.__class__.__name__
 
@@ -837,11 +840,17 @@ class LiteLLMInstructorBaseAgent[
 
         accumulated = ""
         token_buffer = ""
+        thinking_buffer = ""
         last_partial_dict = None
 
         response = await acompletion(**completion_kwargs)
         async for chunk in response:
             run_context.usage += self._extract_usage(chunk)
+
+            # Check if chunk.choices is not empty
+            if not chunk.choices:
+                continue
+
             delta = chunk.choices[0].delta
 
             # Thinking tokens (Claude extended thinking, o1 reasoning)
@@ -850,13 +859,17 @@ class LiteLLMInstructorBaseAgent[
                 "thinking",
                 None,
             )
+            # Note: Not recommended to track thinking tokens in history
             if reasoning:
-                yield ThinkingEvent(
-                    source=class_name,
-                    message="Reasoning...",
-                    data=ThinkingEventData(thinking_content=reasoning),
-                    run_context=run_context,
-                )
+                thinking_buffer += reasoning
+                if len(thinking_buffer) >= token_batch_size:
+                    yield ThinkingEvent(
+                        source=class_name,
+                        message="Reasoning...",
+                        data=ThinkingEventData(thinking_content=thinking_buffer),
+                        run_context=run_context,
+                    )
+                    thinking_buffer = ""
 
             # Content tokens - batch, then accumulate and validate as partial
             if delta.content:
@@ -886,6 +899,15 @@ class LiteLLMInstructorBaseAgent[
                         )
                     except Exception:
                         pass  # Skip invalid partials
+
+        # Emit remaining thinking tokens
+        if thinking_buffer:
+            yield ThinkingEvent(
+                source=class_name,
+                message="Reasoning...",
+                data=ThinkingEventData(thinking_content=thinking_buffer),
+                run_context=run_context,
+            )
 
         # Emit remaining tokens
         if token_buffer:
@@ -974,9 +996,12 @@ class LiteLLMInstructorBaseAgent[
                 "api_key": self.api_key,
                 "drop_params": True,
                 "stream": True,
+                "stream_options": {"include_usage": True},
             }
             if self.reasoning_effort:
                 completion_kwargs["reasoning_effort"] = self.reasoning_effort
+            if self.reasoning_summary:
+                completion_kwargs["reasoning"] = {"summary": self.reasoning_summary}
 
             response = await acompletion(**completion_kwargs)
 
@@ -986,6 +1011,7 @@ class LiteLLMInstructorBaseAgent[
             last_partial_dict: dict[str, Any] | None = None  # For deduplicating PARTIAL events
             accumulated_tool_calls: dict[int, dict[str, Any]] = {}  # index -> {id, name, arguments}
             buffered_partials: list[StreamEvent] = []  # Buffer partials until we know it's final
+            thinking_buffer = ""
 
             async for chunk in response:
                 run_context.usage += self._extract_usage(chunk)
@@ -998,12 +1024,18 @@ class LiteLLMInstructorBaseAgent[
                     None,
                 )
                 if reasoning:
-                    yield ThinkingEvent(
-                        source=class_name,
-                        message=reasoning,
-                        data=ThinkingEventData(streaming=True, thinking_content=reasoning),
-                        run_context=run_context,
-                    )
+                    thinking_buffer += reasoning
+                    if len(thinking_buffer) >= token_batch_size:
+                        yield ThinkingEvent(
+                            source=class_name,
+                            message="Reasoning...",
+                            data=ThinkingEventData(
+                                thinking_content=thinking_buffer,
+                                streaming=True,
+                            ),
+                            run_context=run_context,
+                        )
+                        thinking_buffer = ""
 
                 # Batch and stream content tokens
                 if delta.content:
@@ -1055,6 +1087,18 @@ class LiteLLMInstructorBaseAgent[
                                 accumulated_tool_calls[idx]["name"] = tc.function.name
                             if tc.function and tc.function.arguments:
                                 accumulated_tool_calls[idx]["arguments"] += tc.function.arguments
+
+            # Emit remaining thinking tokens in buffer
+            if thinking_buffer:
+                yield ThinkingEvent(
+                    source=class_name,
+                    message="Reasoning...",
+                    data=ThinkingEventData(
+                        thinking_content=thinking_buffer,
+                        streaming=True,
+                    ),
+                    run_context=run_context,
+                )
 
             # Emit remaining tokens in buffer
             if token_buffer:

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -10,7 +10,7 @@ from typing import Any, Literal, cast
 import instructor
 import openai
 from litellm import acompletion
-from litellm.utils import get_model_info, supports_reasoning, trim_messages
+from litellm.utils import get_model_info, supports_reasoning
 from loguru import logger
 from pydantic import AnyUrl, BaseModel, Field, create_model, model_validator
 
@@ -57,6 +57,7 @@ from akd._base.streaming import (
     ToolResultEvent,
     ToolResultEventData,
 )
+from akd._base.structures import RunUsage
 from akd.configs.project import CONFIG
 from akd.configs.prompts import DEFAULT_SYSTEM_PROMPT
 from akd.tools._base import BaseTool
@@ -279,7 +280,27 @@ class BaseAgent[
         Returns:
             Output matching the agent's output_schema.
         """
+        # only reference, no copy
+        run_context = run_context or RunContext()
+        run_context.run_id = run_context.run_id or uuid.uuid4().hex[:8]
         return await super().arun(params, run_context=run_context, **kwargs)
+
+    async def astream(
+        self,
+        params: Any,
+        run_context: RunContext | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[StreamEvent]:
+        """Stream agent execution with run_context initialization.
+
+        Centralizes run_context creation and run_id assignment,
+        then delegates to parent astream().
+        """
+        # only reference, no copy
+        run_context = run_context or RunContext()
+        run_context.run_id = run_context.run_id or uuid.uuid4().hex[:8]
+        async for event in super().astream(params, run_context=run_context, **kwargs):
+            yield event
 
     async def achat(
         self,
@@ -573,6 +594,7 @@ class LiteLLMInstructorBaseAgent[
         self,
         messages: list[dict[str, str]],
         response_model: type[OutputSchema] | None = None,
+        run_context: RunContext | None = None,
     ) -> OutSchema:
         """
         Obtains a response from the language model asynchronously with automatic message trimming.
@@ -588,15 +610,6 @@ class LiteLLMInstructorBaseAgent[
         Returns:
             Type[BaseModel]: The response from the language model.
         """
-        # Trim messages if enabled to prevent token limit errors
-        if self.enable_trimming:
-            messages = trim_messages(
-                messages,
-                model=self.model_name,
-                max_tokens=self.max_tokens,
-                trim_ratio=self.trim_ratio,
-            )
-
         response_model = response_model or self.output_schema
         instructor_model = self._create_instructor_compatible_model(response_model)
 
@@ -618,16 +631,40 @@ class LiteLLMInstructorBaseAgent[
         if self.reasoning_summary:
             completion_kwargs["reasoning_summary"] = self.reasoning_summary
 
-        response = await self.client.chat.completions.create(**completion_kwargs)
+        response, completion = await self.client.chat.completions.create_with_completion(
+            **completion_kwargs,
+        )
+
+        # Capture token usage from the raw completion
+        if run_context is not None:
+            run_context.usage += self._extract_usage(completion)
 
         response_data = response.model_dump()
         response = response_model(**response_data)
         return cast(OutSchema, response)
 
+    @staticmethod
+    def _extract_usage(completion: Any) -> RunUsage:
+        """Extract token usage from a raw LLM completion.
+
+        Args:
+            completion: Raw completion object from create_with_completion.
+
+        Returns:
+            RunUsage with extracted token counts (zeros if unavailable).
+        """
+        run_usage = RunUsage()
+        usage = getattr(completion, "usage", None)
+        if usage:
+            run_usage.input_tokens = getattr(usage, "prompt_tokens", 0) or 0
+            run_usage.output_tokens = getattr(usage, "completion_tokens", 0) or 0
+            run_usage.requests = 1
+        return run_usage
+
     async def _arun(
         self,
         params: InSchema,
-        run_context: RunContext | None = None,
+        run_context: RunContext,
         **kwargs,
     ) -> OutSchema:
         """Run agent with optional tool calling support.
@@ -669,8 +706,6 @@ class LiteLLMInstructorBaseAgent[
                 # === TOOL CALLING MODE ===
                 # Use _run_tool_loop and consume events to get final output
                 # Note: Tool loop mutates `messages` in place during iterations
-                run_context = (run_context or RunContext()).model_copy()
-                run_context.run_id = run_context.run_id or uuid.uuid4().hex[:8]
                 async for event in self._run_tool_loop(
                     messages,
                     run_context,
@@ -687,6 +722,7 @@ class LiteLLMInstructorBaseAgent[
                 output = await self.get_response_async(
                     messages=messages,
                     response_model=self.output_schema,
+                    run_context=run_context,
                 )
 
             # Add final assistant message
@@ -1187,7 +1223,7 @@ class LiteLLMInstructorBaseAgent[
     async def _astream(
         self,
         params: InSchema,
-        run_context: RunContext | None = None,
+        run_context: RunContext,
         token_batch_size: int = 10,
         **kwargs: Any,
     ) -> AsyncIterator[StreamEvent]:
@@ -1224,10 +1260,6 @@ class LiteLLMInstructorBaseAgent[
                         print(f"Error: {event.error}")
         """
         class_name = self.__class__.__name__
-
-        # Auto-generate run_id for event correlation
-        run_context = (run_context or RunContext()).model_copy()
-        run_context.run_id = run_context.run_id or uuid.uuid4().hex[:8]
 
         yield StartingEvent(
             source=class_name,

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -201,20 +201,6 @@ class BaseAgentConfig(BaseConfig):
 
         return self
 
-    @model_validator(mode="after")
-    def openai_responses_model_name(self):
-        if not self.model_name or not (self.reasoning_effort or self.reasoning_summary):
-            return self
-
-        try:
-            if supports_reasoning(model=self.model_name) and self.model_name.startswith("gpt-5"):
-                self.model_name = f"openai/responses/{self.model_name}"
-                logger.info(f"Converting to {self.model_name}")
-        except Exception:
-            pass
-
-        return self
-
 
 class BaseAgent[
     InSchema: InputSchema,
@@ -595,6 +581,23 @@ class LiteLLMInstructorBaseAgent[
 
         # Replace instructor client with LiteLLM version
         self.client = instructor.from_litellm(acompletion)
+
+    def _post_init(self):
+        super()._post_init()
+
+        # reformat to response format for openai gpt-5* models
+        # only when reasoning is enabled
+        # only applies to litellm so
+        if (
+            self.config.model_name.startswith("gpt-5")
+            and self.config.reasoning_effort
+            and self.config.reasoning_summary
+            and supports_reasoning(model=self.config.model_name)
+        ):
+            logger.info(
+                f"Reformatting model name to {self.config.model_name} to openai/responses/{self.config.model_name}",
+            )
+            self.config.model_name = f"openai/responses/{self.config.model_name}"
 
     def __deepcopy__(self, memo: dict[int, Any]) -> LiteLLMInstructorBaseAgent:
         """Custom deepcopy that recreates the LiteLLM client instead of copying it.

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -812,6 +812,7 @@ class LiteLLMInstructorBaseAgent[
 
         response = await acompletion(**completion_kwargs)
         async for chunk in response:
+            run_context.usage += self._extract_usage(chunk)
             delta = chunk.choices[0].delta
 
             # Thinking tokens (Claude extended thinking, o1 reasoning)
@@ -958,6 +959,7 @@ class LiteLLMInstructorBaseAgent[
             buffered_partials: list[StreamEvent] = []  # Buffer partials until we know it's final
 
             async for chunk in response:
+                run_context.usage += self._extract_usage(chunk)
                 delta = chunk.choices[0].delta
 
                 # Stream reasoning/thinking tokens (o1, o3, Claude extended thinking)

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -283,7 +283,10 @@ class BaseAgent[
         # only reference, no copy
         run_context = run_context or RunContext()
         run_context.run_id = run_context.run_id or uuid.uuid4().hex[:8]
-        return await super().arun(params, run_context=run_context, **kwargs)
+        output = await super().arun(params, run_context=run_context, **kwargs)
+        # attach run_context (with accumulated usage) to final output
+        object.__setattr__(output, "run_context", run_context)
+        return output
 
     async def astream(
         self,

--- a/akd/agents/_base.py
+++ b/akd/agents/_base.py
@@ -285,7 +285,7 @@ class BaseAgent[
         run_context.run_id = run_context.run_id or uuid.uuid4().hex[:8]
         output = await super().arun(params, run_context=run_context, **kwargs)
         # attach run_context (with accumulated usage) to final output
-        object.__setattr__(output, "run_context", run_context)
+        output._run_context = run_context
         return output
 
     async def astream(
@@ -343,7 +343,7 @@ class BaseAgent[
         run_context = run_context or RunContext()
         run_context.run_id = run_context.run_id or uuid.uuid4().hex[:8]
         result = await self._arun(text_input, run_context=run_context, **kwargs)
-        object.__setattr__(result, "run_context", run_context)
+        result._run_context = run_context
         if isinstance(result, TextOutput):
             return result
         return TextOutput(content=result._response or str(result))

--- a/akd/agents/extraction.py
+++ b/akd/agents/extraction.py
@@ -5,7 +5,7 @@ from loguru import logger
 from pydantic import BaseModel, Field
 
 from akd._base import AsyncRunMixin
-from akd.agents import InstructorBaseAgent
+from akd.agents import LiteLLMInstructorBaseAgent
 from akd.structures import ExtractionSchema, SingleEstimation
 
 from .intents import Intent
@@ -58,6 +58,6 @@ class EstimationExtractionOutputSchema(BaseModel):
     )
 
 
-class EstimationExtractionAgent(InstructorBaseAgent):
+class EstimationExtractionAgent(LiteLLMInstructorBaseAgent):
     input_schema = ExtractionInputSchema
     output_schema = EstimationExtractionOutputSchema

--- a/tests/agents/base/test_litellm_base.py
+++ b/tests/agents/base/test_litellm_base.py
@@ -49,93 +49,16 @@ class TestLiteLLMInstructorBaseAgent:
         assert agent.trim_ratio == 0.75
         assert agent.enable_trimming is True
 
-    @patch("akd.agents._base.trim_messages")
+    @pytest.mark.asyncio
+    @patch("akd._base.memory.trim_messages")
     @patch("instructor.from_litellm")
-    async def test_message_trimming_enabled(
+    async def test_full_arun_workflow(
         self,
         mock_instructor: MagicMock,
         mock_trim_messages: MagicMock,
         litellm_config,
     ):
-        """Test that message trimming is called when enabled."""
-        agent = TestLiteLLMAgent(config=litellm_config)
-
-        # Setup mocks
-        mock_client = AsyncMock()
-        mock_instructor.return_value = mock_client
-
-        mock_response = MagicMock()
-        mock_response.model_dump.return_value = {
-            "response": "Test response",
-            "confidence": 0.9,
-        }
-        mock_client.chat.completions.create.return_value = mock_response
-
-        # Mock trim_messages to return the same messages (simulate no trimming needed)
-        test_messages = [{"role": "user", "content": "test"}]
-        mock_trim_messages.return_value = test_messages
-
-        # Re-initialize agent to use mocked instructor
-        agent.client = mock_instructor.return_value
-
-        # Call the method
-        result = await agent.get_response_async(test_messages)
-
-        # Verify trim_messages was called with correct parameters
-        mock_trim_messages.assert_called_once_with(
-            test_messages,
-            model=agent.model_name,
-            max_tokens=agent.max_tokens,
-            trim_ratio=agent.trim_ratio,
-        )
-
-        # Verify the response
-        assert result.response == "Test response"
-        assert result.confidence == 0.9
-
-    @patch("instructor.from_litellm")
-    async def test_message_trimming_disabled(
-        self,
-        mock_instructor: MagicMock,
-        litellm_config,
-    ):
-        """Test that message trimming is skipped when disabled."""
-        # Create config with trimming disabled
-        config = create_config_with_overrides(litellm_config, enable_trimming=False)
-        agent = TestLiteLLMAgent(config=config)
-
-        # Setup mocks
-        mock_client = AsyncMock()
-        mock_instructor.return_value = mock_client
-
-        mock_response = MagicMock()
-        mock_response.model_dump.return_value = {
-            "response": "Test response",
-            "confidence": 0.9,
-        }
-        mock_client.chat.completions.create.return_value = mock_response
-
-        agent.client = mock_instructor.return_value
-
-        test_messages = [{"role": "user", "content": "test"}]
-
-        with patch("akd.agents._base.trim_messages") as mock_trim_messages:
-            result = await agent.get_response_async(test_messages)
-
-            # Verify trim_messages was NOT called
-            mock_trim_messages.assert_not_called()
-
-            # Verify the response
-            assert result.response == "Test response"
-            assert result.confidence == 0.9
-
-    @patch("instructor.from_litellm")
-    async def test_full_arun_workflow(
-        self,
-        mock_instructor: MagicMock,
-        litellm_config,
-    ):
-        """Test the complete _arun workflow with message trimming."""
+        """Test the complete _arun workflow."""
         agent = TestLiteLLMAgent(config=litellm_config)
 
         # Setup mocks
@@ -147,9 +70,17 @@ class TestLiteLLMInstructorBaseAgent:
             "response": "Processed query: test query",
             "confidence": 0.95,
         }
-        mock_client.chat.completions.create.return_value = mock_response
+        # create_with_completion returns (response, completion) tuple
+        mock_completion = MagicMock()
+        mock_completion.usage = None
+        mock_client.chat.completions.create_with_completion = AsyncMock(
+            return_value=(mock_response, mock_completion),
+        )
 
-        agent.client = mock_instructor.return_value
+        agent.client = mock_client
+
+        # Mock trim_messages to pass through
+        mock_trim_messages.side_effect = lambda messages, **kwargs: messages
 
         # Create input
         test_input = LiteLLMTestInputSchema(
@@ -157,20 +88,13 @@ class TestLiteLLMInstructorBaseAgent:
             context="test context",
         )
 
-        with patch("akd.agents._base.trim_messages") as mock_trim_messages:
-            # Mock trim_messages to return shortened messages
-            mock_trim_messages.side_effect = lambda messages, **kwargs: messages[:1]  # Keep only first message
+        # Run the agent
+        result = await agent.arun(test_input)
 
-            # Run the agent
-            result = await agent.arun(test_input)
-
-            # Verify result
-            assert isinstance(result, LiteLLMTestOutputSchema)
-            assert result.response == "Processed query: test query"
-            assert result.confidence == 0.95
-
-            # Verify trim_messages was called
-            mock_trim_messages.assert_called()
+        # Verify result
+        assert isinstance(result, LiteLLMTestOutputSchema)
+        assert result.response == "Processed query: test query"
+        assert result.confidence == 0.95
 
     def test_backward_compatibility_with_instructor_base_agent(self, litellm_config):
         """Test that LiteLLMInstructorBaseAgent maintains compatibility with InstructorBaseAgent."""
@@ -211,65 +135,6 @@ class TestLiteLLMInstructorBaseAgent:
         assert agent.max_tokens == 25000
         assert agent.trim_ratio == 0.6
         assert agent.enable_trimming is False
-
-    @patch("instructor.from_litellm")
-    async def test_large_context_handling(
-        self,
-        mock_instructor: MagicMock,
-        litellm_config,
-    ):
-        """Test that large contexts are properly handled with trimming."""
-        agent = TestLiteLLMAgent(config=litellm_config)
-
-        # Setup mocks
-        mock_client = AsyncMock()
-        mock_instructor.return_value = mock_client
-
-        mock_response = MagicMock()
-        mock_response.model_dump.return_value = {
-            "response": "Handled large context",
-            "confidence": 0.8,
-        }
-        mock_client.chat.completions.create.return_value = mock_response
-
-        agent.client = mock_instructor.return_value
-
-        # Create large message history (simulate the original token overflow scenario)
-        large_messages = []
-        for i in range(100):
-            large_messages.append(
-                {
-                    "role": "user",
-                    "content": f"This is a very long message {i} " + "x" * 1000,
-                },
-            )
-            large_messages.append(
-                {
-                    "role": "assistant",
-                    "content": f"Response to message {i} " + "y" * 1000,
-                },
-            )
-
-        with patch("akd.agents._base.trim_messages") as mock_trim_messages:
-            # Simulate trimming to a reasonable size
-            mock_trim_messages.return_value = large_messages[:10]  # Keep only first 10 messages
-
-            result = await agent.get_response_async(large_messages)
-
-            # Verify trimming was called
-            mock_trim_messages.assert_called_once_with(
-                large_messages,
-                model=agent.model_name,
-                max_tokens=agent.max_tokens,
-                trim_ratio=agent.trim_ratio,
-            )
-
-            # Verify client was called with trimmed messages
-            mock_client.chat.completions.create.assert_called_once()
-            call_args = mock_client.chat.completions.create.call_args
-            assert len(call_args.kwargs["messages"]) == 10
-
-            assert result.response == "Handled large context"
 
     def test_memory_management_stateful(self, litellm_config):
         """Test memory management in stateful mode."""
@@ -321,47 +186,3 @@ class TestLiteLLMInstructorBaseAgent:
             assert agent.max_tokens == config_overrides["max_tokens"]
             assert agent.trim_ratio == config_overrides["trim_ratio"]
             assert agent.enable_trimming == config_overrides["enable_trimming"]
-
-    async def test_large_input_exception_when_trimming_disabled(self, litellm_config):
-        """Test that large input throws exception when trimming is disabled."""
-        # Create config with trimming disabled and very low token limit
-        config = create_config_with_overrides(
-            litellm_config,
-            enable_trimming=False,
-            max_tokens=100,
-        )
-        agent = TestLiteLLMAgent(config=config)
-
-        # Create very large input that will exceed token limits
-        large_input = LiteLLMTestInputSchema(
-            query="love " * 1000000,
-            context="test context",
-        )
-
-        # Should throw exception due to token limit exceeded
-        with pytest.raises(Exception):
-            await agent.arun(large_input)
-
-    async def test_large_input_success_when_trimming_enabled(self, litellm_config):
-        """Test that large input succeeds when trimming is enabled."""
-        # Create config with trimming enabled and same low token limit
-        config = create_config_with_overrides(
-            litellm_config,
-            enable_trimming=True,
-            max_tokens=100,
-        )
-        agent = TestLiteLLMAgent(config=config)
-
-        # Create same very large input
-        large_input = LiteLLMTestInputSchema(
-            query="love " * 1000000,
-            context="test context",
-        )
-
-        # Should succeed without throwing exception due to automatic trimming
-        result = await agent.arun(large_input)
-
-        # Verify we get a valid response
-        assert isinstance(result, LiteLLMTestOutputSchema)
-        assert hasattr(result, "response")
-        assert hasattr(result, "confidence")

--- a/tests/guardrails/test_granite_think.py
+++ b/tests/guardrails/test_granite_think.py
@@ -49,7 +49,24 @@ def is_ollama_available() -> bool:
     base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
     try:
         resp = httpx.get(f"{base_url}/api/tags", timeout=2.0)
+        print(resp.content)
         return resp.status_code == 200
+    except (httpx.RequestError, httpx.TimeoutException):
+        return False
+
+
+def is_granite_available() -> bool:
+    """Check if Ollama is running and has granite guardian models pulled.
+
+    Uses OLLAMA_BASE_URL env var if set, otherwise falls back to localhost:11434.
+    """
+    base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+    try:
+        resp = httpx.get(f"{base_url}/api/tags", timeout=2.0)
+        if resp.status_code != 200:
+            return False
+        models = [m.get("name", "") for m in resp.json().get("models", [])]
+        return any("granite" in model for model in models)
     except (httpx.RequestError, httpx.TimeoutException):
         return False
 
@@ -60,6 +77,10 @@ pytestmark = [
     pytest.mark.skipif(
         not is_ollama_available(),
         reason="Ollama not running — start with: ollama serve",
+    ),
+    pytest.mark.skipif(
+        not is_granite_available(),
+        reason="Granite models not available — ollama pull <model_id>",
     ),
 ]
 

--- a/tests/nodes/test_single_agent_node_template.py
+++ b/tests/nodes/test_single_agent_node_template.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import Field
 
 from akd._base import InputSchema, OutputSchema
-from akd.agents import InstructorBaseAgent
+from akd.agents import Agent
 from akd.nodes.states import GlobalState, NodeState
 from akd.nodes.templates import SingleAgentNodeTemplate
 
@@ -23,7 +23,7 @@ class TestAgentOutputSchema(OutputSchema):
 
 
 # Test agent
-class TestAgent(InstructorBaseAgent[TestAgentInputSchema, TestAgentOutputSchema]):
+class TestAgent(Agent[TestAgentInputSchema, TestAgentOutputSchema]):
     """Test agent for testing."""
 
     input_schema = TestAgentInputSchema

--- a/tests/tools/scrapers/test_crawl4ai_scraper.py
+++ b/tests/tools/scrapers/test_crawl4ai_scraper.py
@@ -122,18 +122,6 @@ class TestCrawl4AIScraperLocalMode:
         with pytest.raises(RuntimeError, match="Can't parse url with PDF"):
             await scraper.arun(params)
 
-    async def test_local_mode_without_playwright_fails(self):
-        """Test that scraper fails gracefully when Playwright is not installed."""
-        if is_playwright_installed():
-            pytest.skip("Playwright is installed - cannot test failure case")
-
-        config = Crawl4AIScraperConfig(use_docker=False)
-        scraper = Crawl4AIWebScraper(config)
-        params = ScraperToolInputSchema(url="https://example.com")
-
-        with pytest.raises(Exception):  # Should raise ImportError or similar
-            await scraper.arun(params)
-
 
 @pytest.mark.asyncio
 class TestCrawl4AIScraperDockerMode:


### PR DESCRIPTION
### Summary :memo:

This PR introduces a `RunUsage` data structure to track token consumption (input, output, and reasoning tokens) across agent executions. It also performs a significant refactor of the `BaseAgent` to centralize `RunContext` management, deprecate the legacy `InstructorBaseAgent` in favor of `LiteLLMInstructorBaseAgent`, and improve support for reasoning models.

### Details

1. **RunUsage Implementation**: Added `RunUsage` to `akd/_base/structures.py` to accumulate input/output tokens and request counts. Integrated this into `RunContext` so usage is tracked for the lifetime of a run.
2. **Context Management Refactor**: Abstracted `RunContext` creation into the upstream `arun`, `astream`, and `achat` methods. This ensures that a valid context (with usage tracking) is always attached to the output object.
3. **Agent Standardization**:
* Renamed/Deprecated `InstructorBaseAgent` in favor of `LiteLLMInstructorBaseAgent`.
* `Agent` is now an alias for `LiteLLMInstructorBaseAgent`.
* Added a deprecation warning for the old class name.


4. **Streaming & Reasoning**: Updated streaming logic (`_stream_llm_response` and `_run_tool_loop`) to support `ThinkingEvent` for reasoning models (e.g., o1, Claude) and properly track reasoning tokens.
5. **Usage Extraction**: Implemented `_extract_usage` to normalize and capture token usage details from LiteLLM responses.

### Bugfixes :bug:

* Fixed `achat` run context propagation.
* Fixed `granite` guardrail tests to properly skip if Ollama/Granite models are not available locally.
* Removed trimming-related tests that were redundant or inefficient.

```python
from akd.agents.query import QueryAgent, QueryAgentInputSchema

agent = QueryAgent()
output = await agent.arun(QueryAgentInputSchema(...))

print(output.run_context) # run context attachd to output at runtime | doesn't appear during serailization as well
```

### Checks

* [x] Tested Changes
* [ ] Stakeholder Approval