### PR TITLE
Bugfix enum serialization for generic Enums

### DIFF
--- a/akd/guardrails/providers/composite.py
+++ b/akd/guardrails/providers/composite.py
@@ -131,7 +131,7 @@ class CompositeGuardrail(GuardrailOperatorMixin, GuardrailProtocol):
                         "mode": self.mode.value,
                         "short_circuited": True,
                         "failed_at_index": len(executed_results) - 1,
-                        "result": result.model_dump(),
+                        "result": result.model_dump(mode="json"),
                     },
                 )
 
@@ -176,7 +176,7 @@ class CompositeGuardrail(GuardrailOperatorMixin, GuardrailProtocol):
             detected_risks=all_detected,
             risk_results=all_risk_results,
             provider=provider_str,
-            extra={"mode": self.mode.value, "sub_results": [r.model_dump() for r in results]},
+            extra={"mode": self.mode.value, "sub_results": [r.model_dump(mode="json") for r in results]},
         )
 
     def _merge_results_any(self, results: list[GuardrailOutput]) -> GuardrailOutput:
@@ -197,7 +197,7 @@ class CompositeGuardrail(GuardrailOperatorMixin, GuardrailProtocol):
             return GuardrailOutput(
                 detected_risks=[],
                 provider=provider_str,
-                extra={"mode": self.mode.value, "sub_results": [r.model_dump() for r in results]},
+                extra={"mode": self.mode.value, "sub_results": [r.model_dump(mode="json") for r in results]},
             )
 
         # All failed - merge all detected risks
@@ -211,5 +211,5 @@ class CompositeGuardrail(GuardrailOperatorMixin, GuardrailProtocol):
             detected_risks=all_detected,
             risk_results=all_risk_results,
             provider=provider_str,
-            extra={"mode": self.mode.value, "sub_results": [r.model_dump() for r in results]},
+            extra={"mode": self.mode.value, "sub_results": [r.model_dump(mode="json") for r in results]},
         )

--- a/akd/guardrails/providers/risk_agent.py
+++ b/akd/guardrails/providers/risk_agent.py
@@ -8,7 +8,7 @@ GuardrailInput/GuardrailOutput for unified interface with other guardrail provid
 import asyncio
 import re
 from collections.abc import Sequence
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from deepeval.metrics import DAGMetric
@@ -38,7 +38,7 @@ from akd.guardrails.categories._base import RiskCategory
 from akd.guardrails.categories.atlas import ScienceRiskCategory
 
 
-class CriterionImportance(Enum):
+class CriterionImportance(StrEnum):
     """Importance level for evaluation criteria."""
 
     LOW = "low"

--- a/akd/serializers.py
+++ b/akd/serializers.py
@@ -4,6 +4,7 @@ This module provides custom serializers that extend LangGraph's JsonPlusSerializ
 to handle Pydantic models and other complex objects properly.
 """
 
+from enum import Enum
 from typing import Any
 
 import numpy as np
@@ -30,9 +31,11 @@ class AKDSerializer(JsonPlusSerializer):
             # Convert NumPy arrays to lists for JSON serialization
             return obj.tolist()
         elif isinstance(obj, dict):
-            return {k: self._convert_pydantic_to_dict(v) for k, v in obj.items()}
+            return {(k.value if isinstance(k, Enum) else k): self._convert_pydantic_to_dict(v) for k, v in obj.items()}
         elif isinstance(obj, (list, tuple)):
             return [self._convert_pydantic_to_dict(item) for item in obj]
+        elif isinstance(obj, Enum):
+            return obj.value
         # elif isinstance(obj, NodeState):
         #     # Convert NodeState to a dictionary
         #     return {


### PR DESCRIPTION
Backend team mentioned that there was serailizaiton issue with CriterionIMportance in risk agent.

So, in this pr we:

- Use StrEnum whrever possible
- Use model_dump json mode during serailization in guardrails

---