### PR TITLE
Improve planner prompts and fix multi-agent input extraction

### DIFF
--- a/akd/configs/planner_prompts.py
+++ b/akd/configs/planner_prompts.py
@@ -73,7 +73,8 @@ WORKFLOW GENERATION STRATEGY:
 - After receiving user clarification → Complete all internal steps (agent selection, input specification, workflow construction) in SAME response
 - DO NOT narrate internal steps separately or ask user to "continue"/"go ahead" for internal processing
 - CRITICAL: If you say "I'll proceed" or "I'll create", you MUST include workflow_plan in THAT SAME response
-- Use reasonable defaults for minor details (time ranges, result limits)
+- DO NOT MODIFY DEFAULTS if they are already provided in the agent schema and the user does not override them. Use reasonable defaults for minor details (time ranges, result limits).
+- Adhere to safe value limits defined in the agent schema. For example, if an agent has top_k with a default, do not set unreasonable values unless the user explicitly requests it.
 
 DATA FLOW REQUIREMENTS:
 When suggesting agents, verify:

--- a/akd/configs/planner_prompts.py
+++ b/akd/configs/planner_prompts.py
@@ -10,31 +10,70 @@ comprehensive guidance for LLM-based workflow planning and input extraction.
 # ============================================================================
 
 WORKFLOW_PLANNER_SYSTEM_PROMPT_TEMPLATE = """IDENTITY and PURPOSE:
-You are an intelligent workflow planner for the AKD (Accelerated Knowledge Discovery) research framework. Your goal is to design scientifically sound, executable workflows with correct data flow between research agents.
+You are a friendly research assistant for the AKD (Accelerated Knowledge Discovery) framework. You help users build research workflows by selecting and configuring available agents.
+
+CONVERSATION STYLE:
+- Be conversational and natural. Match the user's energy — if they say "hi", greet them warmly and ask what they'd like to explore.
+- Keep messages concise. One short question at a time.
+- Users are typically researchers, scientists, or graduate students. They know their domain.
+
+ANTI-PATTERN — FORMULAIC RESPONSES:
+Do NOT ask the same question template for every topic. Each response should feel like a unique conversation, not a form. If you catch yourself generating "What kind of output do you want on [X] — research papers, datasets, code, or a gap analysis?" you are being formulaic. Rephrase based on the specific topic and what the user said.
+
+CRITICAL CONSTRAINT — AGENT-GROUNDED BEHAVIOR:
+You are NOT a domain expert. Do NOT ask domain-specific deep-dive questions.
+Every question you ask MUST directly help you:
+1. Select which agent(s) to use from the available agents list
+2. Configure a specific agent input field
+3. Clarify the user's goal just enough to write a query for an agent
+
+BAD (domain-expert — NEVER do this):
+- "Are you interested in seismological patterns or crustal deformation?"
+- "Do you want eruption forecasting, hazards, or magma dynamics?"
+- Suggesting domain sub-topics, technical terms, or research angles the user didn't mention
+
+GOOD (agent-capability-grounded — vary your phrasing each time):
+- "What topic are you researching?" (when no topic given)
+- Ask what kind of help they need based on context — papers, datasets, code — but phrase it naturally, not as a checklist
+- "Any specific focus, time period, or region — or should I search broadly?"
+
+IMPORTANT: Do NOT recite the same "papers, datasets, code, or gap analysis?" menu for every topic. Adapt your question to the user's words. Examples of natural variation:
+- "I can look up recent research on [topic] or search for relevant datasets — what would be most useful?"
+- "Are you looking for published papers on [topic], or more on the data/tools side?"
+- "Want me to find what the literature says about [topic]?"
+
+The user's topic goes into the agent's query field as-is. Do NOT refine, narrow, or suggest sub-topics — the research agent will handle clarification and deep-dive during execution. Your job is only to pick the right agent(s) and pass the user's query through.
 
 CONVERSATION PHASES:
-You will receive "Current phase: <phase_name>" with each user message. Adapt your behavior accordingly:
-- INITIAL_REQUIREMENTS: Understand research goal, ask 1-2 questions only if genuinely ambiguous
-- GOAL_CLARIFICATION: Refine objectives based on responses
-- AGENT_SELECTION: Choose agents with verified data flow compatibility
-- IO_SPECIFICATION: Define inputs, prefer auto-mapping over manual specification
-- WORKFLOW_CONSTRUCTION: Build execution plan with dependencies
-- VALIDATION: Verify completeness and correctness
-- FINALIZATION: Generate workflow_plan with ready_to_generate=True
+You receive "Current phase: <phase_name>" with each message. Follow these behaviors:
 
-Progress through phases naturally. Skip unnecessary phases for clear requests.
+- INITIAL_REQUIREMENTS: If the user gives a clear research request, skip to building the workflow. If they give a greeting or vague message, respond conversationally and ask what they'd like to research. Do NOT present structured options or list capabilities until you know their topic.
+
+- GOAL_CLARIFICATION: Help the user articulate what they need. Ask naturally based on their topic — don't recite a fixed menu of output types. If they said "explore what's out there on methane", a natural follow-up is "Are you looking for published research, datasets to work with, or both?" — adapted to their words, not a template.
+
+- AGENT_SELECTION: Select agents from the available list. If only one agent is needed, use just one. If multiple agents are needed, chain them with correct data flow. Explain your selection using capability descriptions, never agent IDs.
+
+- IO_SPECIFICATION: Determine input values. Use the user's own words for query/search fields. For fields with allowed values, either ask or use defaults. Do not invent inputs the user didn't mention.
+
+- WORKFLOW_CONSTRUCTION: Build the execution plan with dependencies between agents.
+
+- VALIDATION: Verify completeness.
+
+- FINALIZATION: Present the workflow_plan.
+
+Progress naturally. For clear requests, skip directly to FINALIZATION in one response.
+IMPORTANT: If one agent can solve the user's request, use only one agent. Do not add agents unnecessarily.
 
 AVAILABLE AGENTS:
 {available_agents}
 
 WORKFLOW GENERATION STRATEGY:
-- Clear requests → Generate complete workflow in SINGLE response with ready_to_generate=True
-- Ambiguous requests → Ask 1-2 clarifying questions, then generate complete workflow with ready_to_generate=True in next response
+- Clear requests → Generate complete workflow in SINGLE response
+- Ambiguous requests → Ask 1-2 clarifying questions, then generate complete workflow in next response
 - After receiving user clarification → Complete all internal steps (agent selection, input specification, workflow construction) in SAME response
 - DO NOT narrate internal steps separately or ask user to "continue"/"go ahead" for internal processing
-- CRITICAL: If you say "I'll proceed" or "I'll create", you MUST include workflow_plan and set ready_to_generate=True in THAT SAME response
-- Only set ready_to_generate=False when asking genuine clarifying questions
-- Use reasonable defaults for minor details (time ranges: recent/5 years, result limits: 20-50)
+- CRITICAL: If you say "I'll proceed" or "I'll create", you MUST include workflow_plan in THAT SAME response
+- Use reasonable defaults for minor details (time ranges, result limits)
 
 DATA FLOW REQUIREMENTS:
 When suggesting agents, verify:
@@ -54,63 +93,20 @@ When providing workflow_plan, include:
 - workflow_description: Clear summary in user-friendly language
 - research_goal: User's objective
 - suggested_agents: List with exact agent_id, required_inputs, expected_outputs, depends_on
-- workflow_steps: High-level steps in plain language (NO technical field names or agent IDs)
-- Set ready_to_generate=True
+- workflow_steps: One step per agent in the workflow. Each step describes what that agent will do. Do NOT include manual user steps, post-processing advice, or actions that no agent performs. If the workflow has 1 agent, there should be 1 step. If 2 agents, 2 steps.
 
 OUTPUT INSTRUCTIONS - USER COMMUNICATION:
 CRITICAL RULES FOR USER-FACING MESSAGES:
 1. NEVER show: "agent_id", "confidence", "required_inputs", "expected_outputs", "depends_on"
 2. NEVER ask user to "continue" or "go ahead" after saying "I will proceed"
 3. ALWAYS complete workflow plan in same response after receiving user's clarification
-4. Set ready_to_generate based on whether you're asking a question or saying the workflow is ready
-5. Use plain language: "search", "analyze", "compare" NOT "deep_search agent", "gap_analysis"
+4. Use plain language describing capabilities, NEVER expose agent IDs or technical field names to the user
+5. Do not tell the user to type 'generate' — workflow generation is automatic
 
-WHEN TO SET ready_to_generate=True:
-- You have filled workflow_plan with suggested_agents, workflow_steps, research_goal
-- You have described the workflow to the user
-- You are NOT asking a clarifying question
-- User has confirmed the plan (or no confirmation needed)
-- Say "ready and will be generated" or "workflow is complete" in your message
-- DO NOT say "Type 'generate'" - workflow generation is automatic
-
-WHEN TO SET ready_to_generate=False (even with workflow_plan):
-- You present a plan but want user confirmation: "Here's the plan. Does this look good?"
-- You need clarification on plan details: "I've drafted this workflow, but should I use X or Y?"
-- You're offering alternatives: "Here are two possible approaches. Which do you prefer?"
-- You detected potential issues: "I can create this plan, but there's a concern about..."
-
-GOOD EXAMPLE (complete in one response):
-User: "I want methodologies"
-Assistant: "I'll create a workflow to:
-1. Search for papers on carbon recovery methodologies from 2007-2020
-2. Analyze gaps in regional data affecting IPCC guidelines
-
-Workflow is ready and will be generated."
-[Sets: ready_to_generate=True, workflow_plan fully filled with agents and steps]
-
-BAD EXAMPLE (what NOT to do):
-Assistant: "I will proceed to generate the workflow plan..."
-[Sets: ready_to_generate=False, workflow_plan=None]
-[Waits for user to say "okay" - WRONG! Should have generated in same response]
-
-GOOD EXAMPLE 2 (asking for confirmation):
-User: "Find papers on drug discovery"
-Assistant: "I can create a workflow to:
-1. Search for recent papers on drug discovery
-2. Analyze research gaps
-
-Does this approach work for you, or would you like me to adjust it?"
-[Sets: ready_to_generate=False, workflow_plan filled, question set]
-[Correct! Asking for confirmation, so wait for user response]
-
-BAD EXAMPLE (contradiction - auto-corrected by validator):
-Assistant: "Workflow is ready and will be generated."
-[Sets: ready_to_generate=False, workflow_plan filled, question=None]
-[Wrong! Message says "ready" but flag is False - validator will auto-correct to True]
-
-BAD EXAMPLE 2 (outdated messaging):
-Assistant: "Workflow is ready. Type 'generate' to create the file."
-[Wrong messaging! Don't tell user to type 'generate' - generation is automatic]"""
+WORKFLOW COMPLETION:
+- If you are NOT asking a question: include workflow_plan in your response
+- If you ARE asking a question: set the question field, do not include workflow_plan yet
+- Do not narrate internal steps or say "I'll proceed" without actually including the plan"""
 
 
 # ============================================================================
@@ -141,12 +137,11 @@ Dependencies: {dependencies}
 Expected Outputs: {expected_outputs}
 
 EXTRACTION STRATEGY:
-- Use ALL available context (conversation, workflow plan, agent selection reasoning)
-- For query/search fields: synthesize from refined research goal and conversation
-- For category fields: infer from topic keywords in context
+- Use the conversation, workflow plan, and agent selection reasoning to determine inputs
+- CRITICAL FOR QUERY FIELDS: The "Selection Reasoning" tells you WHY this agent was chosen and what specific part of the user's request it handles. Extract that portion into the query. If the user's request mentions multiple topics for different agents, each agent's query must contain only its own topic — do NOT combine unrelated topics. However, shared qualifiers (region, time period, scope) that apply to the whole request should be included in every agent's query.
+- For category fields: infer from topic keywords relevant to this agent's purpose
 - For limits/counts: use mentioned values or defaults (20-50)
-- Consider workflow position and downstream usage when determining input quality
-- Be specific and context-appropriate
+- Keep queries concise and focused — use the user's own words where possible, do not pad with extra domain terms the user did not mention
 
 CRITICAL - AUTO-MAPPED FIELDS:
 - DO NOT extract values for fields that come from previous agent outputs

--- a/akd/planner/field_mapping_registry.py
+++ b/akd/planner/field_mapping_registry.py
@@ -122,40 +122,48 @@ class FieldMappingRegistry:
         self,
         source_agent_id: str,
         target_agent_id: str,
+        min_confidence: float = 0.0,
     ) -> dict[str, str] | None:
         """
         Get field mapping for source->target agent pair.
 
         Priority:
-        1. Explicit mappings (highest trust)
-        2. LLM-generated mappings (if user approved)
+        1. Explicit mappings (highest trust, always returned regardless of min_confidence)
+        2. LLM-generated mappings (if user approved AND confidence >= min_confidence)
 
         Args:
             source_agent_id: Source agent identifier
             target_agent_id: Target agent identifier
+            min_confidence: Minimum confidence threshold for LLM-generated mappings.
+                Explicit mappings are always returned regardless of this value.
 
         Returns:
             Dict mapping target_field_name -> source_field_name, or None
         """
         key = f"{source_agent_id}->{target_agent_id}"
 
-        # Priority 1: Explicit mappings
+        # Priority 1: Explicit mappings (always trusted)
         if key in self.explicit_mappings:
             logger.debug(f"Using explicit mapping for {key}")
             return self.explicit_mappings[key]
 
-        # Priority 2: LLM-generated (if approved)
+        # Priority 2: LLM-generated (if approved AND above confidence threshold)
         if key in self.llm_mappings:
             entry = self.llm_mappings[key]
-            if entry.user_approved:
+            if not entry.user_approved:
+                logger.debug(
+                    f"LLM mapping exists for {key} but not user-approved, skipping",
+                )
+            elif entry.confidence < min_confidence:
+                logger.debug(
+                    f"LLM mapping exists for {key} but confidence {entry.confidence:.2f} "
+                    f"< threshold {min_confidence:.2f}, skipping",
+                )
+            else:
                 logger.debug(
                     f"Using LLM-generated mapping for {key} (confidence: {entry.confidence:.2f})",
                 )
                 return entry.mapping
-            else:
-                logger.debug(
-                    f"LLM mapping exists for {key} but not user-approved, skipping",
-                )
 
         return None
 

--- a/akd/planner/llm_planner.py
+++ b/akd/planner/llm_planner.py
@@ -171,25 +171,29 @@ class LLMWorkflowPlanner(LiteLLMInstructorBaseAgent[PlannerInput, PlannerRespons
 
     def _get_planner_system_prompt(self) -> str:
         """Get the system prompt for the planner using optimized template from config."""
-        # Build available agents section dynamically from registry
+        # Build available agents section dynamically from registry with full field info
         agents_info = []
         for agent in self.registry.get_enabled_agents():
-            agent_desc = f"- {agent.agent_id}: {agent.description}"
+            lines = [f"### {agent.agent_id}: {agent.description}"]
 
-            # Add input/output info
-            inputs = [f.name for f in agent.input_schema.fields if f.required]
-            outputs = [f.name for f in agent.output_schema.fields]
+            # Input fields with descriptions, types, and allowed values
+            lines.append("  Inputs:")
+            for f in agent.input_schema.fields:
+                req = "REQUIRED" if f.required else f"optional, default={f.default}"
+                field_line = f"    - {f.name} ({f.type}, {req}): {f.description}"
+                if f.allowed_values:
+                    field_line += f" [values: {', '.join(f.allowed_values)}]"
+                lines.append(field_line)
 
-            if inputs:
-                agent_desc += f"\n  Required inputs: {', '.join(inputs)}"
-            if outputs:
-                agent_desc += f"\n  Outputs: {', '.join(outputs)}"
+            # Output fields with descriptions and types
+            lines.append("  Outputs:")
+            for f in agent.output_schema.fields:
+                lines.append(f"    - {f.name} ({f.type}): {f.description}")
 
-            agents_info.append(agent_desc)
+            agents_info.append("\n".join(lines))
 
-        available_agents_text = "\n".join(agents_info) if agents_info else "No agents available"
+        available_agents_text = "\n\n".join(agents_info) if agents_info else "No agents available"
 
-        # Use optimized template from config
         return WORKFLOW_PLANNER_SYSTEM_PROMPT_TEMPLATE.format(available_agents=available_agents_text)
 
     def reset_conversation(self) -> None:
@@ -496,8 +500,13 @@ class InteractivePlannerSession:
 
         Uses conversation history, workflow plan, and agent selection reasoning
         to extract context-aware input values.
+
+        Keys the result by node_id (e.g., "cmr_care_agent_1") to support
+        multiple nodes of the same agent type with different inputs.
         """
         filled_inputs = {}
+        # Track counts to generate node IDs matching WorkflowBuilder.build()
+        agent_counts: dict[str, int] = {}
 
         for agent_suggestion in plan.suggested_agents:
             agent_id = agent_suggestion.agent_id
@@ -507,6 +516,11 @@ class InteractivePlannerSession:
                 logger.warning(f"Agent {agent_id} not in registry, skipping")
                 continue
 
+            # Generate node_id matching WorkflowBuilder.build() logic
+            count = agent_counts.get(agent_id, 1)
+            node_id = f"{agent_id}_{count}"
+            agent_counts[agent_id] = count + 1
+
             try:
                 inputs = await self._fill_inputs_with_llm(
                     agent,
@@ -514,12 +528,12 @@ class InteractivePlannerSession:
                     agent_suggestion,  # Pass agent suggestion for context
                     plan,  # Pass full workflow plan for research goal
                 )
-                filled_inputs[agent_id] = inputs
+                filled_inputs[node_id] = inputs
             except Exception as e:
-                logger.warning(f"Failed to fill inputs for {agent_id}: {e}")
+                logger.warning(f"Failed to fill inputs for {node_id}: {e}")
                 # Fallback to rule-based
                 inputs = self._fallback_input_extraction(agent, agent_id)
-                filled_inputs[agent_id] = inputs
+                filled_inputs[node_id] = inputs
 
         return filled_inputs
 
@@ -607,8 +621,11 @@ class InteractivePlannerSession:
             auto_mapped_fields = []
             if current_idx > 0 and workflow_plan:
                 prev_agent_id = agent_names[current_idx - 1]
-                # Get mapping from registry (via planner object)
-                mapping = self.planner.mapping_registry.get_mapping(prev_agent_id, agent_id)
+                # Get mapping from registry — only trust high-confidence mappings
+                confidence_threshold = self.planner.planner_config.field_mapping_confidence_threshold
+                mapping = self.planner.mapping_registry.get_mapping(
+                    prev_agent_id, agent_id, min_confidence=confidence_threshold
+                )
                 if mapping:
                     auto_mapped_fields = list(mapping.keys())
                 else:

--- a/akd/planner/llm_planner.py
+++ b/akd/planner/llm_planner.py
@@ -174,7 +174,7 @@ class LLMWorkflowPlanner(LiteLLMInstructorBaseAgent[PlannerInput, PlannerRespons
         # Build available agents section dynamically from registry with full field info
         agents_info = []
         for agent in self.registry.get_enabled_agents():
-            lines = [f"### {agent.agent_id}: {agent.description}"]
+            lines = [f"### {agent.agent_id}: {agent.description}\n"]
 
             # Input fields with descriptions, types, and allowed values
             lines.append("  Inputs:")

--- a/akd/planner/workflow_builder.py
+++ b/akd/planner/workflow_builder.py
@@ -141,9 +141,11 @@ class WorkflowBuilder:
         for field in agent.input_schema.fields:
             if field.required and field.name not in inputs:
                 # Get field mapping from registry (uses agent types, not node IDs)
+                # Only use mappings with confidence >= 0.8 to avoid bad auto-approved mappings
                 mapping = self.mapping_registry.get_mapping(
                     prev_agent_id,
                     agent_id,
+                    min_confidence=0.8,
                 )
 
                 if mapping and field.name in mapping:
@@ -234,8 +236,8 @@ class WorkflowBuilder:
             agent_counts[agent_id] = count + 1
             node_ids.append(node_id)
 
-            # Get filled inputs for this agent
-            inputs = filled_inputs.get(agent_id, {})
+            # Get filled inputs for this agent (try node_id first, then agent_id for backward compat)
+            inputs = filled_inputs.get(node_id, filled_inputs.get(agent_id, {}))
 
             # Build io_map for runtime data flow from previous agent
             io_map = {}

--- a/scripts/demo_planner.py
+++ b/scripts/demo_planner.py
@@ -24,12 +24,66 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from akd.planner.llm_planner import create_planner, quick_plan
 from akd.planner.registry import get_agent_registry
+from akd.utils import to_snake_case
 
 app = typer.Typer(help="Demo CLI for the AKD LLM Workflow Planner")
 console = Console()
 
 # Global flag for non-interactive mode
 NON_INTERACTIVE = False
+
+
+def _register_ext_agents():
+    """Register akd-ext agents and disable base registry agents.
+
+    Only akd-ext agents (CMRCareAgent, CodeSearchCareAgent) should be used
+    by the planner. Base agents (deep_search, gap_analysis, code_search) are
+    disabled so the planner doesn't see them.
+
+    Disabling happens only after akd-ext imports succeed to avoid leaving
+    the registry empty if akd-ext is not installed.
+    """
+    registry = get_agent_registry()
+
+    # Register akd-ext agents first — only disable base agents if this succeeds
+    try:
+        from akd_ext.agents.cmr_care import CMRCareAgent
+        from akd_ext.agents.code_search_care import CodeSearchCareAgent
+        from akd_ext.agents.gap import GapAgent as ExtGapAgent
+        from akd_ext.agents.closed_loop_cm1 import (
+            CapabilityFeasibilityMapperAgent,
+            WorkflowSpecBuilderAgent,
+            ExperimentImplementationAgent,
+            InterpretationPaperAssemblyAgent,
+        )
+
+        ext_agents = [
+            CMRCareAgent,
+            CodeSearchCareAgent,
+            ExtGapAgent,
+            CapabilityFeasibilityMapperAgent,
+            WorkflowSpecBuilderAgent,
+            ExperimentImplementationAgent,
+            InterpretationPaperAssemblyAgent,
+        ]
+
+        for agent_cls in ext_agents:
+            agent_id = to_snake_case(agent_cls.__name__)
+            if not registry.get_agent(agent_id):
+                registry.register_agent(agent_cls)
+                logger.info(f"Registered {agent_cls.__name__} from akd-ext")
+
+        # Disable base registry agents now that akd-ext agents are available
+        for agent_id in ["deep_search", "gap_analysis", "code_search"]:
+            agent = registry.get_agent(agent_id)
+            if agent and agent.enabled:
+                registry.update_agent(agent_id, enabled=False)
+                logger.info(f"Disabled base agent: {agent_id}")
+
+    except ImportError:
+        logger.debug("akd-ext not installed, keeping base agents enabled")
+    except Exception as e:
+        logger.warning(f"Failed to register akd-ext agents: {e}")
 
 
 def print_header():
@@ -79,6 +133,7 @@ def print_agent_registry():
 async def interactive_planning_session():
     """Run an interactive planning session."""
     print_header()
+    _register_ext_agents()
 
     # Show available agents
     console.print("\n[bold]Available Agents:[/bold]")
@@ -210,6 +265,8 @@ async def automated_planning_session(
         console.print(f"Initial Request: [green]{initial_request}[/green]")
         console.print(f"Hardcoded Responses: [dim]{hardcoded_responses}[/dim]")
         console.print(f"Max Turns: {max_turns}\n")
+
+    _register_ext_agents()
 
     try:
         # Create planner and start session
@@ -456,6 +513,7 @@ def quick(
     """Quick workflow generation for a research goal."""
 
     async def _quick_plan():
+        _register_ext_agents()
         try:
             if not non_interactive:
                 console.print(f"[blue]Planning workflow for: {goal}[/blue]")

--- a/tests/planner/test_llm_planner.py
+++ b/tests/planner/test_llm_planner.py
@@ -53,7 +53,7 @@ class TestLLMWorkflowPlanner:
         planner = LLMWorkflowPlanner(registry=mock_registry)
         system_prompt = planner._get_planner_system_prompt()
 
-        assert "workflow planner" in system_prompt.lower()
+        assert "research assistant" in system_prompt.lower()
         assert "available agents" in system_prompt.lower()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
### What changes I have done

- Rewrote planner system prompt to stop domain-expert behavior (no more scientific domain expertise questions)
- Planner now has natural, varied conversations instead of repeating "papers, datasets, code, or gap analysis?" for every topic
- Fixed bug where multiple nodes of the same agent type (e.g., two dataset searches) got identical query values
- Enriched agent info in system prompt with full field descriptions, types, and allowed values
- Input extraction now correctly scopes queries per-agent, shared qualifiers (region, time period) are preserved, but topics don't get messed up across agents
- Demo script loads akd-ext agents and disables base registry agents


### How I made the changes

- `akd/configs/planner_prompts.py`: Rewrote planner system prompt (conversation style, anti-formulaic, agent-grounded behavior) and input extraction prompt (per-agent query scoping)
- `akd/planner/llm_planner.py`: Enriched _get_planner_system_prompt() with full field info; fixed _fill_all_agent_inputs() to key by node_id instead of agent_id
- `akd/planner/workflow_builder.py`: Added confidence threshold to field mapping lookups
- `akd/planner/field_mapping_registry.py`: Added min_confidence parameter to get_mapping()
- `scripts/demo_planner.py`: Registers akd-ext agents, disables base agents


### How to test
`uv run python scripts/demo_planner.py interactive`