### PR TITLE
fix: Read agent descriptions from config_schema

### DIFF
--- a/akd/planner/registry.py
+++ b/akd/planner/registry.py
@@ -230,19 +230,9 @@ class AgentRegistry:
                         logger.warning(f"Agent {agent_id} has empty schemas, skipping")
                         continue
 
-                # Get description from config_schema.description field, fall back to docstring
-                description = None
-                config_schema = getattr(agent_class, "config_schema", None)
-                if config_schema:
-                    config_defaults = config_schema.model_fields.get("description")
-                    if config_defaults and config_defaults.default:
-                        description = config_defaults.default.strip()
-                if not description:
-                    description = agent_class.__doc__
-                    if description:
-                        description = description.strip().split("\n")[0]
-                if not description:
-                    description = f"Agent for {agent_id.replace('_', ' ')}"
+                # Get description: config default → docstring → auto-generated
+                config_desc = getattr(getattr(agent_class, "config_schema", None), "model_fields", {}).get("description")
+                description = " ".join(((config_desc.default if config_desc and config_desc.default else None) or agent_class.__doc__ or f"Agent for {agent_id.replace('_', ' ')}").split())
 
                 discovered[agent_id] = AgentEntry(
                     agent_id=agent_id,
@@ -445,19 +435,9 @@ class AgentRegistry:
         input_schema = self._extract_schema(getattr(agent_class, "input_schema", None))
         output_schema = self._extract_schema(getattr(agent_class, "output_schema", None))
 
-        # Get description from config_schema.description field, fall back to docstring
-        description = None
-        config_schema = getattr(agent_class, "config_schema", None)
-        if config_schema:
-            config_defaults = config_schema.model_fields.get("description")
-            if config_defaults and config_defaults.default:
-                description = config_defaults.default.strip()
-        if not description:
-            description = agent_class.__doc__
-            if description:
-                description = description.strip().split("\n")[0]
-        if not description:
-            description = f"Agent for {agent_id.replace('_', ' ')}"
+        # Get description: config default → docstring → auto-generated
+        config_desc = getattr(getattr(agent_class, "config_schema", None), "model_fields", {}).get("description")
+        description = ((config_desc.default if config_desc and config_desc.default else None) or agent_class.__doc__ or f"Agent for {agent_id.replace('_', ' ')}").strip()
 
         # Create entry
         entry = AgentEntry(

--- a/akd/planner/registry.py
+++ b/akd/planner/registry.py
@@ -230,11 +230,18 @@ class AgentRegistry:
                         logger.warning(f"Agent {agent_id} has empty schemas, skipping")
                         continue
 
-                # Get description from docstring
-                description = agent_class.__doc__
-                if description:
-                    description = description.strip().split("\n")[0]
-                else:
+                # Get description from config_schema.description field, fall back to docstring
+                description = None
+                config_schema = getattr(agent_class, "config_schema", None)
+                if config_schema:
+                    config_defaults = config_schema.model_fields.get("description")
+                    if config_defaults and config_defaults.default:
+                        description = config_defaults.default.strip()
+                if not description:
+                    description = agent_class.__doc__
+                    if description:
+                        description = description.strip().split("\n")[0]
+                if not description:
                     description = f"Agent for {agent_id.replace('_', ' ')}"
 
                 discovered[agent_id] = AgentEntry(
@@ -438,11 +445,18 @@ class AgentRegistry:
         input_schema = self._extract_schema(getattr(agent_class, "input_schema", None))
         output_schema = self._extract_schema(getattr(agent_class, "output_schema", None))
 
-        # Get description from docstring
-        description = agent_class.__doc__
-        if description:
-            description = description.strip().split("\n")[0]
-        else:
+        # Get description from config_schema.description field, fall back to docstring
+        description = None
+        config_schema = getattr(agent_class, "config_schema", None)
+        if config_schema:
+            config_defaults = config_schema.model_fields.get("description")
+            if config_defaults and config_defaults.default:
+                description = config_defaults.default.strip()
+        if not description:
+            description = agent_class.__doc__
+            if description:
+                description = description.strip().split("\n")[0]
+        if not description:
             description = f"Agent for {agent_id.replace('_', ' ')}"
 
         # Create entry


### PR DESCRIPTION
### Summary:

- Registry now reads agent descriptions from config_schema.description field instead of class __doc__, giving the planner richer context about agent capabilities
- Falls back to docstring → auto-generated if config field is absent
- Updated both register_agent() and _discover_agents() paths