### PR TITLE
Fix confidence parsing in MultiRiskGraniteGuardianTool

### DIFF
--- a/akd/guardrails/providers/granite_guardian.py
+++ b/akd/guardrails/providers/granite_guardian.py
@@ -337,9 +337,9 @@ class MultiRiskGraniteGuardianToolConfig(GraniteGuardianBaseConfig):
         """Auto-disable think as multi-risk models don't support it."""
         if self.think:
             logger.warning(
-                f"[MultiRiskGraniteGuardianToolConfig] Multi-risk models do not support think=True. "
-                f"Chain-of-thought reasoning is not available in multi-harm detection mode. "
-                f"Automatically disabling think parameter.",
+                "[MultiRiskGraniteGuardianToolConfig] Multi-risk models do not support think=True. "
+                "Chain-of-thought reasoning is not available in multi-harm detection mode. "
+                "Automatically disabling think parameter.",
             )
             self.think = False
         return self
@@ -475,10 +475,10 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
                     f"--- RESPONSE START ---\n{content}\n--- RESPONSE END ---",
                 )
 
-            # Parse: "Yes\n<confidence> High " or "No\n<confidence> Low "
+            # Parse: "Yes\n<confidence> High " or "No\n<confidence> Not Harmful "
             label = "yes" if content.strip().lower().startswith("yes") else "no"
-            confidence_match = re.search(r"<confidence>\s*(\w+)", content)
-            confidence = confidence_match.group(1) if confidence_match else ""
+            confidence_match = re.search(r"<confidence>\s*(.+?)(?:</confidence>|\s*$)", content)
+            confidence = confidence_match.group(1).strip() if confidence_match else ""
 
             if self.debug:
                 logger.debug(


### PR DESCRIPTION
### What

Fix regex bug in `_call_harm_detection` where multi-word confidence values were incorrectly parsed — `"Not Harmful"` was truncated to `"Not"`.

### Why

The regex `<confidence>\s*(\w+)` only captures a single word. The multi-harm model returns `"Not Harmful"` (two words) for safe content, so the parsed confidence was wrong. This would break any downstream logic that checks the confidence value.

### How

- Updated regex from `(\w+)` to `(.+?)(?:</confidence>|\s*$)` to capture the full text between `<confidence>` tags
- Added `.strip()` to clean up whitespace

### How to test

Verified with live Ollama + `granite-guardian-3.2-5b-multi-harm-GGUF`:
- Safe content: `"Not Harmful"` (was `"Not"`)
- Harmful content: `"High"` (unchanged)