### PR TITLE
docs: enhance README and add CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,12 +42,24 @@ Examples: `feature/conflict-agent`, `bugfix/granite-conf-level`, `enhance/baseag
 
 ## Commit Messages
 
-Use lowercase `type: description` format. Keep the first line under 72 characters.
+Use imperative style — describe what the commit does, not what you did. Keep the first line under 72 characters. Add a body after a blank line to explain the **why** when the change isn't obvious.
 
 ```
-fix: updated config description code
-refactor: cleaner public/private apis for output routing mixin
-feature: add as_function to akd BaseTool
+Fix confidence parsing bug in MultiRiskGraniteGuardianTool
+
+The guardian was treating low-confidence results as high-risk due to
+inverted comparison logic. This caused false positives on benign inputs.
+```
+
+```
+Add as_function to akd BaseTool
+```
+
+```
+Refactor base agent to incorporate 2 output modes
+
+Supports both structured (Pydantic) and unstructured (text) output
+routing, allowing agents to dynamically switch based on runtime schema.
 ```
 
 ## Python Style
@@ -139,13 +151,19 @@ This distinction is important:
 
 ### Creating an Agent
 
+The default agent class is **`AKDAgent`** — it comes with LiteLLM + Instructor integration, ReAct-style tool calling, HITL support, streaming, and output routing out of the box. This is what you should use for most agents.
+
+> `LiteLLMInstructorBaseAgent`, `InstructorBaseAgent`, and `Agent` are all aliases for `AKDAgent`.
+>
+> For other agentic base extensions (e.g., LangChain-based, custom providers), see [akd-ext](https://github.com/NASA-IMPACT/akd-ext).
+
 Every agent needs four parts: InputSchema, OutputSchema, Config (optional), and the Agent class.
 
 ```python
 from pydantic import Field
 
 from akd._base import InputSchema, OutputSchema
-from akd.agents._base import BaseAgent, BaseAgentConfig
+from akd.agents._base import AKDAgent, BaseAgentConfig
 
 
 class SummaryInput(InputSchema):
@@ -169,7 +187,7 @@ class SummaryConfig(BaseAgentConfig):
     temperature: float = 0.3
 
 
-class SummaryAgent(BaseAgent[SummaryInput, SummaryOutput]):
+class SummaryAgent(AKDAgent[SummaryInput, SummaryOutput]):
     """Summarizes text to a target length."""
 
     config_schema = SummaryConfig
@@ -199,9 +217,9 @@ async for event in agent.astream(SummaryInput(text="...")):
 
 **Key points:**
 - `InputSchema` and `OutputSchema` require docstrings — schema validation will fail without them
-- Use Python 3.12+ generic syntax: `BaseAgent[SummaryInput, SummaryOutput]`
-- Streaming, HITL, tool calling, and message trimming come for free from `BaseAgent`
-- For structured LLM output, use `LiteLLMInstructorBaseAgent` instead of `BaseAgent`
+- Use Python 3.12+ generic syntax: `AKDAgent[SummaryInput, SummaryOutput]`
+- Streaming, HITL, tool calling, and message trimming come for free
+- `AKDAgent` uses LiteLLM under the hood — any model provider works
 
 ### Creating a Tool
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,328 @@
+# Contributing to akd-core
+
+## Getting Started
+
+```bash
+# Clone the repo
+git clone https://github.com/NASA-IMPACT/accelerated-discovery.git
+cd accelerated-discovery
+
+# Create and activate virtual environment
+uv venv --python 3.12
+source .venv/bin/activate
+
+# Install with dev dependencies
+uv sync --extra dev
+
+# Install pre-commit hooks
+pre-commit install
+```
+
+> **Always run commands through `uv run`** — never use bare `python` or `pytest`. This ensures the correct virtual environment and dependencies are used.
+>
+> ```bash
+> uv run pytest                          # not: pytest
+> uv run python scripts/run_lit_agent.py # not: python scripts/...
+> ```
+
+## Branch Naming
+
+All branches follow the pattern `<type>/<short-description>` and target `develop` (not `main`).
+
+| Prefix | Use |
+|--------|-----|
+| `feature/` | New functionality |
+| `bugfix/` | Bug fixes |
+| `fix/` | Targeted fixes (typos, small corrections) |
+| `refactor/` | Code restructuring without behavior change |
+| `enhance/` | Improvements to existing features |
+| `docs/` | Documentation only |
+
+Examples: `feature/conflict-agent`, `bugfix/granite-conf-level`, `enhance/baseagentconfig`
+
+## Commit Messages
+
+Use lowercase `type: description` format. Keep the first line under 72 characters.
+
+```
+fix: updated config description code
+refactor: cleaner public/private apis for output routing mixin
+feature: add as_function to akd BaseTool
+```
+
+## Python Style
+
+### Python 3.12+ Modern Syntax
+
+Always use modern type syntax — never import from `typing` for things that have built-in equivalents:
+
+```python
+# Do this
+name: str | None = None
+items: list[str] = []
+mapping: dict[str, int] = {}
+type SearchResults = list[SearchResultItem]
+
+# Not this
+from typing import Optional, List, Dict
+name: Optional[str] = None
+items: List[str] = []
+```
+
+### General Style
+
+- **Line length**: 120 characters (configured in ruff)
+- **Quotes**: double quotes (`"`, not `'`)
+- **Line endings**: LF (Unix-style)
+- **Pydantic v2** for all models
+- **All async**: agents and tools implement `async def _arun()`
+
+### Variable Naming
+
+Be descriptive and intentional with names. Code is read far more than it is written.
+
+- No single-letter variables outside of loop counters or comprehensions
+- No cryptic abbreviations — `search_results` not `sr`, `document_content` not `doc_c`
+- Boolean variables should read as conditions: `is_valid`, `has_results`, `should_retry`
+- Use consistent terminology from the codebase — `run_context` not `ctx`, `input_schema` not `in_schema`
+
+## Pre-commit Hooks
+
+Pre-commit hooks run automatically on `git commit`. The following hooks are configured:
+
+- **trailing-whitespace** — removes trailing whitespace
+- **end-of-file-fixer** — ensures files end with a newline
+- **check-yaml** — validates YAML syntax
+- **debug-statements** — catches leftover `breakpoint()` / `pdb` calls
+- **isort** — sorts imports (black-compatible profile)
+- **add-trailing-comma** — adds trailing commas (Python 3.6+)
+- **ruff-check** — linting with auto-fix
+- **ruff-format** — code formatting
+
+To run hooks manually against all files:
+
+```bash
+pre-commit run --all-files
+```
+
+Never skip hooks with `--no-verify`. If a hook fails, fix the issue — don't bypass it.
+
+## Testing
+
+```bash
+uv run pytest                         # full suite (parallel, with coverage)
+uv run pytest tests/agents/base/ -v   # specific directory
+uv run pytest -m unit                 # by marker
+uv run pytest -k "test_human"         # by name pattern
+```
+
+**Markers:** `unit`, `integration`, `slow`, `requires_ml`
+
+- Tests live in `tests/` and mirror the `akd/` directory structure
+- Use `pytest-asyncio` (auto mode) — just write `async def test_...()` and it works
+- Coverage is collected automatically via `pytest-cov`
+- Tests run in parallel via `pytest-xdist`
+
+## Creating Agents and Tools
+
+akd-core uses a consistent **4-part pattern** for all agents and tools. Understanding this pattern is the key to extending the framework.
+
+### The Public vs Private API
+
+This distinction is important:
+
+- **`_arun()`** — the **private** method you **override** when creating an agent or tool. This is where your implementation logic goes.
+- **`arun()`** — the **public** method callers **invoke** to run your agent or tool. It handles the full lifecycle: sessions, streaming events, guardrails, error handling, and then calls your `_arun()` internally.
+- **`astream()`** — the **public** async generator callers use for streaming. Yields `StreamEvent` objects.
+
+**Never call `_arun()` directly.** Always use `arun()` or `astream()`.
+
+### Creating an Agent
+
+Every agent needs four parts: InputSchema, OutputSchema, Config (optional), and the Agent class.
+
+```python
+from pydantic import Field
+
+from akd._base import InputSchema, OutputSchema
+from akd.agents._base import BaseAgent, BaseAgentConfig
+
+
+class SummaryInput(InputSchema):
+    """Input for the summarization agent."""
+
+    text: str = Field(..., description="The text to summarize")
+    max_length: int = Field(default=200, description="Maximum summary length in words")
+
+
+class SummaryOutput(OutputSchema):
+    """Output from the summarization agent."""
+
+    summary: str = Field(..., description="The generated summary")
+    word_count: int = Field(..., description="Number of words in the summary")
+
+
+class SummaryConfig(BaseAgentConfig):
+    """Configuration for the summarization agent."""
+
+    model_name: str = "gpt-4o-mini"
+    temperature: float = 0.3
+
+
+class SummaryAgent(BaseAgent[SummaryInput, SummaryOutput]):
+    """Summarizes text to a target length."""
+
+    config_schema = SummaryConfig
+    input_schema = SummaryInput
+    output_schema = SummaryOutput
+
+    async def _arun(self, params: SummaryInput, run_context=None, **kwargs) -> SummaryOutput:
+        # Your implementation here — this is called by the public arun()/astream()
+        ...
+```
+
+**Using it:**
+
+```python
+agent = SummaryAgent(config={"model_name": "gpt-4o-mini"})
+
+# Simple invocation
+result = await agent.arun(SummaryInput(text="...", max_length=100))
+
+# Streaming
+async for event in agent.astream(SummaryInput(text="...")):
+    if event.event_type == "streaming":
+        print(event.token, end="")
+    elif event.event_type == "completed":
+        print(event.output.summary)
+```
+
+**Key points:**
+- `InputSchema` and `OutputSchema` require docstrings — schema validation will fail without them
+- Use Python 3.12+ generic syntax: `BaseAgent[SummaryInput, SummaryOutput]`
+- Streaming, HITL, tool calling, and message trimming come for free from `BaseAgent`
+- For structured LLM output, use `LiteLLMInstructorBaseAgent` instead of `BaseAgent`
+
+### Creating a Tool
+
+Tools follow the same pattern but inherit from `BaseTool`:
+
+```python
+from pydantic import Field
+
+from akd._base import InputSchema, OutputSchema
+from akd.tools._base import BaseTool, BaseToolConfig
+
+
+class FetchInput(InputSchema):
+    """Input for fetching a URL."""
+
+    url: str = Field(..., description="The URL to fetch")
+
+
+class FetchOutput(OutputSchema):
+    """Output from fetching a URL."""
+
+    content: str = Field(..., description="The fetched content")
+    status_code: int = Field(..., description="HTTP status code")
+
+
+class FetchToolConfig(BaseToolConfig):
+    """Configuration for the fetch tool."""
+
+    timeout: int = 30
+
+
+class FetchTool(BaseTool[FetchInput, FetchOutput]):
+    """Fetches content from a URL."""
+
+    config_schema = FetchToolConfig
+    input_schema = FetchInput
+    output_schema = FetchOutput
+
+    async def _arun(self, params: FetchInput, run_context=None, **kwargs) -> FetchOutput:
+        # Your implementation here
+        ...
+```
+
+**Using it:**
+
+```python
+tool = FetchTool()
+
+# Direct invocation
+result = await tool.arun(FetchInput(url="https://example.com"))
+
+# As a function (for LLM tool calling)
+fn = tool.as_function()
+result = await fn(url="https://example.com")
+
+# Get tool definition for LLM function calling
+definition = tool.as_tool_definition()
+```
+
+**Composition:** Tools can be composed using the Composite pattern. See `CompositeSearchTool`, `CompositeResolver`, and `CompositeGuardrail` for examples of combining multiple tools into one.
+
+### Adding Guardrails to Your Agent
+
+Use the decorator API to add input/output guardrails:
+
+```python
+from akd.guardrails import guardrail
+from akd.guardrails.providers import GraniteGuardianTool
+
+@guardrail(
+    input_guardrail=GraniteGuardianTool(),
+    fail_on_input_risk=True,
+)
+class SafeSummaryAgent(SummaryAgent):
+    ...
+```
+
+Or apply at runtime:
+
+```python
+from akd.guardrails import apply_guardrails
+
+agent = SummaryAgent()
+guarded = apply_guardrails(agent, input_guardrail=GraniteGuardianTool())
+```
+
+### Registering with the Planner
+
+To make your agent discoverable by the workflow planner, add it to the agent registry configuration. The planner's `AgentRegistry` can auto-discover agents — your agent just needs to follow the standard 4-part pattern with proper schema docstrings, and it can be registered for workflow planning.
+
+### How akd-ext Extends akd-core
+
+[akd-ext](https://github.com/NASA-IMPACT/akd-ext) is the canonical example of extending akd-core. It imports base classes from akd-core and builds domain-specific agents and tools on top:
+
+```python
+# In akd-ext, you import from akd-core
+from akd._base import InputSchema, OutputSchema
+from akd.agents._base import BaseAgent, BaseAgentConfig
+
+# Then create your domain-specific extensions
+class DomainSpecificAgent(BaseAgent[MyInput, MyOutput]):
+    ...
+```
+
+The same pattern works for any project that depends on akd-core.
+
+## PR Process
+
+1. Branch from `develop` using the naming convention above
+2. Make your changes, ensuring pre-commit hooks pass
+3. Write tests that mirror the `akd/` directory structure
+4. Run `uv run pytest` to verify everything passes
+5. Open a PR targeting `develop`
+
+## Further Reading
+
+For deeper dives into framework internals, see the specs in `docs/specs/`:
+
+- **AKD_BASE.md** — base class system, AbstractBase, schema validation
+- **STREAMING.md** — event types, StreamingMixin, event data models
+- **TOOL_CALLING.md** — tool loop, ToolCall/ToolResult, function conversion
+- **HUMAN_INTERRUPT.md** — pause/resume lifecycle, HumanTool, HumanResponse
+- **AGENT_MEMORY.md** — memory sessions, message management
+- **AKD_GUARDRAILS.md** — guardrail protocol, providers, risk categories

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ akd-core is designed to be extended. Every agent and tool follows a consistent 4
 
 ```python
 from akd._base import InputSchema, OutputSchema
-from akd.agents._base import BaseAgent, BaseAgentConfig
+from akd.agents._base import AKDAgent, BaseAgentConfig
 
 class MyInput(InputSchema):
     """What goes in."""
@@ -179,7 +179,7 @@ class MyOutput(OutputSchema):
     """What comes out."""
     answer: str
 
-class MyAgent(BaseAgent[MyInput, MyOutput]):
+class MyAgent(AKDAgent[MyInput, MyOutput]):
     input_schema = MyInput
     output_schema = MyOutput
 
@@ -187,7 +187,7 @@ class MyAgent(BaseAgent[MyInput, MyOutput]):
         ...  # your logic here
 ```
 
-Your agent automatically gets streaming, tool calling, HITL, message trimming, and guardrail support. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide with tool examples, guardrail integration, and planner registration.
+`AKDAgent` is the default batteries-included agent — it comes with LiteLLM + Instructor, ReAct tool calling, HITL, streaming, and output routing. Your agent inherits all of it. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide with tool examples, guardrail integration, and planner registration.
 
 This is exactly how [akd-ext](https://github.com/NASA-IMPACT/akd-ext) builds on akd-core — importing base classes and creating domain-specific agents and tools.
 

--- a/README.md
+++ b/README.md
@@ -1,62 +1,220 @@
-# Accelerated Discovery Framework
+# Accelerated Knowledge Discovery Core (akd-core)
 
-A **human-centric MAS Framework** for scientific discovery that empowers researchers while maintaining scientific integrity, transparency, and reproducibility.
+A human-centric multi-agent system (MAS) framework for scientific discovery — providing base classes, streaming, human-in-the-loop (HITL), guardrails, and out-of-box agents and tools.
+
+## Ecosystem
+
+akd-core is the foundation layer that drives the entire AKD ecosystem:
+
+- **akd-core** (this repo) — base classes, streaming infrastructure, HITL, guardrails, and out-of-box agents/tools for scientific discovery
+- **[akd-framework](https://github.com/NASA-IMPACT/akd-framework/)** — the AKD backend application, built on akd-core
+- **[akd-ext](https://github.com/NASA-IMPACT/akd-ext)** — community extensions that use akd-core's base agents and tools to build domain-specific capabilities
+
+akd-core is standalone and pip-installable. Everything downstream inherits its streaming, HITL, and guardrail infrastructure.
 
 ## Core Philosophy
 
-This framework is built on the principle that **human researchers should direct the discovery process**. AI agents are powerful tools to augment, not replace, human intellect and intuition. We prioritize:
+- **Human-in-the-loop control** — researchers direct the discovery process; AI augments, never replaces
+- **Scientific integrity** — deep attribution, evidence validation, and rigorous guardrails
+- **Transparent and reproducible** — every workflow is a shareable, inspectable artifact
+- **Open collaboration** — community-driven framework for shared scientific advancement
 
-- **Human-in-the-loop control** - The researcher has final say on workflow, parameters, and interpretation
-- **Scientific integrity** - Deep attribution, conflicting evidence identification, and rigorous validation
-- **Transparent & reproducible research** - Every workflow is a shareable, inspectable artifact
-- **Open collaboration** - Community-driven framework for shared scientific advancement
+See [Design Philosophy](docs/design_philosophy.md) for the full set of principles and golden rules.
 
-## Architecture
+## What You Get
 
-The system implements a **Planner-Orchestrator** pattern with standardized `NodeTemplate` components for maximum flexibility and scientific rigor:
+- **Async-first** — all agents and tools implement `async def _arun()` with full `astream()` support
+- **Streaming-native** — 11 typed event types covering tokens, reasoning, tool calls, and HITL
+- **Type-safe** — Pydantic v2 schemas with required docstrings for all inputs and outputs
+- **Composable** — tools combine via Composite patterns (search, resolvers, guardrails)
+- **HITL built-in** — pause, save state, get human input, resume seamlessly
+- **Guardrails** — pluggable safety layer with decorator API
+- **LLM-agnostic** — works with any provider via LiteLLM (OpenAI, Anthropic, Ollama, etc.)
 
-### Core Design Patterns
+```python
+from akd.agents import BaseAgent
 
-- **NodeTemplate Architecture**: All functional components implement the standardized `AbstractNodeTemplate` (`akd.nodes.templates`) with:
-  - Well-defined state management
-  - Input/output guardrails for validation
-  - Tool subset isolation (principle of least privilege)
-  - Framework-agnostic design that can wrap into any orchestration engine
+agent = BaseAgent(config={"model_name": "gpt-4o-mini"})
+async for event in agent.astream(input_params):
+    match event.event_type:
+        case "streaming": print(event.token, end="")
+        case "tool_calling": print(f"Calling {event.tool_name}...")
+        case "human_input_required": response = input(event.human_prompt)
+        case "completed": result = event.output
+```
 
-- **Context Management**:
-  - **Global Context**: Maintains overall research project state
-  - **Local Context**: Sandboxed, need-to-know subsets for individual agents
-  - Prevents context bleeding between agents
+## Streaming
 
-- **Human-in-the-Loop Control**: Researchers maintain control over:
-  - Workflow approval and modifications
-  - Parameter tuning for any component
-  - Branching and merging decisions
+Everything in akd-core is a stream of typed events. Agents emit `StreamEvent` objects as they execute:
 
-- **Multi-Agent Coordination**: Specialized agents work together with conflict detection and gap identification
+| Event | Description |
+|-------|-------------|
+| `STARTING` | Agent/tool begins execution |
+| `RUNNING` | Progress update |
+| `STREAMING` | Raw LLM tokens as they arrive |
+| `THINKING` | Reasoning tokens (Claude extended thinking, o1/o3) |
+| `PARTIAL` | Partial structured output as it streams |
+| `TOOL_CALLING` | Agent invokes a tool |
+| `TOOL_RESULT` | Tool returns its result |
+| `HUMAN_INPUT_REQUIRED` | Agent needs human input — execution pauses |
+| `HUMAN_RESPONSE` | Resumed with human input |
+| `COMPLETED` | Execution finished successfully |
+| `FAILED` | Execution failed with error details |
 
-### Human-in-the-Loop Control Points
+Each event carries typed data (e.g., `CompletedEventData[T]` includes the output, `FailedEventData` includes the error) and a `run_context` for execution state.
 
-The framework ensures researchers maintain control throughout the discovery process:
+## Human-in-the-Loop
 
-- **Plan Approval**: Initial research plans and any significant modifications require explicit human approval
-- **Parameter Control**: Researchers can inspect and adjust parameters for any NodeTemplate component
-- **Workflow Direction**: AI proposes next steps but humans direct the overall research strategy
-- **Quality Gates**: Human validation required before accepting AI-generated analyses or conclusions
-- **Branching Decisions**: Research workflow branching and merging decisions are human-directed
+HITL is a first-class concept, not an afterthought. The `HumanTool` enables any agent to pause execution, request human input, and resume:
 
-**Golden Rule**: When in doubt about research direction, data validity, or result interpretation, the system defers to human researcher guidance.
+1. Agent calls `HumanTool` during its tool loop
+2. Framework emits `HUMAN_INPUT_REQUIRED` event with the question and full message history
+3. Caller saves state and collects human response
+4. Resume with `RunContext(messages=saved_history, human_response=HumanResponse(...))`
+5. Agent continues exactly where it left off
 
-For comprehensive design principles, see [Design Philosophy](docs/design_philosophy.md).
+This works across any transport — REST APIs, WebSockets, CLI — because the pause/resume is state-based, not connection-based.
+
+## Out-of-Box Agents
+
+| Category | Agent | Description |
+|----------|-------|-------------|
+| **Research** | `DeepLitSearchAgent` | Multi-agent deep literature search with triage, clarification, and synthesis |
+| | `ControlledSearchAgent` | Controlled search with configurable parameters |
+| | `AspectSearchAgent` | Interview-pattern multi-aspect search |
+| | `CodeSearchAgent` | Code repository search |
+| | `QuestionAnsweringAgent` | QA over retrieved content |
+| **Analysis** | `GapAgent` | Research gap identification via knowledge graphs |
+| | `EstimationExtractionAgent` | Intent-based data extraction |
+| | `StormAgent` | Structured narrative generation |
+| **Utility** | `IntentAgent` | User intent classification |
+| | `QueryAgent` | Query reformulation and refinement |
+| | `FollowUpQueryAgent` | Follow-up query generation |
+| | `RelevancyAgent` | Binary relevance classification |
+| | `MultiRubricRelevancyAgent` | Multi-dimensional relevance scoring |
+| **Base** | `BaseAgent` | Core agent with streaming, tool calling, HITL, message trimming |
+| | `LiteLLMInstructorBaseAgent` | Structured Pydantic output via Instructor |
+
+## Out-of-Box Tools
+
+| Category | Tool | Description |
+|----------|------|-------------|
+| **Search** | `SearxNGSearchTool` | Web search via SearxNG |
+| | `SerperSearchTool` | Web search via Serper API |
+| | `SemanticScholarSearchTool` | Academic paper search |
+| | `CompositeSearchTool` | Multi-source search (combines backends) |
+| | `SearchPipeline` | Full pipeline: search + resolve + scrape |
+| **Scraping** | `WebScraper` | Web content extraction |
+| | `PDFScraper` | PDF content extraction |
+| | `DoclingScraper` | Advanced document parsing (tables, structure) |
+| **Resolvers** | `CrossRefDoiResolver` | DOI resolution via CrossRef |
+| | `ArxivResolver` | arXiv paper lookup |
+| | `ADSResolver` | NASA ADS paper lookup |
+| | `UnpaywallResolver` | Open access paper lookup |
+| | `CompositeResolver` | Chain multiple resolvers |
+| **Evaluation** | `RelevancyTool` | Content relevance scoring |
+| | `RerankerTool` | Result reranking |
+| | `SourceValidator` | Source credibility assessment |
+| **Special** | `HumanTool` | Human-in-the-loop interaction |
+| | `OutputTool` | Structured output capture |
+
+## Guardrails
+
+akd-core includes a pluggable guardrail system with a unified `GuardrailProtocol` interface:
+
+**Providers:**
+- `GraniteGuardianTool` — IBM Granite Guardian model (local or cloud)
+- `RiskAgent` — LLM-based risk assessment with configurable criteria
+- `CompositeGuardrail` — chain multiple providers (AND, OR, CONSENSUS modes)
+
+**Risk categories:** Granite built-in categories, Atlas dynamic taxonomy, and science-specific risks (misinformation, bias, attribution).
+
+```python
+from akd.guardrails import guardrail
+from akd.guardrails.providers import GraniteGuardianTool
+
+@guardrail(input_guardrail=GraniteGuardianTool(), fail_on_input_risk=True)
+class SafeAgent(BaseAgent):
+    ...
+```
+
+## Workflow Planner
+
+The planner converts natural language research goals into executable multi-agent workflows:
+
+```python
+from akd.planner.llm_planner import create_planner
+
+planner = await create_planner()
+session = await planner.plan_workflow("Find papers on AlphaFold and identify research gaps")
+response = await session.start()
+
+while not response.ready_to_generate:
+    user_input = input(f"{response.message}\nYour response: ")
+    response = await session.respond(user_input)
+
+workflow = await session.generate_workflow()
+```
+
+The planner uses an `AgentRegistry` with auto-discovery, field mapping between agent inputs/outputs, and generates executable `WorkflowFormat` definitions.
+
+## Extending akd-core
+
+akd-core is designed to be extended. Every agent and tool follows a consistent 4-part pattern:
+
+1. **InputSchema** — Pydantic model defining what goes in (requires docstring)
+2. **OutputSchema** — Pydantic model defining what comes out (requires docstring)
+3. **Config** — `BaseAgentConfig` or `BaseToolConfig` with settings
+4. **Implementation** — subclass `BaseAgent[In, Out]` or `BaseTool[In, Out]`, implement `_arun()`
+
+```python
+from akd._base import InputSchema, OutputSchema
+from akd.agents._base import BaseAgent, BaseAgentConfig
+
+class MyInput(InputSchema):
+    """What goes in."""
+    query: str
+
+class MyOutput(OutputSchema):
+    """What comes out."""
+    answer: str
+
+class MyAgent(BaseAgent[MyInput, MyOutput]):
+    input_schema = MyInput
+    output_schema = MyOutput
+
+    async def _arun(self, params: MyInput, run_context=None, **kwargs) -> MyOutput:
+        ...  # your logic here
+```
+
+Your agent automatically gets streaming, tool calling, HITL, message trimming, and guardrail support. See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide with tool examples, guardrail integration, and planner registration.
+
+This is exactly how [akd-ext](https://github.com/NASA-IMPACT/akd-ext) builds on akd-core — importing base classes and creating domain-specific agents and tools.
 
 ## Quick Start
 
 ### Prerequisites
 
 - Python 3.12+
-- `uv` package manager (recommended)
+- `uv` package manager
 
 ### Installation
+
+**As a dependency** (for akd-ext, akd-framework, or your own project):
+
+```bash
+uv pip install "akd @ git+https://github.com/NASA-IMPACT/accelerated-discovery.git@develop"
+```
+
+Or add to your `pyproject.toml`:
+
+```toml
+dependencies = [
+    "akd @ git+https://github.com/NASA-IMPACT/accelerated-discovery.git@develop",
+]
+```
+
+**For local development:**
 
 ```bash
 # Create and activate virtual environment
@@ -72,117 +230,46 @@ uv sync --extra dev
 # For local development (includes marimo and other local tools)
 uv sync --extra dev --extra local
 
-# For ML development (includes pandas, sentence-transformers, docling, deepeval)
+# For ML features (includes sentence-transformers, docling, deepeval)
 uv sync --extra ml
 
 # Setup environment variables
 cp .env.example .env
-# Edit .env with your API keys and configurations
-
+# Edit .env with your API keys
 ```
 
-### Basic Usage
+### Usage
 
-Refer to the [notebooks](notebooks) for examples.
-
-## Workflow Planning System
-
-The framework includes an LLM-based workflow planner that converts natural language research goals into executable workflows:
-
-### Interactive Planning
-
-```python
-from akd.planner.llm_planner import create_planner
-
-planner = await create_planner()
-session = await planner.plan_workflow("Find papers on AlphaFold and identify research gaps")
-response = await session.start()
-
-while not response.ready_to_generate:
-    user_input = input(f"{response.message}\nYour response: ")
-    response = await session.respond(user_input)
-
-workflow = await session.generate_workflow()
-workflow.save_to_file("research_workflow.json")
-```
-
-### Automated Planning
-
-```bash
-# Interactive session
-python scripts/demo_planner.py interactive
-
-# Automated mode (CI/CD, batch processing)
-python scripts/demo_planner.py automated "Research goal" --quiet -o workflow.json
-
-# Quick planning
-python scripts/demo_planner.py quick "Find papers on protein folding"
-```
-
-See [Planner Documentation](akd/planner/README.md) for comprehensive usage and deployment guides.
-
-## Core Tools & Agents
-
-### Search Infrastructure
-- **Search Tools**: SearxNG (web), Semantic Scholar (academic), code repositories
-- **Search Agents**: Deep search with iterative refinement, controlled search workflows, query processing and refinement
-- **Relevancy Filtering**: Content assessment, link validation, context-aware filtering
-
-### Content Extraction
-- **Document Processing**: PDF extraction (PyPaperBot), advanced document parsing (Docling)
-- **Web Scraping**: Multi-source content extraction with validation
-- **Quality Control**: Source validation, credibility assessment, attribution tracking
-
-## Scientific Guardrails
-
-The framework implements deep guardrails specifically designed for scientific research integrity:
-
-### Deep Attribution & Validation
-- **Traceable Claims**: All claims traceable to specific source sentences and data points
-- **Source Quality**: Prioritizes refereed journals and validated data repositories
-- **Attribution Chain**: Complete attribution from final claims back to original sources
-- **Quality Validation**: Multi-level validation of source credibility and relevance
-
-### Conflict Detection & Gap Analysis
-- **Agentic RAG**: Multi-agent approach to comprehensive information retrieval
-  - **Gap Agent**: Actively identifies missing information and research gaps
-  - **Conflict Agent**: Specifically searches for contradictory evidence and conflicting findings
-- **Bias Prevention**: Deliberately surfaces contradictory evidence to prevent confirmation bias
-- **Evidence Balance**: Ensures both supporting and conflicting evidence is presented
-
-### Transparent Research Process
-- **Stateful Execution**: Complete workflow state capture for reproducibility
-- **Shareable Artifacts**: Research graphs that others can inspect, validate, and extend
-- **Human Validation**: All AI-generated content clearly labeled and requires human approval
-- **Complete Transparency**: Every step of the research process is inspectable and documented
-
-## Key Features
-
-- **Human-in-the-Loop Control**: Researchers direct the discovery process with AI augmentation
-- **Framework Agnostic**: Core logic decoupled from orchestration engines for maximum flexibility
-- **Reproducible Research**: Complete workflow capture enables true reproducibility and sharing
-- **Community-Driven**: Open framework designed for collaborative scientific advancement
+See the [notebooks](notebooks) directory for examples.
 
 ## Project Structure
 
 ```
-akd/                    # Core framework
-├── agents/            # Specialized research agents
-├── planner/           # LLM workflow planner and builder
-├── nodes/             # NodeTemplate implementations
-├── tools/             # Research tools and scrapers
-├── configs/           # Configuration and prompts
-└── mapping/           # Field mapping definitions
+akd/
+  _base/         # AbstractBase, schemas, streaming, HITL, tool calling, sessions
+  agents/        # Out-of-box agents (search, analysis, utility)
+  tools/         # Out-of-box tools (search, scraping, resolvers, evaluation)
+  guardrails/    # GuardrailProtocol, providers, risk categories, decorators
+  planner/       # LLM planner, agent registry, workflow builder
+  configs/       # Project configuration and prompts
 
-examples/              # Usage examples
-scripts/               # Utility scripts and demos
-tests/                 # Comprehensive test suite
+docs/            # Design philosophy and specs
+notebooks/       # Usage examples (Jupyter, Marimo)
+scripts/         # Utility scripts and demos
+tests/           # Test suite (mirrors akd/ structure)
 ```
+
+## Roadmap
+
+These features are part of the design vision but not yet fully implemented:
+
+- **Conflict Agent** — a dedicated agent that specifically searches for contradictory evidence and conflicting findings across sources. Currently, conflict detection is a design principle (see [Design Philosophy](docs/design_philosophy.md)) but lacks a standalone agent implementation.
+- **Full Attribution Chain** — end-to-end traceability from final claims back to specific source sentences. Partial support exists today: `GapAgent` provides `attributed_source_answers` and the guardrail system includes an `ATTRIBUTION` risk category.
 
 ## Contributing
 
-This is an open, community-driven framework. See our [design philosophy](docs/design_philosophy.md) for development and design guidelines.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, style guide, branch conventions, and how to create agents and tools.
 
 ## License
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE](LICENSE) file for details.
+Apache License 2.0 — see [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

- Rewrites README to position repo as **akd-core** with ecosystem context (akd-core → akd-framework → akd-ext)
- Adds honest framing: moves unimplemented features (Conflict Agent, full attribution chain) to a Roadmap section
- Adds streaming events table, HITL explanation, out-of-box agent/tool catalog tables, guardrails overview, and git install guide for downstream consumers
- Adds **CONTRIBUTING.md** with branch naming conventions, Python 3.12+ style guide, variable naming guidelines, pre-commit hooks, testing conventions, `arun()` vs `_arun()` distinction, and full agent/tool creation guide

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify CONTRIBUTING.md renders correctly on GitHub
- [ ] Confirm all links (design philosophy, akd-framework, akd-ext, LICENSE) resolve
- [ ] Confirm agent/tool class names in tables match actual codebase