### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/akd/__init__.py
+++ b/akd/__init__.py
@@ -11,7 +11,9 @@ research through:
 - Framework agnostic core logic decoupled from orchestration engines
 """
 
-__version__ = "0.1.0"
+from importlib.metadata import version as _version
+
+__version__ = _version("akd")
 __author__ = "NASA IMPACT"
 __email__ = "np0069@uah.edu,mr0051@uah.edu"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akd"
-version = "0.1.0"
+version = "0.1.1"
 description = "Human-centric Multi-Agent System (MAS) framework for scientific discovery"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

- Bump version from 0.1.0 to 0.1.1
- Replace hardcoded `__version__` in `akd/__init__.py` with `importlib.metadata.version("akd")` so version is sourced solely from `pyproject.toml`

## Test plan

- [x] `uv run python -c "import akd; print(akd.__version__)"` prints `0.1.1`
