### PR TITLE
Release: AKD v0.1.1

### DIFF
--- a/akd/__init__.py
+++ b/akd/__init__.py
@@ -11,7 +11,9 @@ research through:
 - Framework agnostic core logic decoupled from orchestration engines
 """
 
-__version__ = "0.1.0"
+from importlib.metadata import version as _version
+
+__version__ = _version("akd")
 __author__ = "NASA IMPACT"
 __email__ = "np0069@uah.edu,mr0051@uah.edu"
 

--- a/akd/__init__.py
+++ b/akd/__init__.py
@@ -11,9 +11,13 @@ research through:
 - Framework agnostic core logic decoupled from orchestration engines
 """
 
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _version
 
-__version__ = _version("akd")
+try:
+    __version__ = _version("akd")
+except PackageNotFoundError:
+    __version__ = "0.1.1"
 __author__ = "NASA IMPACT"
 __email__ = "np0069@uah.edu,mr0051@uah.edu"
 

--- a/akd/guardrails/providers/granite_guardian.py
+++ b/akd/guardrails/providers/granite_guardian.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 import os
 import re
 from enum import StrEnum
@@ -321,6 +322,17 @@ class MultiRiskGraniteGuardianToolConfig(GraniteGuardianBaseConfig):
         ],
         description="Harm categories to report (filters model output, defaults to all harmful).",
     )
+    score_threshold: float = Field(
+        default=0.0,
+        description=(
+            "Minimum per-category score required to include a detected risk. "
+            "Range 0.0-1.0. Default 0.0 = no filtering (all detected categories pass). "
+            "Set (e.g., 0.5) to drop low-confidence detections and reduce false positives. "
+            "Has no effect if Ollama does not return logprobs (scores are None)."
+        ),
+        ge=0.0,
+        le=1.0,
+    )
 
     @model_validator(mode="after")
     def validate_multi_risk_model(self) -> Self:
@@ -384,12 +396,13 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
         # Step 1: Detect if harmful (Yes/No + confidence)
         step1_result = await self._call_harm_detection(step1_prompt)
 
-        is_harmful = step1_result.get("label", "").lower() == "yes"
+        label = step1_result.get("label", "").lower()
         confidence = step1_result.get("confidence", "")
+        is_harmful = label == "yes"
 
         if self.debug:
             logger.debug(
-                f"[{self.__class__.__name__}] Step 1 - is_harmful={is_harmful}, confidence={confidence}",
+                f"[{self.__class__.__name__}] Step 1 - is_harmful={is_harmful}, label={label}, confidence={confidence}",
             )
 
         if not is_harmful:
@@ -399,7 +412,7 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
                 risk_results={},
                 provider=self.__class__.__name__,
                 extra={
-                    "risk_label": "no",
+                    "risk_label": label or "no",
                     "confidence": confidence,
                     "step1_raw": step1_result.get("raw_response"),
                 },
@@ -410,22 +423,32 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
         step2_prompt = step1_prompt + step1_result["raw_response"] + _END_OF_TEXT + "\n<categories>"
         step2_result = await self._call_category_detection(step2_prompt)
 
-        # Filter to configured categories and exclude non-harmful markers
+        per_category_scores: dict[GraniteHarmCategory, float | None] = step2_result.get("scores", {})
+        threshold = self.config.score_threshold
+        _non_harmful = (GraniteHarmCategory.NOT_HARMFUL_PROMPT, GraniteHarmCategory.NOT_HARMFUL_RESPONSE)
+
+        # Filter: configured categories only, exclude non-harmful markers, drop categories
+        # whose per-category score is below the threshold. Categories without a score
+        # (e.g., when Ollama doesn't return logprobs) pass through unfiltered.
         detected = [
             cat
             for cat in step2_result.get("categories", [])
             if cat in categories_to_check
-            and cat not in (GraniteHarmCategory.NOT_HARMFUL_PROMPT, GraniteHarmCategory.NOT_HARMFUL_RESPONSE)
+            and cat not in _non_harmful
+            and (per_category_scores.get(cat) is None or per_category_scores[cat] >= threshold)
         ]
 
         if self.debug:
             logger.debug(
                 f"[{self.__class__.__name__}] Step 2 - Detected {len(detected)} risks "
-                f"(filtered from {len(step2_result.get('categories', []))}): {[r.value for r in detected]}",
+                f"(filtered from {len(step2_result.get('categories', []))}, threshold={threshold}): "
+                f"{[(r.value, per_category_scores.get(r)) for r in detected]}",
             )
 
-        # Build per-risk results
-        risk_results: dict[RiskCategory, dict[str, Any]] = {cat: {"is_risky": True} for cat in detected}
+        # Build per-risk results with per-category score.
+        risk_results: dict[RiskCategory, dict[str, Any]] = {
+            cat: {"is_risky": True, "score": per_category_scores.get(cat)} for cat in detected
+        }
 
         return GuardrailOutput(
             detected_risks=detected,
@@ -511,6 +534,10 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
                     "model": self.config.model.value,
                     "prompt": prompt,
                     "stream": False,
+                    # logprobs let us derive per-category model confidence from the
+                    # first token emitted for each category name.
+                    "logprobs": True,
+                    "top_logprobs": 5,
                     "options": {
                         "num_ctx": 8192,
                         "temperature": 0,
@@ -521,7 +548,9 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
             )
             response.raise_for_status()
 
-            content = response.json().get("response", "")
+            data = response.json()
+            content = data.get("response", "")
+            token_logprobs = data.get("logprobs") or []
 
             if self.debug:
                 logger.debug(
@@ -529,34 +558,91 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
                     f"--- RESPONSE START ---\n{content}\n--- RESPONSE END ---",
                 )
 
-            categories = self._parse_categories(content)
+            categories_with_scores = self._parse_categories_with_scores(content, token_logprobs)
+            categories = [cat for cat, _ in categories_with_scores]
+            scores = {cat: s for cat, s in categories_with_scores}
 
             if self.debug:
                 logger.debug(
-                    f"[{self.__class__.__name__}] Step 2 - Parsed categories: {[c.value for c in categories]}",
+                    f"[{self.__class__.__name__}] Step 2 - Parsed categories with scores: "
+                    f"{[(c.value, s) for c, s in categories_with_scores]}",
                 )
 
             return {
                 "categories": categories,
+                "scores": scores,
                 "raw_response": content,
             }
         except Exception as e:
             logger.error(f"[{self.__class__.__name__}] Step 2 error: {e}")
-            return {"error": str(e), "categories": []}
+            return {"error": str(e), "categories": [], "scores": {}}
 
     def _parse_categories(self, content: str) -> list[GraniteHarmCategory]:
-        """Parse comma-separated categories from model output."""
-        content = content.replace("</categories>", "").strip()
-        if not content:
+        """Parse comma-separated categories from model output (no scores)."""
+        return [cat for cat, _ in self._parse_categories_with_scores(content, [])]
+
+    def _parse_categories_with_scores(
+        self,
+        content: str,
+        token_logprobs: list[dict[str, Any]],
+    ) -> list[tuple[GraniteHarmCategory, float | None]]:
+        """Parse categories from model output and compute per-category scores from logprobs.
+
+        For each emitted category, the score is the probability of its first token
+        (``exp(logprob)`` of the token that starts the category name). None if logprobs
+        are unavailable. Categories are returned in the order they appear in ``content``.
+        """
+        cleaned = content.replace("</categories>", "").strip()
+        if not cleaned:
             return []
 
-        raw_categories = [cat.strip() for cat in content.split(",") if cat.strip()]
+        raw_categories = [c.strip() for c in cleaned.split(",") if c.strip()]
 
-        categories = []
-        for raw_cat in raw_categories:
+        # Walk the token stream and find, for each emitted category, the logprob of
+        # the first non-whitespace, non-comma token that starts it.
+        first_token_logprobs = self._first_token_logprob_per_category(token_logprobs)
+
+        results: list[tuple[GraniteHarmCategory, float | None]] = []
+        for i, raw_cat in enumerate(raw_categories):
             try:
-                categories.append(GraniteHarmCategory(raw_cat))
+                cat = GraniteHarmCategory(raw_cat)
             except ValueError:
-                logger.warning(f"[MultiHarmGraniteGuardianTool] Unknown category: {raw_cat}")
+                logger.warning(f"[{self.__class__.__name__}] Unknown category: {raw_cat}")
+                continue
+            lp = first_token_logprobs[i] if i < len(first_token_logprobs) else None
+            score = math.exp(lp) if lp is not None else None
+            results.append((cat, score))
 
-        return categories
+        return results
+
+    @staticmethod
+    def _first_token_logprob_per_category(
+        token_logprobs: list[dict[str, Any]],
+    ) -> list[float | None]:
+        """Extract the logprob of the first token of each comma-separated category.
+
+        The Step 2 output looks like ``Violence, Unethical Behavior``. We skip leading
+        whitespace/commas and grab the logprob of each category's first token. Returns a
+        list of logprobs aligned with the comma-separated category order.
+        """
+        if not token_logprobs:
+            return []
+
+        first_lps: list[float | None] = []
+        expecting_start = True  # at position 0 and after each comma
+        for entry in token_logprobs:
+            tok = entry.get("token", "")
+            stripped = tok.strip()
+            # A comma ends the current category; next non-whitespace token starts the next one.
+            if "," in tok:
+                expecting_start = True
+                continue
+            # Skip pure whitespace/newline tokens between categories.
+            if not stripped:
+                continue
+            if expecting_start:
+                lp = entry.get("logprob")
+                first_lps.append(lp if isinstance(lp, (int, float)) else None)
+                expecting_start = False
+
+        return first_lps

--- a/akd/guardrails/providers/granite_guardian.py
+++ b/akd/guardrails/providers/granite_guardian.py
@@ -423,7 +423,7 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
         step2_prompt = step1_prompt + step1_result["raw_response"] + _END_OF_TEXT + "\n<categories>"
         step2_result = await self._call_category_detection(step2_prompt)
 
-        per_category_scores: dict[GraniteHarmCategory, float | None] = step2_result.get("scores", {})
+        category_scores: dict[GraniteHarmCategory, float | None] = step2_result.get("categories", {})
         threshold = self.config.score_threshold
         _non_harmful = (GraniteHarmCategory.NOT_HARMFUL_PROMPT, GraniteHarmCategory.NOT_HARMFUL_RESPONSE)
 
@@ -432,22 +432,20 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
         # (e.g., when Ollama doesn't return logprobs) pass through unfiltered.
         detected = [
             cat
-            for cat in step2_result.get("categories", [])
-            if cat in categories_to_check
-            and cat not in _non_harmful
-            and (per_category_scores.get(cat) is None or per_category_scores[cat] >= threshold)
+            for cat, score in category_scores.items()
+            if cat in categories_to_check and cat not in _non_harmful and (score is None or score >= threshold)
         ]
 
         if self.debug:
             logger.debug(
                 f"[{self.__class__.__name__}] Step 2 - Detected {len(detected)} risks "
-                f"(filtered from {len(step2_result.get('categories', []))}, threshold={threshold}): "
-                f"{[(r.value, per_category_scores.get(r)) for r in detected]}",
+                f"(filtered from {len(category_scores)}, threshold={threshold}): "
+                f"{[(r.value, category_scores.get(r)) for r in detected]}",
             )
 
         # Build per-risk results with per-category score.
         risk_results: dict[RiskCategory, dict[str, Any]] = {
-            cat: {"is_risky": True, "score": per_category_scores.get(cat)} for cat in detected
+            cat: {"is_risky": True, "score": category_scores.get(cat)} for cat in detected
         }
 
         return GuardrailOutput(
@@ -459,7 +457,7 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
                 "confidence": confidence,
                 "step1_raw": step1_result.get("raw_response"),
                 "step2_raw": step2_result.get("raw_response"),
-                "unfiltered_categories": step2_result.get("categories", []),
+                "unfiltered_categories": category_scores,
             },
         )
 
@@ -558,51 +556,44 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
                     f"--- RESPONSE START ---\n{content}\n--- RESPONSE END ---",
                 )
 
-            categories_with_scores = self._parse_categories_with_scores(content, token_logprobs)
-            categories = [cat for cat, _ in categories_with_scores]
-            scores = {cat: s for cat, s in categories_with_scores}
+            categories = self._parse_categories(content, token_logprobs)
 
             if self.debug:
                 logger.debug(
                     f"[{self.__class__.__name__}] Step 2 - Parsed categories with scores: "
-                    f"{[(c.value, s) for c, s in categories_with_scores]}",
+                    f"{[(c.value, s) for c, s in categories.items()]}",
                 )
 
             return {
                 "categories": categories,
-                "scores": scores,
                 "raw_response": content,
             }
         except Exception as e:
             logger.error(f"[{self.__class__.__name__}] Step 2 error: {e}")
-            return {"error": str(e), "categories": [], "scores": {}}
+            return {"error": str(e), "categories": {}}
 
-    def _parse_categories(self, content: str) -> list[GraniteHarmCategory]:
-        """Parse comma-separated categories from model output (no scores)."""
-        return [cat for cat, _ in self._parse_categories_with_scores(content, [])]
-
-    def _parse_categories_with_scores(
+    def _parse_categories(
         self,
         content: str,
-        token_logprobs: list[dict[str, Any]],
-    ) -> list[tuple[GraniteHarmCategory, float | None]]:
-        """Parse categories from model output and compute per-category scores from logprobs.
+        token_logprobs: list[dict[str, Any]] | None = None,
+    ) -> dict[GraniteHarmCategory, float | None]:
+        """Parse categories from model output into a ``{category: score}`` mapping.
 
-        For each emitted category, the score is the probability of its first token
-        (``exp(logprob)`` of the token that starts the category name). None if logprobs
-        are unavailable. Categories are returned in the order they appear in ``content``.
+        The score is ``exp(first_token_logprob)`` (model confidence in emitting that
+        category's first token), or ``None`` when ``token_logprobs`` is not provided.
+        Python dicts preserve insertion order, so the model's emission order is kept.
         """
         cleaned = content.replace("</categories>", "").strip()
         if not cleaned:
-            return []
+            return {}
 
         raw_categories = [c.strip() for c in cleaned.split(",") if c.strip()]
 
         # Walk the token stream and find, for each emitted category, the logprob of
         # the first non-whitespace, non-comma token that starts it.
-        first_token_logprobs = self._first_token_logprob_per_category(token_logprobs)
+        first_token_logprobs = self._first_token_logprob_per_category(token_logprobs or [])
 
-        results: list[tuple[GraniteHarmCategory, float | None]] = []
+        results: dict[GraniteHarmCategory, float | None] = {}
         for i, raw_cat in enumerate(raw_categories):
             try:
                 cat = GraniteHarmCategory(raw_cat)
@@ -610,8 +601,7 @@ class MultiRiskGraniteGuardianTool(GraniteGuardianTool):
                 logger.warning(f"[{self.__class__.__name__}] Unknown category: {raw_cat}")
                 continue
             lp = first_token_logprobs[i] if i < len(first_token_logprobs) else None
-            score = math.exp(lp) if lp is not None else None
-            results.append((cat, score))
+            results[cat] = math.exp(lp) if lp is not None else None
 
         return results
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akd"
-version = "0.1.0"
+version = "0.1.1"
 description = "Human-centric Multi-Agent System (MAS) framework for scientific discovery"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -152,7 +152,7 @@ wheels = [
 
 [[package]]
 name = "akd"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },
@@ -6040,6 +6040,13 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/abada41517ce0011775f0f4eacc79659bc9bc6c361e6bfe6f7052a6b9363/torch-2.10.0-3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:98c01b8bb5e3240426dcde1446eed6f40c778091c8544767ef1168fc663a05a6", size = 915622781, upload-time = "2026-03-11T14:17:11.354Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c6/4dfe238342ffdcec5aef1c96c457548762d33c40b45a1ab7033bb26d2ff2/torch-2.10.0-3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80b1b5bfe38eb0e9f5ff09f206dcac0a87aadd084230d4a36eea5ec5232c115b", size = 915627275, upload-time = "2026-03-11T14:16:11.325Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f0/72bf18847f58f877a6a8acf60614b14935e2f156d942483af1ffc081aea0/torch-2.10.0-3-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:46b3574d93a2a8134b3f5475cfb98e2eb46771794c57015f6ad1fb795ec25e49", size = 915523474, upload-time = "2026-03-11T14:17:44.422Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/39/590742415c3030551944edc2ddc273ea1fdfe8ffb2780992e824f1ebee98/torch-2.10.0-3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b1d5e2aba4eb7f8e87fbe04f86442887f9167a35f092afe4c237dfcaaef6e328", size = 915632474, upload-time = "2026-03-11T14:15:13.666Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8e/34949484f764dde5b222b7fe3fede43e4a6f0da9d7f8c370bb617d629ee2/torch-2.10.0-3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0228d20b06701c05a8f978357f657817a4a63984b0c90745def81c18aedfa591", size = 915523882, upload-time = "2026-03-11T14:14:46.311Z" },
     { url = "https://files.pythonhosted.org/packages/cc/af/758e242e9102e9988969b5e621d41f36b8f258bb4a099109b7a4b4b50ea4/torch-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5fd4117d89ffd47e3dcc71e71a22efac24828ad781c7e46aaaf56bf7f2796acf", size = 145996088, upload-time = "2026-01-21T16:24:44.171Z" },
     { url = "https://files.pythonhosted.org/packages/23/8e/3c74db5e53bff7ed9e34c8123e6a8bfef718b2450c35eefab85bb4a7e270/torch-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:787124e7db3b379d4f1ed54dd12ae7c741c16a4d29b49c0226a89bea50923ffb", size = 915711952, upload-time = "2026-01-21T16:23:53.503Z" },
     { url = "https://files.pythonhosted.org/packages/6e/01/624c4324ca01f66ae4c7cd1b74eb16fb52596dce66dbe51eff95ef9e7a4c/torch-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c66c61f44c5f903046cc696d088e21062644cbe541c7f1c4eaae88b2ad23547", size = 113757972, upload-time = "2026-01-21T16:24:39.516Z" },


### PR DESCRIPTION
## Summary

Patch release v0.1.1 — adds per-category logprob scoring to the multi-risk Granite Guardian tool and consolidates version management.

- **Per-category logprob scores**: `MultiRiskGraniteGuardianTool` Step 2 now requests token logprobs from Ollama and derives a `score = exp(first_token_logprob)` per detected harm category, giving callers a real numeric confidence signal (e.g., `Violence=0.97` vs `Harmful=0.35`)
- **Score threshold filtering**: New `score_threshold` config field (0.0–1.0, default 0.0) to optionally drop low-confidence category detections and reduce false positives
- **Single version source**: Replaced hardcoded `__version__` in `akd/__init__.py` with `importlib.metadata.version("akd")` — version is now sourced solely from `pyproject.toml`

### Changes since v0.1.0
- `abd39dd` Consolidate _parse_categories into single dict-returning function
- `0ea08ee` Add per-category score to MultiRiskGraniteGuardianTool via Step 2 logprobs
- `7fc0863` Bump version to 0.1.1, use importlib.metadata for single version source

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Confirm all existing tests pass (`uv run pytest`)
- [x] `uv run python -c "import akd; print(akd.__version__)"` prints `0.1.1`