### PR TITLE
Add fallback for __version__ when running from source

### DIFF
--- a/akd/__init__.py
+++ b/akd/__init__.py
@@ -11,9 +11,13 @@ research through:
 - Framework agnostic core logic decoupled from orchestration engines
 """
 
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _version
 
-__version__ = _version("akd")
+try:
+    __version__ = _version("akd")
+except PackageNotFoundError:
+    __version__ = "0.1.1"
 __author__ = "NASA IMPACT"
 __email__ = "np0069@uah.edu,mr0051@uah.edu"
 


### PR DESCRIPTION
## Summary

- Add `try/except PackageNotFoundError` around `importlib.metadata.version("akd")` so `__version__` falls back to `"0.1.1"` when the package isn't installed (e.g., running directly from source without `uv sync`)

## Test plan

- [x] `uv run python -c "import akd; print(akd.__version__)"` prints `0.1.1` (installed path)
- [ ] Running from source without installing still imports without error