### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/akd/__init__.py
+++ b/akd/__init__.py
@@ -17,7 +17,7 @@ from importlib.metadata import version as _version
 try:
     __version__ = _version("akd")
 except PackageNotFoundError:
-    __version__ = "0.1.1"
+    __version__ = "0.2.0"
 __author__ = "NASA IMPACT"
 __email__ = "np0069@uah.edu,mr0051@uah.edu"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "akd"
-version = "0.1.1"
+version = "0.2.0"
 description = "Human-centric Multi-Agent System (MAS) framework for scientific discovery"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -152,7 +152,7 @@ wheels = [
 
 [[package]]
 name = "akd"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "crawl4ai" },


### PR DESCRIPTION
Bumps the project version from \`0.1.1\` → \`0.2.0\` following the large refactor landed in #432 (search/gap/storm agents removed, langchain/langgraph made optional via \`akd[serializer]\`, core deps trimmed, and \`QueryAgent\` / \`IntentAgent\` / \`FollowUpQueryAgent\` retired).

A minor version bump reflects the breaking API surface removals in that PR — downstream packages (\`akd-framework\`, \`akd-ext\`, \`akd-evals\`) need their imports/extras updated to match.

# Changes

- \`pyproject.toml\`: \`version = "0.1.1"\` → \`"0.2.0"\`
- \`akd/__init__.py\`: source-install fallback string \`"0.1.1"\` → \`"0.2.0"\`
- \`uv.lock\`: regenerated (single-line update: \`akd v0.1.1\` → \`v0.2.0\`)

# Test plan

- [x] \`uv lock\` regenerates cleanly
- [x] \`uv run python -c "import akd; print(akd.__version__)"\` prints \`0.2.0\`
- [ ] CI green on the branch