### PR TITLE
Widen RunContext.messages to list[Any] for adapter flexibility

### DIFF
--- a/akd/_base/structures.py
+++ b/akd/_base/structures.py
@@ -103,9 +103,13 @@ class RunContext(BaseModel):
         default=None,
         description="Human response for resumption after HUMAN_INPUT_REQUIRED",
     )
-    messages: list[dict[str, Any]] | None = Field(
+    messages: list[Any] | None = Field(
         default=None,
-        description="Conversation history for resumption",
+        description=(
+            "Conversation history for resumption. AKD's own BaseAgent populates "
+            "these as OpenAI-style {role, content} dicts; adapters (pydantic-ai, "
+            "langchain, etc.) may carry their native message types instead."
+        ),
     )
     run_id: str | None = Field(
         default=None,


### PR DESCRIPTION
Changes `RunContext.messages` from `list[dict[str, Any]] | None` to `list[Any] | None` so non-AKD-native adapters (pydantic-ai, langchain) can carry native message types directly instead of stashing under extras. All tests passing.